### PR TITLE
feat: contribute KeyringSettingsSource class to load keyring variables

### DIFF
--- a/pydantic_settings/__init__.py
+++ b/pydantic_settings/__init__.py
@@ -3,6 +3,7 @@ from .sources import (
     DotEnvSettingsSource,
     EnvSettingsSource,
     InitSettingsSource,
+    KeyringSettingsSource,
     PydanticBaseSettingsSource,
     SecretsSettingsSource,
 )
@@ -13,6 +14,7 @@ __all__ = (
     'DotEnvSettingsSource',
     'EnvSettingsSource',
     'InitSettingsSource',
+    'KeyringSettingsSource',
     'PydanticBaseSettingsSource',
     'SecretsSettingsSource',
     'SettingsConfigDict',


### PR DESCRIPTION
## Proposal

PR to fulfill the feature proposal:

- #139

## Details

- A `keyring_backend` is provided, and behaves similarly to the `env_file`: if the named backend is not found, nothing is loaded. If not specified, the default backend is used.

## Request for review

- Is the approach of `try`/`except ImportError: pass` acceptable? An alternative would be to set a variable that could be used to gate the calling of the `keyring` module.
- How should I implement error handling for the access of the variables? (As mentioned in the original proposal). If the keyring is locked it will raise an error. I haven't added this handling to keep the original proposal simple.