### PR TITLE
Improve `DotenvType` to accept `str`

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
 
 
-DotenvType = Union[Path, List[Path], Tuple[Path, ...]]
+DotenvType = Union[Path, str, List[Union[Path, str]], Tuple[Union[Path, str], ...]]
 
 # This is used as default value for `_env_file` in the `BaseSettings` class and
 # `env_file` in `DotEnvSettingsSource` so the default can be distinguished from `None`.


### PR DESCRIPTION
Fixes first error reported in https://github.com/pydantic/pydantic-settings/issues/95

```
test.py:4: error: Incompatible types (expression has type "str", TypedDict item "env_file" has type "Path | list[Path] | tuple[Path, ...] | None")  [typeddict-item]
```

Selected Reviewer: @samuelcolvin