### PR TITLE
Use config values as default in `PydanticBaseEnvSettingsSource.__init__`

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -117,8 +117,8 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         self, settings_cls: type[BaseSettings], case_sensitive: bool | None = None, env_prefix: str | None = None
     ) -> None:
         super().__init__(settings_cls)
-        self.case_sensitive = case_sensitive if case_sensitive is not None else False
-        self.env_prefix = env_prefix if env_prefix is not None else ''
+        self.case_sensitive = case_sensitive if case_sensitive is not None else self.config.get('case_sensitive', False)
+        self.env_prefix = env_prefix if env_prefix is not None else self.config.get('env_prefix', '')
 
     def _apply_case_sensitive(self, value: str) -> str:
         return value.lower() if not self.case_sensitive else value

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -32,6 +32,7 @@ from pydantic_settings import (
     InitSettingsSource,
     PydanticBaseSettingsSource,
     SecretsSettingsSource,
+    SettingsConfigDict,
 )
 from pydantic_settings.sources import SettingsError, read_env_file
 
@@ -1698,3 +1699,21 @@ def test_env_json_field_dict(env):
             'input': 'bar',
         }
     ]
+
+
+def test_custom_env_source_default_values_from_config():
+    class CustomEnvSettingsSource(EnvSettingsSource):
+        pass
+
+    class Settings(BaseSettings):
+        foo: str = 'test'
+
+        model_config = SettingsConfigDict(env_prefix='prefix_', case_sensitive=True)
+
+    s = Settings()
+    assert s.model_config['env_prefix'] == 'prefix_'
+    assert s.model_config['case_sensitive'] is True
+
+    c = CustomEnvSettingsSource(s)
+    assert c.env_prefix == 'prefix_'
+    assert c.case_sensitive is True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1714,6 +1714,6 @@ def test_custom_env_source_default_values_from_config():
     assert s.model_config['env_prefix'] == 'prefix_'
     assert s.model_config['case_sensitive'] is True
 
-    c = CustomEnvSettingsSource(s)
+    c = CustomEnvSettingsSource(Settings)
     assert c.env_prefix == 'prefix_'
     assert c.case_sensitive is True


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic-settings/issues/98

Selected Reviewer: @samuelcolvin