### PR TITLE
Add explicit type hint to `BaseSettings.model_config`

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import ConfigDict
 from pydantic._internal._utils import deep_update
@@ -153,7 +153,7 @@ class BaseSettings(BaseModel):
             # to an informative error and much better than a confusing error
             return {}
 
-    model_config = SettingsConfigDict(
+    model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
         extra='forbid',
         arbitrary_types_allowed=True,
         validate_default=True,


### PR DESCRIPTION
Noticed this small issue when working inside `settings_customise_sources`. Before this PR (by using either `cls` or `settings_cls`):

![image](https://github.com/pydantic/pydantic-settings/assets/65306057/aacdc137-d97a-4e4e-ab20-8bdad6f6cd16)

After:

![image](https://github.com/pydantic/pydantic-settings/assets/65306057/b8241e00-35e5-4fb6-8c19-527180bea46f)

What's weird is that my IDE seems to infer the type correctly in other places, even without this improvement:

![image](https://github.com/pydantic/pydantic-settings/assets/65306057/e40d3eb1-6519-4e7c-a5d4-6552698c965f)

By the way, is the `settings_cls` argument necessary, as `settings_customise_sources` is already a class method and we have access to `cls`?

Selected Reviewer: @dmontagu