### PR TITLE
Fix garbled up docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -317,7 +317,7 @@ Once you have your `.env` file filled with variables, *pydantic* supports loadin
 1. Setting the `env_file` (and `env_file_encoding` if you don't want the default encoding of your OS) on `model_config`
 in the `BaseSettings` class:
 
-```py test="skip" lint="skip"
+```py
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 ```
@@ -325,7 +325,7 @@ class Settings(BaseSettings):
 2. Instantiating the `BaseSettings` derived class with the `_env_file` keyword argument
 (and the `_env_file_encoding` if needed):
 
-```py test="skip" lint="skip"
+```py
 settings = Settings(_env_file='prod.env', _env_file_encoding='utf-8')
 ```
 
@@ -347,7 +347,7 @@ while `.env` would be ignored.
 If you need to load multiple dotenv files, you can pass multiple file paths as a tuple or list. The files will be
 loaded in order, with each file overriding the previous one.
 
-```py test="skip" lint="skip"
+```py
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         # `.env.prod` takes priority over `.env`
@@ -381,7 +381,7 @@ Once you have your secret files, *pydantic* supports loading it in two ways:
 
 1. Setting the `secrets_dir` on `model_config` in a `BaseSettings` class to the directory where your secret files are stored.
 
-```py test="skip" lint="skip"
+```py
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(secrets_dir='/var/run')
 
@@ -390,7 +390,7 @@ class Settings(BaseSettings):
 
 2. Instantiating the `BaseSettings` derived class with the `_secrets_dir` keyword argument:
 
-```py test="skip" lint="skip"
+```py
 settings = Settings(_secrets_dir='/var/run')
 ```
 
@@ -413,7 +413,7 @@ and using secrets in Docker see the official
 
 First, define your `Settings` class with a `SettingsConfigDict` that specifies the secrets directory.
 
-```py test="skip" lint="skip"
+```py
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(secrets_dir='/run/secrets')
 


### PR DESCRIPTION
### Why this change?

The docs are garbled up in a few places.

![Screenshot 2023-06-26 at 08 26 44](https://github.com/pydantic/pydantic-settings/assets/994357/9419bc8d-30d7-4554-b743-57831e1ed17b)

### What was done?

- Removed the occurrences of `test="skip" lint="skip"` which followed the three backticks to mark a code block.

### Concerns, notes, side-effects etc

- I'm not sure if instead there was some missing plugin or something that should instead be added rather than removing these declarations. However, I couldn't find these declarations elsewhere in the docs, so I figured I'd just remove them.
