### PR TITLE
Fix `_replace_field_names_case_insensitively` precondition inconsistency

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -229,7 +229,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                 values[name] = value
                 continue
 
-            if lenient_issubclass(sub_model_field.annotation, BaseModel):
+            if lenient_issubclass(sub_model_field.annotation, BaseModel) and isinstance(value, dict):
                 values[sub_model_field_name] = self._replace_field_names_case_insensitively(sub_model_field, value)
             else:
                 values[sub_model_field_name] = value


### PR DESCRIPTION
Make recursive `PydanticBaseEnvSettingsSource._replace_field_names_case_insensitively` behave similarly to the check in `PydanticBaseEnvSettingsSource.__call__`.

Use in `__call__`:
```
if field_value is not None:
    if (
        not self.case_sensitive
        and lenient_issubclass(field.annotation, BaseModel)
        and isinstance(field_value, dict)
    ):
        data[field_key] = self._replace_field_names_case_insensitively(field, field_value)
    else:
        data[field_key] = field_value
```

this use-case checks if the `field_value` is of type dict so the `.items()` can be called.

But during `_replace_field_names_case_insensitively` the recursive call:

```
if lenient_issubclass(sub_model_field.annotation, BaseModel):
    values[sub_model_field_name] = self._replace_field_names_case_insensitively(sub_model_field, value)
else:
    values[sub_model_field_name] = value
```

does not check for the type to be a dict. I.e. this can raise an AttributeError when the BaseModel is represented in any other way than a dict value.

This is a plausible scenario since field validators can extract complex info from a flat entity (e.g. a string with a specific format). One could argue that this can be provided in the `decode_complex_value`.

However, if this parsing is universal, it would mean that this logic must be provided multiple times.

Selected Reviewer: @dmontagu