### PR TITLE
Add documentation about compatibility with pydantic 1.x BaseSettings when using dotenv

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -389,6 +389,8 @@ it will raise `ValidationError` in settings construction.
 
 For compatibility with pydantic 1.x BaseSettings you should use `extra=ignore`: 
 ```py
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file='.env',

--- a/docs/index.md
+++ b/docs/index.md
@@ -392,10 +392,7 @@ For compatibility with pydantic 1.x BaseSettings you should use `extra=ignore`:
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(
-        env_file='.env',
-        extra='ignore'
-    )
+    model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 ```
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -383,9 +383,19 @@ Because python-dotenv is used to parse the file, bash-like semantics such as `ex
 (depending on your OS and environment) may allow your dotenv file to also be used with `source`,
 see [python-dotenv's documentation](https://saurabh-kumar.com/python-dotenv/#usages) for more details.
 
-Pydantic settings consider `extra` config in case of dotenv file. It means if you set the `extra=forbid`
+Pydantic settings consider `extra` config in case of dotenv file. It means if you set the `extra=forbid` (*default*)
 on `model_config` and your dotenv file contains an entry for a field that is not defined in settings model,
 it will raise `ValidationError` in settings construction.
+
+For compatibility with pydantic 1.x BaseSettings you should use `extra=ignore`: 
+```py
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file='.env',
+        extra='ignore'
+    )
+```
+
 
 ## Secrets
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -391,6 +391,7 @@ For compatibility with pydantic 1.x BaseSettings you should use `extra=ignore`:
 ```py
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -387,7 +387,7 @@ Pydantic settings consider `extra` config in case of dotenv file. It means if yo
 on `model_config` and your dotenv file contains an entry for a field that is not defined in settings model,
 it will raise `ValidationError` in settings construction.
 
-For compatibility with pydantic 1.x BaseSettings you should use `extra=ignore`: 
+For compatibility with pydantic 1.x BaseSettings you should use `extra=ignore`:
 ```py
 from pydantic_settings import BaseSettings, SettingsConfigDict
 


### PR DESCRIPTION
…when using dotenv

This PR adds more info about compatibility with old behavior, since in current version `extra` seems to be defaulted to `forbid`, which broke behavior expected in pydantic 1.x BaseSettings.

More info: #125