### PR TITLE
dotenv no error w/ an env key shorter than prefix (#106)

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -578,7 +578,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
         # As `extra` config is allowed in dotenv settings source, We have to
         # update data with extra env variabels from dotenv file.
         for env_name, env_value in self.env_vars.items():
-            if env_value is not None:
+            if env_name.startswith(self.env_prefix) and env_value is not None:
                 env_name_without_prefix = env_name[self.env_prefix_len :]
                 first_key, *_ = env_name_without_prefix.split(self.env_nested_delimiter)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -680,6 +680,37 @@ def test_env_file_config(env, tmp_path):
     assert s.c == 'best string'
 
 
+prefix_test_env_file = """\
+# this is a comment
+prefix_A=good string
+# another one, followed by whitespace
+
+prefix_b='better string'
+prefix_c="best string"
+f="random value"
+"""
+
+
+@pytest.mark.skipif(not dotenv, reason='python-dotenv not installed')
+def test_env_file_with_env_prefix(env, tmp_path):
+    p = tmp_path / '.env'
+    p.write_text(prefix_test_env_file)
+
+    class Settings(BaseSettings):
+        a: str
+        b: str
+        c: str
+
+        model_config = ConfigDict(env_file=p, env_prefix='prefix_')
+
+    env.set('prefix_A', 'overridden var')
+
+    s = Settings()
+    assert s.a == 'overridden var'
+    assert s.b == 'better string'
+    assert s.c == 'best string'
+
+
 @pytest.mark.skipif(not dotenv, reason='python-dotenv not installed')
 def test_env_file_config_case_sensitive(tmp_path):
     p = tmp_path / '.env'


### PR DESCRIPTION
fixes #106 

I created a test that tests a dotenv config class with a prefix to test the effect of my changes