### PR TITLE
Format docs for import

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+description: Support for loading a settings or config class from environment variables or secrets files.
+---
+
 If you create a model that inherits from `BaseSettings`, the model initialiser will attempt to determine
 the values of any fields not passed as keyword arguments by reading from the environment. (Default values
 will still be used if the matching environment variable is not set.)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,3 @@
----
-description: Support for loading a settings or config class from environment variables or secrets files.
----
 
 If you create a model that inherits from `BaseSettings`, the model initialiser will attempt to determine
 the values of any fields not passed as keyword arguments by reading from the environment. (Default values


### PR DESCRIPTION
Formats the index.md page so it can be imported into pydantic docs using https://github.com/fire1ce/mkdocs-embed-external-markdown.

Current the plugin assumes the first line is a heading and strips it. This adds a blank line so no stripping occurs. Same workaround could be handled by adding a `# Pydantic Settings` heading, which might be something to do in the future.