### PR TITLE
Ignore env_prefix if validation_alias is set

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -129,9 +129,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                             (alias[0], self._apply_case_sensitive(alias[0]), True if len(alias) > 1 else False)
                         )
             else:  # string validation alias
-                field_info.append(
-                    (v_alias, self._apply_case_sensitive(self.config.get('env_prefix', '') + v_alias), False)
-                )
+                field_info.append((v_alias, self._apply_case_sensitive(v_alias), False))
         else:
             field_info.append(
                 (field_name, self._apply_case_sensitive(self.config.get('env_prefix', '') + field_name), False)


### PR DESCRIPTION
Found this when checking https://github.com/pydantic/pydantic-settings/issues/14
This was the behavior in V1 and changed by mistake in V2.
Also, I've updated the docs pr regarding this https://github.com/pydantic/pydantic-settings/pull/18/commits/6a29a7d5ba294083c36268c7847788b2fc867e3b