### PR TITLE
Tweak sources to have `case_sensitive` and `env_prefix` usable as args

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ print(Settings().model_dump())
 
 By default, the environment variable name is the same as the field name.
 
-You can change the prefix for all environment variables by setting the `env_prefix` config setting, 
+You can change the prefix for all environment variables by setting the `env_prefix` config setting,
 or via the `_env_prefix` keyword argument on instantiation:
 
 ```py

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,37 @@ print(Settings().model_dump())
 
     Check the [Environment variable names documentation](#environment-variable-names) for more information.
 
+## Additionnal config values
+
+The following extra configuration values are available when using `BaseSettings`:
+
+* `case_sensitive`: Whether environment variables names should be read with case-sensitivity. Defaults to `False`.
+* `env_prefix`: Prefix for all environment variables. Defaults to `''`.
+* `env_file`: The env file(s) to load settings values from. Defaults to `None`.
+* `env_file_encoding`: The env file encoding, e.g. `'latin-1'`. Defaults to `None`.
+* `env_nested_delimiter`: The nested env values delimiter. Defaults to `None`.
+* `secrets_dir`: The secret files directory. Defaults to `None`.
+
+All of these values will be described in the following sections.
+
+!!! note
+    For better auto-completion, `SettingsConfigDict` can be used.
+
+All of these configuration options can be set during initialization:
+
+```py
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    v1: str = ''
+    model_config = SettingsConfigDict(env_prefix='my_prefix_')
+
+
+# Initialization values take priority over `model_config`.
+Settings(_env_prefix='other_prefix_')
+```
+
 ## Environment variable names
 
 By default, the environment variable name is the same as the field name.
@@ -316,7 +347,7 @@ in the `BaseSettings` class:
 
 ```py test="skip" lint="skip"
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file='.env', env_file_encoding = 'utf-8')
+    model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 ```
 
 2. Instantiating the `BaseSettings` derived class with the `_env_file` keyword argument

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,42 +86,12 @@ print(Settings().model_dump())
 
     Check the [Environment variable names documentation](#environment-variable-names) for more information.
 
-## Additionnal config values
-
-The following extra configuration values are available when using `BaseSettings`:
-
-* `case_sensitive`: Whether environment variables names should be read with case-sensitivity. Defaults to `False`.
-* `env_prefix`: Prefix for all environment variables. Defaults to `''`.
-* `env_file`: The env file(s) to load settings values from. Defaults to `None`.
-* `env_file_encoding`: The env file encoding, e.g. `'latin-1'`. Defaults to `None`.
-* `env_nested_delimiter`: The nested env values delimiter. Defaults to `None`.
-* `secrets_dir`: The secret files directory. Defaults to `None`.
-
-All of these values will be described in the following sections.
-
-!!! note
-    For better auto-completion, `SettingsConfigDict` can be used.
-
-All of these configuration options can be set during initialization:
-
-```py
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-
-class Settings(BaseSettings):
-    v1: str = ''
-    model_config = SettingsConfigDict(env_prefix='my_prefix_')
-
-
-# Initialization values take priority over `model_config`.
-Settings(_env_prefix='other_prefix_')
-```
-
 ## Environment variable names
 
 By default, the environment variable name is the same as the field name.
 
-You can change the prefix for all environment variables by setting the `env_prefix` config setting:
+You can change the prefix for all environment variables by setting the `env_prefix` config setting, 
+or via the `_env_prefix` keyword argument on instantiation:
 
 ```py
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -165,6 +135,8 @@ When `case_sensitive` is `True`, the environment variable names must match field
 so in this example `redis_host` could only be modified via `export redis_host`. If you want to name environment variables
 all upper-case, you should name attribute all upper-case too. You can still name environment variables anything
 you like through `Field(validation_alias=...)`.
