### PR TITLE
Add default value to source classes init params

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -39,7 +39,9 @@ class BaseSettings(BaseModel):
     Args:
         _case_sensitive: Whether environment variables names should be read with case-sensitivity. Defaults to `None`.
         _env_prefix: Prefix for all environment variables. Defaults to `None`.
-        _env_file: The env file(s) to load settings values from. Defaults to `Path('')`.
+        _env_file: The env file(s) to load settings values from. Defaults to `Path('')`, which
+            means that the value from `model_config['env_file']` should be used. You can also pass
+            `None` to indicate that environment variables should not be loaded from an env file.
         _env_file_encoding: The env file encoding, e.g. `'latin-1'`. Defaults to `None`.
         _env_nested_delimiter: The nested env values delimiter. Defaults to `None`.
         _secrets_dir: The secret files directory. Defaults to `None`.

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -14,9 +14,8 @@ from .sources import (
     InitSettingsSource,
     PydanticBaseSettingsSource,
     SecretsSettingsSource,
+    env_file_sentinel,
 )
-
-env_file_sentinel: DotenvType = Path('')
 
 
 class SettingsConfigDict(ConfigDict, total=False):
@@ -158,7 +157,7 @@ class BaseSettings(BaseModel):
         validate_default=True,
         case_sensitive=False,
         env_prefix='',
-        env_file=None,
+        env_file=env_file_sentinel,
         env_file_encoding=None,
         env_nested_delimiter=None,
         secrets_dir=None,

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -8,13 +8,13 @@ from pydantic._internal._utils import deep_update
 from pydantic.main import BaseModel
 
 from .sources import (
+    ENV_FILE_SENTINEL,
     DotEnvSettingsSource,
     DotenvType,
     EnvSettingsSource,
     InitSettingsSource,
     PydanticBaseSettingsSource,
     SecretsSettingsSource,
-    env_file_sentinel,
 )
 
 
@@ -49,7 +49,7 @@ class BaseSettings(BaseModel):
         __pydantic_self__,
         _case_sensitive: bool | None = None,
         _env_prefix: str | None = None,
-        _env_file: DotenvType | None = env_file_sentinel,
+        _env_file: DotenvType | None = ENV_FILE_SENTINEL,
         _env_file_encoding: str | None = None,
         _env_nested_delimiter: str | None = None,
         _secrets_dir: str | Path | None = None,
@@ -105,7 +105,7 @@ class BaseSettings(BaseModel):
         # Determine settings config values
         case_sensitive = _case_sensitive if _case_sensitive is not None else self.model_config.get('case_sensitive')
         env_prefix = _env_prefix if _env_prefix is not None else self.model_config.get('env_prefix')
-        env_file = _env_file if _env_file != env_file_sentinel else self.model_config.get('env_file')
+        env_file = _env_file if _env_file != ENV_FILE_SENTINEL else self.model_config.get('env_file')
         env_file_encoding = (
             _env_file_encoding if _env_file_encoding is not None else self.model_config.get('env_file_encoding')
         )
@@ -157,7 +157,7 @@ class BaseSettings(BaseModel):
         validate_default=True,
         case_sensitive=False,
         env_prefix='',
-        env_file=env_file_sentinel,
+        env_file=None,
         env_file_encoding=None,
         env_nested_delimiter=None,
         secrets_dir=None,

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -22,7 +22,12 @@ if TYPE_CHECKING:
 
 
 DotenvType = Union[Path, List[Path], Tuple[Path, ...]]
-env_file_sentinel: DotenvType = Path('')
+
+# This is used as default value for `_env_file` in `Settings` class and
+# `env_file` in `DotEnvSettingsSource`. Then passing `None` as `_env_file`
+# during initialization of `Settings` has a special meaning and it will
+# override the `env_file` specified in config.
+ENV_FILE_SENTINEL: DotenvType = Path('')
 
 
 class SettingsError(ValueError):
@@ -531,13 +536,13 @@ class DotEnvSettingsSource(EnvSettingsSource):
     def __init__(
         self,
         settings_cls: type[BaseSettings],
-        env_file: DotenvType | None = env_file_sentinel,
+        env_file: DotenvType | None = ENV_FILE_SENTINEL,
         env_file_encoding: str | None = None,
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,
         env_nested_delimiter: str | None = None,
     ) -> None:
-        self.env_file = env_file if env_file != env_file_sentinel else settings_cls.model_config.get('env_file')
+        self.env_file = env_file if env_file != ENV_FILE_SENTINEL else settings_cls.model_config.get('env_file')
         self.env_file_encoding = (
             env_file_encoding if env_file_encoding is not None else settings_cls.model_config.get('env_file_encoding')
         )

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 
 DotenvType = Union[Path, List[Path], Tuple[Path, ...]]
+env_file_sentinel: DotenvType = Path('')
 
 
 class SettingsError(ValueError):
@@ -252,12 +253,12 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
     def __init__(
         self,
         settings_cls: type[BaseSettings],
-        secrets_dir: str | Path | None,
+        secrets_dir: str | Path | None = None,
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,
     ) -> None:
         super().__init__(settings_cls, case_sensitive, env_prefix)
-        self.secrets_dir = secrets_dir
+        self.secrets_dir = secrets_dir if secrets_dir is not None else self.config.get('secrets_dir')
 
     def __call__(self) -> dict[str, Any]:
         """
@@ -345,7 +346,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         env_nested_delimiter: str | None = None,
     ) -> None:
         super().__init__(settings_cls, case_sensitive, env_prefix)
-        self.env_nested_delimiter = env_nested_delimiter
+        self.env_nested_delimiter = (
+            env_nested_delimiter if env_nested_delimiter is not None else self.config.get('env_nested_delimiter')
+        )
         self.env_prefix_len = len(self.env_prefix)
 
         self.env_vars = self._load_env_vars()
@@ -528,14 +531,16 @@ class DotEnvSettingsSource(EnvSettingsSource):
     def __init__(
         self,
         settings_cls: type[BaseSettings],
-        env_file: DotenvType | None,
-        env_file_encoding: str | None,
+        env_file: DotenvType | None = env_file_sentinel,
+        env_file_encoding: str | None = None,
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,
         env_nested_delimiter: str | None = None,
     ) -> None:
-        self.env_file = env_file
-        self.env_file_encoding = env_file_encoding
+        self.env_file = env_file if env_file != env_file_sentinel else settings_cls.model_config.get('env_file')
+        self.env_file_encoding = (
+            env_file_encoding if env_file_encoding is not None else settings_cls.model_config.get('env_file_encoding')
+        )
         super().__init__(settings_cls, case_sensitive, env_prefix, env_nested_delimiter)
 
     def _load_env_vars(self) -> Mapping[str, str | None]:

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -23,10 +23,9 @@ if TYPE_CHECKING:
 
 DotenvType = Union[Path, List[Path], Tuple[Path, ...]]
 
-# This is used as default value for `_env_file` in `Settings` class and
-# `env_file` in `DotEnvSettingsSource`. Then passing `None` as `_env_file`
-# during initialization of `Settings` has a special meaning and it will
-# override the `env_file` specified in config.
+# This is used as default value for `_env_file` in the `BaseSettings` class and
+# `env_file` in `DotEnvSettingsSource` so the default can be distinguished from `None`.
+# See the docstring of `BaseSettings` for more details.
 ENV_FILE_SENTINEL: DotenvType = Path('')
 
 


### PR DESCRIPTION
This makes source classes inheritable in custom source classes. So, the custom source class doesn't need to override the `__init__` to provide a fallback value from the config.


Selected Reviewer: @dmontagu