### PR TITLE
fix typos in pydantic settings module

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -44,7 +44,7 @@ class BaseSettings(BaseModel):
     This is useful in production for secrets you do not wish to save in code, it plays nicely with docker(-compose),
     Heroku and any 12 factor app design.
 
-    All the bellow attributes can be set via `model_config`.
+    All the below attributes can be set via `model_config`.
 
     Args:
         _case_sensitive: Whether environment variables names should be read with case-sensitivity. Defaults to `None`.

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -47,7 +47,7 @@ class PydanticBaseSettingsSource(ABC):
         """
         Gets the value, the key for model creation, and a flag to determine whether value is complex.
 
-        This is an abstract method that should be overrided in every settings source classes.
+        This is an abstract method that should be overridden in every settings source classes.
 
         Args:
             field: The field.
@@ -324,7 +324,7 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
         for field_key, env_name, value_is_complex in self._extract_field_info(field, field_name):
             path = self.find_case_path(self.secrets_path, env_name, self.case_sensitive)
             if not path:
-                # path does not exist, we curently don't return a warning for this
+                # path does not exist, we currently don't return a warning for this
                 continue
 
             if path.is_file():


### PR DESCRIPTION
```
./pydantic_settings/sources.py:50: overrided ==> overridden
./pydantic_settings/sources.py:327: curently ==> currently
./pydantic_settings/main.py:47: bellow ==> below
```