### PR TITLE
docs: fix link with relative

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,12 +72,12 @@ print(Settings().model_dump())
 1. The environment variable name is overridden using `validation_alias`. In this case, the environment variable
    `my_auth_key` will be read instead of `auth_key`.
 
-    Check the [`Field` documentation](/usage/fields/) for more information.
+    Check the [`Field` documentation](../fields/) for more information.
 
 2. The `AliasChoices` class allows to have multiple environment variable names for a single field.
    The first environment variable that is found will be used.
 
-    Check the [`AliasChoices`](/usage/fields/#aliaspath-and-aliaschoices) for more information.
+    Check the [`AliasChoices`](../fields/#aliaspath-and-aliaschoices) for more information.
 
 3. The `ImportString` class allows to import an object from a string.
    In this case, the environment variable `special_function` will be read and the function `math.cos` will be imported.
@@ -113,7 +113,7 @@ There are two ways to do this:
 * Using `Field(alias=...)` (see `api_key` above)
 * Using `Field(validation_alias=...)` (see `auth_key` above)
 
-Check the [`Field` aliases documentation](/usage/fields#field-aliases) for more information about aliases.
+Check the [`Field` aliases documentation](../fields#field-aliases) for more information about aliases.
 
 ### Case-sensitivity
 


### PR DESCRIPTION
e.g.
- https://docs.pydantic.dev/dev-v2/usage/pydantic_settings/#environment-variable-names
  - Check the `Field aliases documentation` for more information about aliases