### PR TITLE
Reimplement setting source classes

### DIFF
--- a/pydantic_settings/__init__.py
+++ b/pydantic_settings/__init__.py
@@ -1,9 +1,23 @@
 import warnings
 
 from .main import BaseSettings
+from .sources import (
+    DotEnvSettingsSource,
+    EnvSettingsSource,
+    InitSettingsSource,
+    PydanticBaseSettingsSource,
+    SecretsSettingsSource,
+)
 from .version import VERSION
 
-__all__ = ('BaseSettings',)
+__all__ = (
+    'BaseSettings',
+    'PydanticBaseSettingsSource',
+    'InitSettingsSource',
+    'SecretsSettingsSource',
+    'EnvSettingsSource',
+    'DotEnvSettingsSource',
+)
 
 __version__ = VERSION
 warnings.warn(

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -137,7 +137,7 @@ class BaseSettings(BaseModel):
         @classmethod
         def customise_sources(
             cls,
-            settings_cls: type['BaseSettings'],
+            settings_cls: Type['BaseSettings'],
             init_settings: 'PydanticBaseSource',
             env_settings: 'PydanticBaseSource',
             dotenv_settings: 'PydanticBaseSource',
@@ -154,7 +154,7 @@ class BaseSettings(BaseModel):
 
 
 class PydanticBaseSource(ABC):
-    def __init__(self, settings_cls: type[BaseSettings]):
+    def __init__(self, settings_cls: Type[BaseSettings]):
         self.settings_cls = settings_cls
         self.config = settings_cls.__config__
         self.case_sensitive = self.config.case_sensitive
@@ -168,7 +168,7 @@ class PydanticBaseSource(ABC):
             return json.loads(value)
         return value
 
-    def __call__(self) -> dict[str, Any]:
+    def __call__(self) -> Dict[str, Any]:
         d: Dict[str, Any] = {}
 
         for name, field in self.settings_cls.__fields__.items():
@@ -188,7 +188,7 @@ class PydanticBaseSource(ABC):
 class InitSettingsSource(PydanticBaseSource):
     __slots__ = ('init_kwargs',)
 
-    def __init__(self, settings_cls: type[BaseSettings], init_kwargs: Dict[str, Any]):
+    def __init__(self, settings_cls: Type[BaseSettings], init_kwargs: Dict[str, Any]):
         self.init_kwargs = init_kwargs
         super().__init__(settings_cls)
 
@@ -205,7 +205,7 @@ class InitSettingsSource(PydanticBaseSource):
 class SecretsSettingsSource(PydanticBaseSource):
     __slots__ = ('secrets_dir',)
 
-    def __init__(self, settings_cls: type[BaseSettings], secrets_dir: Optional[StrPath]):
+    def __init__(self, settings_cls: Type[BaseSettings], secrets_dir: Optional[StrPath]):
         self.secrets_dir: Optional[StrPath] = secrets_dir
         super().__init__(settings_cls)
 
@@ -265,7 +265,7 @@ class EnvSettingsSource(PydanticBaseSource):
 
     def __init__(
         self,
-        settings_cls: type[BaseSettings],
+        settings_cls: Type[BaseSettings],
         env_nested_delimiter: Optional[str] = None,
         env_prefix_len: int = 0,
     ):
@@ -360,7 +360,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
 
     def __init__(
         self,
-        settings_cls: type[BaseSettings],
+        settings_cls: Type[BaseSettings],
         env_file: Optional[DotenvType],
         env_file_encoding: Optional[str],
         env_nested_delimiter: Optional[str] = None,

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -1,5 +1,7 @@
+import json
 import os
 import warnings
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import AbstractSet, Any, Callable, ClassVar, Dict, List, Mapping, Optional, Tuple, Type, Union
 
@@ -57,6 +59,14 @@ class BaseSettings(BaseModel):
         # Configure built-in sources
         init_settings = InitSettingsSource(init_kwargs=init_kwargs)
         env_settings = EnvSettingsSource(
+            self,
+            env_nested_delimiter=(
+                _env_nested_delimiter if _env_nested_delimiter is not None else self.__config__.env_nested_delimiter
+            ),
+            env_prefix_len=len(self.__config__.env_prefix),
+        )
+        dotenv_settings = DotEnvSettingsSource(
+            self,
             env_file=(_env_file if _env_file != env_file_sentinel else self.__config__.env_file),
             env_file_encoding=(
                 _env_file_encoding if _env_file_encoding is not None else self.__config__.env_file_encoding
@@ -66,13 +76,18 @@ class BaseSettings(BaseModel):
             ),
             env_prefix_len=len(self.__config__.env_prefix),
         )
-        file_secret_settings = SecretsSettingsSource(secrets_dir=_secrets_dir or self.__config__.secrets_dir)
+
+        file_secret_settings = SecretsSettingsSource(self, secrets_dir=_secrets_dir or self.__config__.secrets_dir)
         # Provide a hook to set built-in sources priority and add / remove sources
         sources = self.__config__.customise_sources(
-            init_settings=init_settings, env_settings=env_settings, file_secret_settings=file_secret_settings
+            self,
+            init_settings=init_settings,
+            env_settings=env_settings,
+            dotenv_settings=dotenv_settings,
+            file_secret_settings=file_secret_settings,
         )
         if sources:
-            return deep_update(*reversed([source(self) for source in sources]))
+            return deep_update(*reversed([source() for source in sources]))
         else:
             # no one should mean to do this, but I think returning an empty dict is marginally preferable
             # to an informative error and much better than a confusing error
@@ -120,11 +135,13 @@ class BaseSettings(BaseModel):
         @classmethod
         def customise_sources(
             cls,
+            settings_cls: type['BaseSettings'],
             init_settings: SettingsSourceCallable,
             env_settings: SettingsSourceCallable,
+            dotenv_settings: SettingsSourceCallable,
             file_secret_settings: SettingsSourceCallable,
         ) -> Tuple[SettingsSourceCallable, ...]:
-            return init_settings, env_settings, file_secret_settings
+            return init_settings, env_settings, dotenv_settings, file_secret_settings
 
         @classmethod
         def parse_env_var(cls, field_name: str, raw_val: str) -> Any:
@@ -134,98 +151,169 @@ class BaseSettings(BaseModel):
     __config__: ClassVar[Type[Config]]
 
 
-class InitSettingsSource:
+class PydanticBaseSource(ABC):
+    def __init__(self, settings_cls: type[BaseSettings]):
+        self.settings_cls = settings_cls
+        self.config = settings_cls.__config__
+        self.case_sensitive = self.config.case_sensitive
+
+    @abstractmethod
+    def get_field_value(self, field: ModelField) -> Any:
+        pass
+
+    @classmethod
+    def prepare_field(cls, field: ModelField, value: Any) -> Any:
+        if field.is_complex:
+            return json.loads(value)
+        return value
+
+    def __call__(self) -> dict[str, Any]:
+        d: Dict[str, Any] = {}
+
+        for field in self.settings_cls.__fields__.values():
+            field_value = self.get_field_value(field)
+            if field_value is not None:
+                d[field.alias] = field_value
+
+        return d
+
+
+class InitSettingsSource(PydanticBaseSource):
     __slots__ = ('init_kwargs',)
 
     def __init__(self, init_kwargs: Dict[str, Any]):
         self.init_kwargs = init_kwargs
 
-    def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
+    def get_field_value(self, field: ModelField) -> Any:
+        pass
+
+    def __call__(self) -> Dict[str, Any]:
         return self.init_kwargs
 
     def __repr__(self) -> str:
         return f'InitSettingsSource(init_kwargs={self.init_kwargs!r})'
 
 
-class EnvSettingsSource:
+class SecretsSettingsSource(PydanticBaseSource):
+    __slots__ = ('secrets_dir',)
+
+    def __init__(self, settings_cls: type[BaseSettings], secrets_dir: Optional[StrPath]):
+        self.secrets_dir: Optional[StrPath] = secrets_dir
+        super().__init__(settings_cls)
+
+    def __call__(self) -> Dict[str, Any]:
+        """
+        Build fields from "secrets" files.
+        """
+        secrets: Dict[str, Optional[str]] = {}
+
+        if self.secrets_dir is None:
+            return secrets
+
+        self.secrets_path = Path(self.secrets_dir).expanduser()
+
+        if not self.secrets_path.exists():
+            warnings.warn(f'directory "{self.secrets_path}" does not exist')
+            return secrets
+
+        if not self.secrets_path.is_dir():
+            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type(self.secrets_path)}')
+
+        return super().__call__()
+
+    @classmethod
+    def find_case_path(cls, dir_path: Path, file_name: str, case_sensitive: bool) -> Optional[Path]:
+        """
+        Find a file within path's directory matching filename, optionally ignoring case.
+        """
+        for f in dir_path.iterdir():
+            if f.name == file_name:
+                return f
+            elif not case_sensitive and f.name.lower() == file_name.lower():
+                return f
+        return None
+
+    def get_field_value(self, field: ModelField) -> Any:
+        for env_name in field.field_info.extra['env_names']:
+            path = self.find_case_path(self.secrets_path, env_name, self.settings_cls.__config__.case_sensitive)
+            if not path:
+                # path does not exist, we curently don't return a warning for this
+                continue
+
+            if path.is_file():
+                return self.prepare_field(field, path.read_text().strip(), env_name)
+            else:
+                warnings.warn(
+                    f'attempted to load secret file "{path}" but found a {path_type(path)} instead.',
+                    stacklevel=4,
+                )
+
+    @classmethod
+    def prepare_field(cls, field: ModelField, value: Any, env_name: str) -> Any:
+        if field.is_complex():
+            try:
+                return json.loads(value)
+            except ValueError as e:
+                raise SettingsError(f'error parsing env var "{env_name}"') from e
+        return value
+
+    def __repr__(self) -> str:
+        return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
+
+
+class EnvSettingsSource(PydanticBaseSource):
     __slots__ = ('env_file', 'env_file_encoding', 'env_nested_delimiter', 'env_prefix_len')
 
     def __init__(
         self,
-        env_file: Optional[DotenvType],
-        env_file_encoding: Optional[str],
+        settings_cls: type[BaseSettings],
         env_nested_delimiter: Optional[str] = None,
         env_prefix_len: int = 0,
     ):
-        self.env_file: Optional[DotenvType] = env_file
-        self.env_file_encoding: Optional[str] = env_file_encoding
+        super().__init__(settings_cls)
+
         self.env_nested_delimiter: Optional[str] = env_nested_delimiter
         self.env_prefix_len: int = env_prefix_len
 
-    def __call__(self, settings: BaseSettings) -> Dict[str, Any]:  # noqa C901
-        """
-        Build environment variables suitable for passing to the Model.
-        """
-        d: Dict[str, Any] = {}
+        self.env_vars: Mapping[str, Optional[str]] = self._load_env_vars()
 
-        if settings.__config__.case_sensitive:
-            env_vars: Mapping[str, Optional[str]] = os.environ
-        else:
-            env_vars = {k.lower(): v for k, v in os.environ.items()}
+    def _load_env_vars(self) -> Mapping[str, Optional[str]]:
+        if self.settings_cls.__config__.case_sensitive:
+            return os.environ
+        return {k.lower(): v for k, v in os.environ.items()}
 
-        dotenv_vars = self._read_env_files(settings.__config__.case_sensitive)
-        if dotenv_vars:
-            env_vars = {**dotenv_vars, **env_vars}
+    def get_field_value(self, field: ModelField) -> Any:
+        env_val: Optional[str] = None
+        for env_name in field.field_info.extra['env_names']:
+            env_val = self.env_vars.get(env_name)
+            if env_val is not None:
+                break
 
-        for field in settings.__fields__.values():
-            env_val: Optional[str] = None
-            for env_name in field.field_info.extra['env_names']:
-                env_val = env_vars.get(env_name)
-                if env_val is not None:
-                    break
+        return self.prepare_field(field, env_val, env_name)
 
-            is_complex, allow_parse_failure = self.field_is_complex(field)
-            if is_complex:
-                if env_val is None:
-                    # field is complex but no value found so far, try explode_env_vars
-                    env_val_built = self.explode_env_vars(field, env_vars)
-                    if env_val_built:
-                        d[field.alias] = env_val_built
+    def prepare_field(self, field: ModelField, value: Any, env_name: str) -> Any:
+        is_complex, allow_parse_failure = self.field_is_complex(field)
+        if is_complex:
+            if value is None:
+                # field is complex but no value found so far, try explode_env_vars
+                env_val_built = self.explode_env_vars(field, self.env_vars)
+                if env_val_built:
+                    return env_val_built
+            else:
+                # field is complex and there's a value, decode that as JSON, then add explode_env_vars
+                try:
+                    value = json.loads(value)
+                except ValueError as e:
+                    if not allow_parse_failure:
+                        raise SettingsError(f'error parsing env var "{env_name}"') from e
+
+                if isinstance(value, dict):
+                    return deep_update(value, self.explode_env_vars(field, self.env_vars))
                 else:
-                    # field is complex and there's a value, decode that as JSON, then add explode_env_vars
-                    try:
-                        env_val = settings.__config__.parse_env_var(field.name, env_val)
-                    except ValueError as e:
-                        if not allow_parse_failure:
-                            raise SettingsError(f'error parsing env var "{env_name}"') from e
-
-                    if isinstance(env_val, dict):
-                        d[field.alias] = deep_update(env_val, self.explode_env_vars(field, env_vars))
-                    else:
-                        d[field.alias] = env_val
-            elif env_val is not None:
-                # simplest case, field is not complex, we only need to add the value if it was found
-                d[field.alias] = env_val
-
-        return d
-
-    def _read_env_files(self, case_sensitive: bool) -> Dict[str, Optional[str]]:
-        env_files = self.env_file
-        if env_files is None:
-            return {}
-
-        if isinstance(env_files, (str, os.PathLike)):
-            env_files = [env_files]
-
-        dotenv_vars = {}
-        for env_file in env_files:
-            env_path = Path(env_file).expanduser()
-            if env_path.is_file():
-                dotenv_vars.update(
-                    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=case_sensitive)
-                )
-
-        return dotenv_vars
+                    return value
+        elif value is not None:
+            # simplest case, field is not complex, we only need to add the value if it was found
+            return value
 
     def field_is_complex(self, field: ModelField) -> Tuple[bool, bool]:
         """
@@ -263,60 +351,56 @@ class EnvSettingsSource:
 
     def __repr__(self) -> str:
         return (
-            f'EnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
-            f'env_nested_delimiter={self.env_nested_delimiter!r})'
+            f'EnvSettingsSource(env_nested_delimiter={self.env_nested_delimiter!r}, '
+            f'env_prefix_len={self.env_prefix_len!r})'
         )
 
 
-class SecretsSettingsSource:
-    __slots__ = ('secrets_dir',)
+class DotEnvSettingsSource(EnvSettingsSource):
+    def __init__(
+        self,
+        settings_cls: type[BaseSettings],
+        env_file: Optional[DotenvType],
+        env_file_encoding: Optional[str],
+        env_nested_delimiter: Optional[str] = None,
+        env_prefix_len: int = 0,
+    ):
+        self.env_file: Optional[DotenvType] = env_file
+        self.env_file_encoding: Optional[str] = env_file_encoding
 
-    def __init__(self, secrets_dir: Optional[StrPath]):
-        self.secrets_dir: Optional[StrPath] = secrets_dir
+        super().__init__(settings_cls, env_nested_delimiter, env_prefix_len)
 
-    def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
-        """
-        Build fields from "secrets" files.
-        """
-        secrets: Dict[str, Optional[str]] = {}
+    def _load_env_vars(self) -> Mapping[str, Optional[str]]:
+        env_vars = super()._load_env_vars()
+        dotenv_vars = self._read_env_files(self.settings_cls.__config__.case_sensitive)
+        if dotenv_vars:
+            env_vars = {**dotenv_vars, **env_vars}
 
-        if self.secrets_dir is None:
-            return secrets
+        return env_vars
 
-        secrets_path = Path(self.secrets_dir).expanduser()
+    def _read_env_files(self, case_sensitive: bool) -> Mapping[str, Optional[str]]:
+        env_files = self.env_file
+        if env_files is None:
+            return {}
 
-        if not secrets_path.exists():
-            warnings.warn(f'directory "{secrets_path}" does not exist')
-            return secrets
+        if isinstance(env_files, (str, os.PathLike)):
+            env_files = [env_files]
 
-        if not secrets_path.is_dir():
-            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type(secrets_path)}')
+        dotenv_vars = {}
+        for env_file in env_files:
+            env_path = Path(env_file).expanduser()
+            if env_path.is_file():
+                dotenv_vars.update(
+                    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=case_sensitive)
+                )
 
-        for field in settings.__fields__.values():
-            for env_name in field.field_info.extra['env_names']:
-                path = find_case_path(secrets_path, env_name, settings.__config__.case_sensitive)
-                if not path:
-                    # path does not exist, we curently don't return a warning for this
-                    continue
-
-                if path.is_file():
-                    secret_value = path.read_text().strip()
-                    if field.is_complex():
-                        try:
-                            secret_value = settings.__config__.parse_env_var(field.name, secret_value)
-                        except ValueError as e:
-                            raise SettingsError(f'error parsing env var "{env_name}"') from e
-
-                    secrets[field.alias] = secret_value
-                else:
-                    warnings.warn(
-                        f'attempted to load secret file "{path}" but found a {path_type(path)} instead.',
-                        stacklevel=4,
-                    )
-        return secrets
+        return dotenv_vars
 
     def __repr__(self) -> str:
-        return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
+        return (
+            f'DotEnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
+            f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r})'
+        )
 
 
 def read_env_file(

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -9,7 +9,7 @@ from pydantic.main import BaseModel
 from pydantic.typing import StrPath, display_as_type
 from pydantic.utils import deep_update, sequence_like
 
-from pydantic_settings.sources import (
+from .sources import (
     DotEnvSettingsSource,
     DotenvType,
     EnvSettingsSource,

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -1,24 +1,24 @@
-import json
-import os
+from __future__ import annotations as _annotations
+
 import warnings
-from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import AbstractSet, Any, Callable, ClassVar, Dict, List, Mapping, Optional, Tuple, Type, Union
+from typing import AbstractSet, Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
 
 from pydantic.config import BaseConfig, Extra
 from pydantic.fields import ModelField
 from pydantic.main import BaseModel
-from pydantic.typing import StrPath, display_as_type, get_origin, is_union
-from pydantic.utils import deep_update, path_type, sequence_like
+from pydantic.typing import StrPath, display_as_type
+from pydantic.utils import deep_update, sequence_like
+
+from pydantic_settings.sources import (
+    DotEnvSettingsSource,
+    DotenvType,
+    EnvSettingsSource,
+    InitSettingsSource,
+    PydanticBaseSettingsSource,
+    SecretsSettingsSource,
+)
 
 env_file_sentinel = str(object())
-
-SettingsSourceCallable = Callable[['BaseSettings'], Dict[str, Any]]
-DotenvType = Union[StrPath, List[StrPath], Tuple[StrPath, ...]]
-
-
-class SettingsError(ValueError):
-    pass
 
 
 class BaseSettings(BaseModel):
@@ -137,12 +137,12 @@ class BaseSettings(BaseModel):
         @classmethod
         def customise_sources(
             cls,
-            settings_cls: Type['BaseSettings'],
-            init_settings: 'PydanticBaseSource',
-            env_settings: 'PydanticBaseSource',
-            dotenv_settings: 'PydanticBaseSource',
-            file_secret_settings: 'PydanticBaseSource',
-        ) -> Tuple['PydanticBaseSource', ...]:
+            settings_cls: Type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> Tuple[PydanticBaseSettingsSource, ...]:
             return init_settings, env_settings, dotenv_settings, file_secret_settings
 
         @classmethod
@@ -151,281 +151,3 @@ class BaseSettings(BaseModel):
 
     # populated by the metaclass using the Config class defined above, annotated here to help IDEs only
     __config__: ClassVar[Type[Config]]
-
-
-class PydanticBaseSource(ABC):
-    def __init__(self, settings_cls: Type[BaseSettings]):
-        self.settings_cls = settings_cls
-        self.config = settings_cls.__config__
-        self.case_sensitive = self.config.case_sensitive
-
-    @abstractmethod
-    def get_field_value(self, field: ModelField) -> Any:
-        pass
-
-    def prepare_field(self, field_name: str, field: ModelField, value: Any) -> Any:
-        if field.is_complex():
-            return json.loads(value)
-        return value
-
-    def __call__(self) -> Dict[str, Any]:
-        d: Dict[str, Any] = {}
-
-        for name, field in self.settings_cls.__fields__.items():
-            field_value = self.get_field_value(field)
-
-            try:
-                field_value = self.prepare_field(name, field, field_value)
-            except ValueError as e:
-                raise SettingsError(f'error parsing value for field "{name}"') from e
-
-            if field_value is not None:
-                d[field.alias] = field_value
-
-        return d
-
-
-class InitSettingsSource(PydanticBaseSource):
-    __slots__ = ('init_kwargs',)
-
-    def __init__(self, settings_cls: Type[BaseSettings], init_kwargs: Dict[str, Any]):
-        self.init_kwargs = init_kwargs
-        super().__init__(settings_cls)
-
-    def get_field_value(self, field: ModelField) -> Any:
-        pass
-
-    def __call__(self) -> Dict[str, Any]:
-        return self.init_kwargs
-
-    def __repr__(self) -> str:
-        return f'InitSettingsSource(init_kwargs={self.init_kwargs!r})'
-
-
-class SecretsSettingsSource(PydanticBaseSource):
-    __slots__ = ('secrets_dir',)
-
-    def __init__(self, settings_cls: Type[BaseSettings], secrets_dir: Optional[StrPath]):
-        self.secrets_dir: Optional[StrPath] = secrets_dir
-        super().__init__(settings_cls)
-
-    def __call__(self) -> Dict[str, Any]:
-        """
-        Build fields from "secrets" files.
-        """
-        secrets: Dict[str, Optional[str]] = {}
-
-        if self.secrets_dir is None:
-            return secrets
-
-        self.secrets_path = Path(self.secrets_dir).expanduser()
-
-        if not self.secrets_path.exists():
-            warnings.warn(f'directory "{self.secrets_path}" does not exist')
-            return secrets
-
-        if not self.secrets_path.is_dir():
-            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type(self.secrets_path)}')
-
-        return super().__call__()
-
-    @classmethod
-    def find_case_path(cls, dir_path: Path, file_name: str, case_sensitive: bool) -> Optional[Path]:
-        """
-        Find a file within path's directory matching filename, optionally ignoring case.
-        """
-        for f in dir_path.iterdir():
-            if f.name == file_name:
-                return f
-            elif not case_sensitive and f.name.lower() == file_name.lower():
-                return f
-        return None
-
-    def get_field_value(self, field: ModelField) -> Any:
-        for env_name in field.field_info.extra['env_names']:
-            path = self.find_case_path(self.secrets_path, env_name, self.settings_cls.__config__.case_sensitive)
-            if not path:
-                # path does not exist, we curently don't return a warning for this
-                continue
-
-            if path.is_file():
-                return path.read_text().strip()
-            else:
-                warnings.warn(
-                    f'attempted to load secret file "{path}" but found a {path_type(path)} instead.',
-                    stacklevel=4,
-                )
-
-    def __repr__(self) -> str:
-        return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
-
-
-class EnvSettingsSource(PydanticBaseSource):
-    __slots__ = ('env_nested_delimiter', 'env_prefix_len')
-
-    def __init__(
-        self,
-        settings_cls: Type[BaseSettings],
-        env_nested_delimiter: Optional[str] = None,
-        env_prefix_len: int = 0,
-    ):
-        super().__init__(settings_cls)
-
-        self.env_nested_delimiter: Optional[str] = env_nested_delimiter
-        self.env_prefix_len: int = env_prefix_len
-
-        self.env_vars: Mapping[str, Optional[str]] = self._load_env_vars()
-
-    def _load_env_vars(self) -> Mapping[str, Optional[str]]:
-        if self.settings_cls.__config__.case_sensitive:
-            return os.environ
-        return {k.lower(): v for k, v in os.environ.items()}
-
-    def get_field_value(self, field: ModelField) -> Any:
-        env_val: Optional[str] = None
-        for env_name in field.field_info.extra['env_names']:
-            env_val = self.env_vars.get(env_name)
-            if env_val is not None:
-                break
-
-        return env_val
-
-    def prepare_field(self, field_name: str, field: ModelField, value: Any) -> Any:
-        is_complex, allow_parse_failure = self.field_is_complex(field)
-        if is_complex:
-            if value is None:
-                # field is complex but no value found so far, try explode_env_vars
-                env_val_built = self.explode_env_vars(field, self.env_vars)
-                if env_val_built:
-                    return env_val_built
-            else:
-                # field is complex and there's a value, decode that as JSON, then add explode_env_vars
-                try:
-                    value = json.loads(value)
-                except ValueError as e:
-                    if not allow_parse_failure:
-                        raise e
-
-                if isinstance(value, dict):
-                    return deep_update(value, self.explode_env_vars(field, self.env_vars))
-                else:
-                    return value
-        elif value is not None:
-            # simplest case, field is not complex, we only need to add the value if it was found
-            return value
-
-    def field_is_complex(self, field: ModelField) -> Tuple[bool, bool]:
-        """
-        Find out if a field is complex, and if so whether JSON errors should be ignored
-        """
-        if field.is_complex():
-            allow_parse_failure = False
-        elif is_union(get_origin(field.type_)) and field.sub_fields and any(f.is_complex() for f in field.sub_fields):
-            allow_parse_failure = True
-        else:
-            return False, False
-
-        return True, allow_parse_failure
-
-    def explode_env_vars(self, field: ModelField, env_vars: Mapping[str, Optional[str]]) -> Dict[str, Any]:
-        """
-        Process env_vars and extract the values of keys containing env_nested_delimiter into nested dictionaries.
-
-        This is applied to a single field, hence filtering by env_var prefix.
-        """
-        prefixes = [f'{env_name}{self.env_nested_delimiter}' for env_name in field.field_info.extra['env_names']]
-        result: Dict[str, Any] = {}
-        for env_name, env_val in env_vars.items():
-            if not any(env_name.startswith(prefix) for prefix in prefixes):
-                continue
-            # we remove the prefix before splitting in case the prefix has characters in common with the delimiter
-            env_name_without_prefix = env_name[self.env_prefix_len :]
-            _, *keys, last_key = env_name_without_prefix.split(self.env_nested_delimiter)
-            env_var = result
-            for key in keys:
-                env_var = env_var.setdefault(key, {})
-            env_var[last_key] = env_val
-
-        return result
-
-    def __repr__(self) -> str:
-        return (
-            f'EnvSettingsSource(env_nested_delimiter={self.env_nested_delimiter!r}, '
-            f'env_prefix_len={self.env_prefix_len!r})'
-        )
-
-
-class DotEnvSettingsSource(EnvSettingsSource):
-    __slots__ = ('env_file', 'env_file_encoding', 'env_nested_delimiter', 'env_prefix_len')
-
-    def __init__(
-        self,
-        settings_cls: Type[BaseSettings],
-        env_file: Optional[DotenvType],
-        env_file_encoding: Optional[str],
-        env_nested_delimiter: Optional[str] = None,
-        env_prefix_len: int = 0,
-    ):
-        self.env_file: Optional[DotenvType] = env_file
-        self.env_file_encoding: Optional[str] = env_file_encoding
-
-        super().__init__(settings_cls, env_nested_delimiter, env_prefix_len)
-
-    def _load_env_vars(self) -> Mapping[str, Optional[str]]:
-        env_vars = super()._load_env_vars()
-        dotenv_vars = self._read_env_files(self.settings_cls.__config__.case_sensitive)
-        if dotenv_vars:
-            env_vars = {**dotenv_vars, **env_vars}
-
-        return env_vars
-
-    def _read_env_files(self, case_sensitive: bool) -> Mapping[str, Optional[str]]:
-        env_files = self.env_file
-        if env_files is None:
-            return {}
-
-        if isinstance(env_files, (str, os.PathLike)):
-            env_files = [env_files]
-
-        dotenv_vars = {}
-        for env_file in env_files:
-            env_path = Path(env_file).expanduser()
-            if env_path.is_file():
-                dotenv_vars.update(
-                    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=case_sensitive)
-                )
-
-        return dotenv_vars
-
-    def __repr__(self) -> str:
-        return (
-            f'DotEnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
-            f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r})'
-        )
-
-
-def read_env_file(
-    file_path: StrPath, *, encoding: str = None, case_sensitive: bool = False
-) -> Dict[str, Optional[str]]:
-    try:
-        from dotenv import dotenv_values
-    except ImportError as e:
-        raise ImportError('python-dotenv is not installed, run `pip install pydantic[dotenv]`') from e
-
-    file_vars: Dict[str, Optional[str]] = dotenv_values(file_path, encoding=encoding or 'utf8')
-    if not case_sensitive:
-        return {k.lower(): v for k, v in file_vars.items()}
-    else:
-        return file_vars
-
-
-def find_case_path(dir_path: Path, file_name: str, case_sensitive: bool) -> Optional[Path]:
-    """
-    Find a file within path's directory matching filename, optionally ignoring case.
-    """
-    for f in dir_path.iterdir():
-        if f.name == file_name:
-            return f
-        elif not case_sensitive and f.name.lower() == file_name.lower():
-            return f
-    return None

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1,0 +1,325 @@
+from __future__ import annotations as _annotations
+
+import json
+import os
+import warnings
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union
+
+from pydantic.fields import ModelField
+from pydantic.typing import StrPath, get_origin, is_union
+from pydantic.utils import deep_update, path_type
+
+if TYPE_CHECKING:
+    from pydantic_settings.main import BaseSettings
+
+
+DotenvType = Union[StrPath, List[StrPath], Tuple[StrPath, ...]]
+SettingsSourceCallable = Callable[['BaseSettings'], Dict[str, Any]]
+
+
+class SettingsError(ValueError):
+    pass
+
+
+class PydanticBaseSettingsSource(ABC):
+    """
+    Abstract base class for settings sources, every settings source classes should inherit from it.
+    """
+
+    def __init__(self, settings_cls: Type[BaseSettings]):
+        self.settings_cls = settings_cls
+        self.config = settings_cls.__config__
+
+    @abstractmethod
+    def get_field_value(self, field: ModelField) -> Any:
+        """
+        Get the value for a field.
+
+        This is an abstract method that should be overrided in every settings source classes.
+
+        Args:
+            field (ModelField): The field.
+
+        Returns:
+            Any: The value of the field.
+        """
+        pass
+
+    def prepare_field_value(self, field_name: str, field: ModelField, value: Any) -> Any:
+        """
+        Prepare the value of a field.
+
+        Args:
+            field_name (str): The field name.
+            field (ModelField): The field.
+            value (Any): The value of the field that has to be prepared.
+
+        Returns:
+            Any: The prepared value.
+        """
+        if field.is_complex():
+            return json.loads(value)
+        return value
+
+    def __call__(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {}
+
+        for name, field in self.settings_cls.__fields__.items():
+            try:
+                field_value = self.get_field_value(field)
+            except Exception as e:
+                raise SettingsError(
+                    f'error getting value for field "{name}" from source "{self.__class__.__name__}"'
+                ) from e
+
+            try:
+                field_value = self.prepare_field_value(name, field, field_value)
+            except ValueError as e:
+                raise SettingsError(
+                    f'error parsing value for field "{name}" from source "{self.__class__.__name__}"'
+                ) from e
+
+            if field_value is not None:
+                d[field.alias] = field_value
+
+        return d
+
+
+class InitSettingsSource(PydanticBaseSettingsSource):
+    def __init__(self, settings_cls: Type[BaseSettings], init_kwargs: Dict[str, Any]):
+        self.init_kwargs = init_kwargs
+        super().__init__(settings_cls)
+
+    def get_field_value(self, field: ModelField) -> Any:
+        pass
+
+    def __call__(self) -> Dict[str, Any]:
+        return self.init_kwargs
+
+    def __repr__(self) -> str:
+        return f'InitSettingsSource(init_kwargs={self.init_kwargs!r})'
+
+
+class SecretsSettingsSource(PydanticBaseSettingsSource):
+    def __init__(self, settings_cls: Type[BaseSettings], secrets_dir: Optional[StrPath]):
+        self.secrets_dir: Optional[StrPath] = secrets_dir
+        super().__init__(settings_cls)
+
+    def __call__(self) -> Dict[str, Any]:
+        """
+        Build fields from "secrets" files.
+        """
+        secrets: Dict[str, Optional[str]] = {}
+
+        if self.secrets_dir is None:
+            return secrets
+
+        self.secrets_path = Path(self.secrets_dir).expanduser()
+
+        if not self.secrets_path.exists():
+            warnings.warn(f'directory "{self.secrets_path}" does not exist')
+            return secrets
+
+        if not self.secrets_path.is_dir():
+            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type(self.secrets_path)}')
+
+        return super().__call__()
+
+    @classmethod
+    def find_case_path(cls, dir_path: Path, file_name: str, case_sensitive: bool) -> Optional[Path]:
+        """
+        Find a file within path's directory matching filename, optionally ignoring case.
+        """
+        for f in dir_path.iterdir():
+            if f.name == file_name:
+                return f
+            elif not case_sensitive and f.name.lower() == file_name.lower():
+                return f
+        return None
+
+    def get_field_value(self, field: ModelField) -> Any:
+        for env_name in field.field_info.extra['env_names']:
+            path = self.find_case_path(self.secrets_path, env_name, self.settings_cls.__config__.case_sensitive)
+            if not path:
+                # path does not exist, we curently don't return a warning for this
+                continue
+
+            if path.is_file():
+                return path.read_text().strip()
+            else:
+                warnings.warn(
+                    f'attempted to load secret file "{path}" but found a {path_type(path)} instead.',
+                    stacklevel=4,
+                )
+
+    def __repr__(self) -> str:
+        return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
+
+
+class EnvSettingsSource(PydanticBaseSettingsSource):
+    def __init__(
+        self,
+        settings_cls: Type[BaseSettings],
+        env_nested_delimiter: Optional[str] = None,
+        env_prefix_len: int = 0,
+    ):
+        super().__init__(settings_cls)
+
+        self.env_nested_delimiter: Optional[str] = env_nested_delimiter
+        self.env_prefix_len: int = env_prefix_len
+
+        self.env_vars: Mapping[str, Optional[str]] = self._load_env_vars()
+
+    def _load_env_vars(self) -> Mapping[str, Optional[str]]:
+        if self.settings_cls.__config__.case_sensitive:
+            return os.environ
+        return {k.lower(): v for k, v in os.environ.items()}
+
+    def get_field_value(self, field: ModelField) -> Any:
+        env_val: Optional[str] = None
+        for env_name in field.field_info.extra['env_names']:
+            env_val = self.env_vars.get(env_name)
+            if env_val is not None:
+                break
+
+        return env_val
+
+    def prepare_field_value(self, field_name: str, field: ModelField, value: Any) -> Any:
+        is_complex, allow_parse_failure = self.field_is_complex(field)
+        if is_complex:
+            if value is None:
+                # field is complex but no value found so far, try explode_env_vars
+                env_val_built = self.explode_env_vars(field, self.env_vars)
+                if env_val_built:
+                    return env_val_built
+            else:
+                # field is complex and there's a value, decode that as JSON, then add explode_env_vars
+                try:
+                    value = json.loads(value)
+                except ValueError as e:
+                    if not allow_parse_failure:
+                        raise e
+
+                if isinstance(value, dict):
+                    return deep_update(value, self.explode_env_vars(field, self.env_vars))
+                else:
+                    return value
+        elif value is not None:
+            # simplest case, field is not complex, we only need to add the value if it was found
+            return value
+
+    def field_is_complex(self, field: ModelField) -> Tuple[bool, bool]:
+        """
+        Find out if a field is complex, and if so whether JSON errors should be ignored
+        """
+        if field.is_complex():
+            allow_parse_failure = False
+        elif is_union(get_origin(field.type_)) and field.sub_fields and any(f.is_complex() for f in field.sub_fields):
+            allow_parse_failure = True
+        else:
+            return False, False
+
+        return True, allow_parse_failure
+
+    def explode_env_vars(self, field: ModelField, env_vars: Mapping[str, Optional[str]]) -> Dict[str, Any]:
+        """
+        Process env_vars and extract the values of keys containing env_nested_delimiter into nested dictionaries.
+
+        This is applied to a single field, hence filtering by env_var prefix.
+        """
+        prefixes = [f'{env_name}{self.env_nested_delimiter}' for env_name in field.field_info.extra['env_names']]
+        result: Dict[str, Any] = {}
+        for env_name, env_val in env_vars.items():
+            if not any(env_name.startswith(prefix) for prefix in prefixes):
+                continue
+            # we remove the prefix before splitting in case the prefix has characters in common with the delimiter
+            env_name_without_prefix = env_name[self.env_prefix_len :]
+            _, *keys, last_key = env_name_without_prefix.split(self.env_nested_delimiter)
+            env_var = result
+            for key in keys:
+                env_var = env_var.setdefault(key, {})
+            env_var[last_key] = env_val
+
+        return result
+
+    def __repr__(self) -> str:
+        return (
+            f'EnvSettingsSource(env_nested_delimiter={self.env_nested_delimiter!r}, '
+            f'env_prefix_len={self.env_prefix_len!r})'
+        )
+
+
+class DotEnvSettingsSource(EnvSettingsSource):
+    def __init__(
+        self,
+        settings_cls: Type[BaseSettings],
+        env_file: Optional[DotenvType],
+        env_file_encoding: Optional[str],
+        env_nested_delimiter: Optional[str] = None,
+        env_prefix_len: int = 0,
+    ):
+        self.env_file: Optional[DotenvType] = env_file
+        self.env_file_encoding: Optional[str] = env_file_encoding
+
+        super().__init__(settings_cls, env_nested_delimiter, env_prefix_len)
+
+    def _load_env_vars(self) -> Mapping[str, Optional[str]]:
+        env_vars = super()._load_env_vars()
+        dotenv_vars = self._read_env_files(self.settings_cls.__config__.case_sensitive)
+        if dotenv_vars:
+            env_vars = {**dotenv_vars, **env_vars}
+
+        return env_vars
+
+    def _read_env_files(self, case_sensitive: bool) -> Mapping[str, Optional[str]]:
+        env_files = self.env_file
+        if env_files is None:
+            return {}
+
+        if isinstance(env_files, (str, os.PathLike)):
+            env_files = [env_files]
+
+        dotenv_vars = {}
+        for env_file in env_files:
+            env_path = Path(env_file).expanduser()
+            if env_path.is_file():
+                dotenv_vars.update(
+                    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=case_sensitive)
+                )
+
+        return dotenv_vars
+
+    def __repr__(self) -> str:
+        return (
+            f'DotEnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
+            f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r})'
+        )
+
+
+def read_env_file(
+    file_path: StrPath, *, encoding: str = None, case_sensitive: bool = False
+) -> Dict[str, Optional[str]]:
+    try:
+        from dotenv import dotenv_values
+    except ImportError as e:
+        raise ImportError('python-dotenv is not installed, run `pip install pydantic[dotenv]`') from e
+
+    file_vars: Dict[str, Optional[str]] = dotenv_values(file_path, encoding=encoding or 'utf8')
+    if not case_sensitive:
+        return {k.lower(): v for k, v in file_vars.items()}
+    else:
+        return file_vars
+
+
+def find_case_path(dir_path: Path, file_name: str, case_sensitive: bool) -> Optional[Path]:
+    """
+    Find a file within path's directory matching filename, optionally ignoring case.
+    """
+    for f in dir_path.iterdir():
+        if f.name == file_name:
+            return f
+        elif not case_sensitive and f.name.lower() == file_name.lower():
+            return f
+    return None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,7 +3,7 @@ import sys
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import pytest
 from pydantic import BaseModel, Field, HttpUrl, NoneStr, SecretStr, ValidationError, dataclasses
@@ -525,7 +525,7 @@ def test_env_takes_precedence(env):
             @classmethod
             def customise_sources(
                 cls,
-                settings_cls: type['BaseSettings'],
+                settings_cls: Type['BaseSettings'],
                 init_settings: SettingsSourceCallable,
                 env_settings: SettingsSourceCallable,
                 dotenv_settings: SettingsSourceCallable,
@@ -557,7 +557,7 @@ def test_config_file_settings_nornir(env):
             @classmethod
             def customise_sources(
                 cls,
-                settings_cls: type['BaseSettings'],
+                settings_cls: Type['BaseSettings'],
                 init_settings: SettingsSourceCallable,
                 env_settings: SettingsSourceCallable,
                 dotenv_settings: SettingsSourceCallable,
@@ -1156,7 +1156,7 @@ def test_external_settings_sources_precedence(env):
             @classmethod
             def customise_sources(
                 cls,
-                settings_cls: type['BaseSettings'],
+                settings_cls: Type['BaseSettings'],
                 init_settings: SettingsSourceCallable,
                 env_settings: SettingsSourceCallable,
                 dotenv_settings: SettingsSourceCallable,
@@ -1179,7 +1179,7 @@ def test_external_settings_sources_filter_env_vars():
     vault_storage = {'user:password': {'apple': 'value 0', 'banana': 'value 2'}}
 
     class VaultSettingsSource(PydanticBaseSource):
-        def __init__(self, settings_cls: type[BaseSettings], user: str, password: str):
+        def __init__(self, settings_cls: Type[BaseSettings], user: str, password: str):
             self.user = user
             self.password = password
             super().__init__(settings_cls)
@@ -1203,7 +1203,7 @@ def test_external_settings_sources_filter_env_vars():
             @classmethod
             def customise_sources(
                 cls,
-                settings_cls: type[BaseSettings],
+                settings_cls: Type[BaseSettings],
                 init_settings: SettingsSourceCallable,
                 env_settings: SettingsSourceCallable,
                 dotenv_settings: SettingsSourceCallable,
@@ -1277,7 +1277,7 @@ def test_env_setting_source_custom_env_parse(env):
             @classmethod
             def customise_sources(
                 cls,
-                settings_cls: type['BaseSettings'],
+                settings_cls: Type['BaseSettings'],
                 init_settings: SettingsSourceCallable,
                 env_settings: SettingsSourceCallable,
                 dotenv_settings: SettingsSourceCallable,
@@ -1306,7 +1306,7 @@ def test_env_settings_source_custom_env_parse_is_bad(env):
             @classmethod
             def customise_sources(
                 cls,
-                settings_cls: type['BaseSettings'],
+                settings_cls: Type['BaseSettings'],
                 init_settings: SettingsSourceCallable,
                 env_settings: SettingsSourceCallable,
                 dotenv_settings: SettingsSourceCallable,
@@ -1340,7 +1340,7 @@ def test_secret_settings_source_custom_env_parse(tmp_path):
             @classmethod
             def customise_sources(
                 cls,
-                settings_cls: type['BaseSettings'],
+                settings_cls: Type['BaseSettings'],
                 init_settings: SettingsSourceCallable,
                 env_settings: SettingsSourceCallable,
                 dotenv_settings: SettingsSourceCallable,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -225,7 +225,7 @@ def test_set_dict_model(env):
 
 def test_invalid_json(env):
     env.set('apples', '["russet", "granny smith",]')
-    with pytest.raises(SettingsError, match='error parsing env var "apples"'):
+    with pytest.raises(SettingsError, match='error parsing value for field "apples"'):
         ComplexSettings()
 
 
@@ -1067,7 +1067,7 @@ def test_secrets_path_invalid_json(tmp_path):
         class Config:
             secrets_dir = tmp_path
 
-    with pytest.raises(SettingsError, match='error parsing env var "foo"'):
+    with pytest.raises(SettingsError, match='error parsing value for field "foo"'):
         Settings()
 
 
@@ -1235,19 +1235,19 @@ def test_customise_sources_empty():
 
 def test_builtins_settings_source_repr():
     assert (
-        repr(InitSettingsSource(init_kwargs={'apple': 'value 0', 'banana': 'value 1'}))
+        repr(InitSettingsSource(BaseSettings, init_kwargs={'apple': 'value 0', 'banana': 'value 1'}))
         == "InitSettingsSource(init_kwargs={'apple': 'value 0', 'banana': 'value 1'})"
     )
     assert (
-        repr(EnvSettingsSource(BaseSettings(), env_nested_delimiter='__'))
+        repr(EnvSettingsSource(BaseSettings, env_nested_delimiter='__'))
         == "EnvSettingsSource(env_nested_delimiter='__', env_prefix_len=0)"
     )
-    assert repr(DotEnvSettingsSource(BaseSettings(), env_file='.env', env_file_encoding='utf-8')) == (
+    assert repr(DotEnvSettingsSource(BaseSettings, env_file='.env', env_file_encoding='utf-8')) == (
         "DotEnvSettingsSource(env_file='.env', env_file_encoding='utf-8', "
         'env_nested_delimiter=None, env_prefix_len=0)'
     )
     assert (
-        repr(SecretsSettingsSource(BaseSettings(), secrets_dir='/secrets'))
+        repr(SecretsSettingsSource(BaseSettings, secrets_dir='/secrets'))
         == "SecretsSettingsSource(secrets_dir='/secrets')"
     )
 
@@ -1291,7 +1291,7 @@ def test_env_settings_source_custom_env_parse_is_bad(env):
                 return cls.json_loads(raw_val)
 
     env.set('top', '1=apple,2=banana')
-    with pytest.raises(SettingsError, match='error parsing env var "top"'):
+    with pytest.raises(SettingsError, match='error parsing value for field "top"'):
         Settings()
 
 


### PR DESCRIPTION
Reimplement pydantic-settings based on the idea proposed in https://github.com/pydantic/pydantic-settings/pull/10#pullrequestreview-1222893531

- Added `PydanticBaseSource` abc
- Other source classes changed to inherit from abc
- Added `DotEnvSettingsSource` inherit from `EnvSettingsSource`