+
+Case-sensitivity can also be set via the `_case_sensitive` keyword argument on instantiation.
 
 In case of nested models, the `case_sensitive` setting will be applied to all nested models.
 

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -19,7 +19,7 @@ from .sources import (
 env_file_sentinel: DotenvType = Path('')
 
 
-class SettingsConfigDict(ConfigDict):
+class SettingsConfigDict(ConfigDict, total=False):
     case_sensitive: bool
     env_prefix: str
     env_file: DotenvType | None
@@ -41,7 +41,6 @@ class BaseSettings(BaseModel):
         _case_sensitive: Whether environment variables names should be read with case-sensitivity. Defaults to `None`.
         _env_prefix: Prefix for all environment variables. Defaults to `None`.
         _env_file: The env file(s) to load settings values from. Defaults to `Path('')`.
-        _env_file_encoding: The env file encoding. e.g. `'latin-1'`. Defaults to `None`.
         _env_file_encoding: The env file encoding, e.g. `'latin-1'`. Defaults to `None`.
         _env_nested_delimiter: The nested env values delimiter. Defaults to `None`.
         _secrets_dir: The secret files directory. Defaults to `None`.

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -115,7 +115,7 @@ class BaseSettings(BaseModel):
             if _env_nested_delimiter is not None
             else self.model_config.get('env_nested_delimiter')
         )
-        secrets_dir = _secrets_dir or self.model_config.get('secrets_dir')
+        secrets_dir = _secrets_dir if _secrets_dir is not None else self.model_config.get('secrets_dir')
 
         # Configure built-in sources
         init_settings = InitSettingsSource(self.__class__, init_kwargs=init_kwargs)

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -19,7 +19,7 @@ from .sources import (
 env_file_sentinel: DotenvType = Path('')
 
 
-class SettingsConfigDict(ConfigDict, total=False):
+class SettingsConfigDict(ConfigDict):
     case_sensitive: bool
     env_prefix: str
     env_file: DotenvType | None
@@ -38,8 +38,11 @@ class BaseSettings(BaseModel):
     All the bellow attributes can be set via `model_config`.
 
     Args:
+        _case_sensitive: Whether environment variables names should be read with case-sensitivity. Defaults to `None`.
+        _env_prefix: Prefix for all environment variables. Defaults to `None`.
         _env_file: The env file(s) to load settings values from. Defaults to `Path('')`.
         _env_file_encoding: The env file encoding. e.g. `'latin-1'`. Defaults to `None`.
+        _env_file_encoding: The env file encoding, e.g. `'latin-1'`. Defaults to `None`.
         _env_nested_delimiter: The nested env values delimiter. Defaults to `None`.
         _secrets_dir: The secret files directory. Defaults to `None`.
     """

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -534,9 +534,9 @@ class DotEnvSettingsSource(EnvSettingsSource):
         env_prefix: str | None = None,
         env_nested_delimiter: str | None = None,
     ) -> None:
-        super().__init__(settings_cls, case_sensitive, env_prefix, env_nested_delimiter)
         self.env_file = env_file
         self.env_file_encoding = env_file_encoding
+        super().__init__(settings_cls, case_sensitive, env_prefix, env_nested_delimiter)
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
         return self._read_env_files(self.case_sensitive)

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -108,8 +108,15 @@ class InitSettingsSource(PydanticBaseSettingsSource):
 
 
 class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
+    def __init__(
+        self, settings_cls: type[BaseSettings], case_sensitive: bool | None = None, env_prefix: str | None = None
+    ) -> None:
+        super().__init__(settings_cls)
+        self.case_sensitive = case_sensitive if case_sensitive is not None else False
+        self.env_prefix = env_prefix if env_prefix is not None else ''
+
     def _apply_case_sensitive(self, value: str) -> str:
-        return value.lower() if not self.config.get('case_sensitive') else value
+        return value.lower() if not self.case_sensitive else value
 
     def _extract_field_info(self, field: FieldInfo, field_name: str) -> list[tuple[str, str, bool]]:
         """
@@ -147,9 +154,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
             else:  # string validation alias
                 field_info.append((v_alias, self._apply_case_sensitive(v_alias), False))
         else:
-            field_info.append(
-                (field_name, self._apply_case_sensitive(self.config.get('env_prefix', '') + field_name), False)
-            )
+            field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), False))
 
         return field_info
 
@@ -231,7 +236,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                 ) from e
 
             if field_value is not None:
-                if not self.config.get('case_sensitive', False) and lenient_issubclass(field.annotation, BaseModel):
+                if not self.case_sensitive and lenient_issubclass(field.annotation, BaseModel):
                     data[field_key] = self._replace_field_names_case_insensitively(field, field_value)
                 else:
                     data[field_key] = field_value
@@ -244,9 +249,15 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
     Source class for loading settings values from secret files.
     """
 
-    def __init__(self, settings_cls: type[BaseSettings], secrets_dir: str | Path | None):
+    def __init__(
+        self,
+        settings_cls: type[BaseSettings],
+        secrets_dir: str | Path | None,
+        case_sensitive: bool | None = None,
+        env_prefix: str | None = None,
+    ) -> None:
+        super().__init__(settings_cls, case_sensitive, env_prefix)
         self.secrets_dir = secrets_dir
-        super().__init__(settings_cls)
 
     def __call__(self) -> dict[str, Any]:
         """
@@ -302,9 +313,7 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
         """
 
         for field_key, env_name, value_is_complex in self._extract_field_info(field, field_name):
-            path = self.find_case_path(
-                self.secrets_path, env_name, self.settings_cls.model_config.get('case_sensitive', False)
-            )
+            path = self.find_case_path(self.secrets_path, env_name, self.case_sensitive)
             if not path:
                 # path does not exist, we curently don't return a warning for this
                 continue
@@ -331,18 +340,18 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
     def __init__(
         self,
         settings_cls: type[BaseSettings],
+        case_sensitive: bool | None = None,
+        env_prefix: str | None = None,
         env_nested_delimiter: str | None = None,
-        env_prefix_len: int = 0,
-    ):
-        super().__init__(settings_cls)
+    ) -> None:
+        super().__init__(settings_cls, case_sensitive, env_prefix)
+        self.env_nested_delimiter = env_nested_delimiter
+        self.env_prefix_len = len(self.env_prefix)
 
-        self.env_nested_delimiter: str | None = env_nested_delimiter
-        self.env_prefix_len: int = env_prefix_len
-
-        self.env_vars: Mapping[str, str | None] = self._load_env_vars()
+        self.env_vars = self._load_env_vars()
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
-        if self.settings_cls.model_config.get('case_sensitive'):
+        if self.case_sensitive:
             return os.environ
         return {k.lower(): v for k, v in os.environ.items()}
 
@@ -521,16 +530,16 @@ class DotEnvSettingsSource(EnvSettingsSource):
         settings_cls: type[BaseSettings],
         env_file: DotenvType | None,
         env_file_encoding: str | None,
+        case_sensitive: bool | None = None,
+        env_prefix: str | None = None,
         env_nested_delimiter: str | None = None,
-        env_prefix_len: int = 0,
-    ):
-        self.env_file: DotenvType | None = env_file
-        self.env_file_encoding: str | None = env_file_encoding
-
-        super().__init__(settings_cls, env_nested_delimiter, env_prefix_len)
+    ) -> None:
+        super().__init__(settings_cls, case_sensitive, env_prefix, env_nested_delimiter)
+        self.env_file = env_file
+        self.env_file_encoding = env_file_encoding
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
-        return self._read_env_files(self.settings_cls.model_config.get('case_sensitive', False))
+        return self._read_env_files(self.case_sensitive)
 
     def _read_env_files(self, case_sensitive: bool) -> Mapping[str, str | None]:
         env_files = self.env_file
@@ -554,7 +563,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
         data: dict[str, Any] = super().__call__()
 
         data_lower_keys: list[str] = []
-        if not self.settings_cls.model_config.get('case_sensitive', False):
+        if not self.case_sensitive:
             data_lower_keys = [x.lower() for x in data.keys()]
 
         # As `extra` config is allowed in dotenv settings source, We have to


### PR DESCRIPTION
Fixes #74.

Ended up doing a bit of refactoring, the idea is to avoid accessing `self.config` (even `self.settings_cls.model_config` in some places, which points to the same config object) in sources, and determine the values to use in `_settings_build_values` instead.

Alternatively we could have some kind of "context" object, created by merging args values from `_settings_build_values` and values from the `model_config`. This way we wouldn't have to pass each config value by hand to the sources' `__init__`.

Waiting for review before fixing tests and updating documentation.

Selected Reviewer: @hramezani