### PR TITLE
Env var extraction to classmethod

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ class Settings(BaseSettings):
     # export my_prefix_more_settings='{"foo": "x", "apple": 1}'
     more_settings: SubModel = SubModel()
 
-    model_config = SettingsConfigDict(env_prefix='my_prefix_')  # (5)!
+    model_config = SettingsConfigDict(env_prefix='my_prefix_', extra='ignore')  # (5)!
 
 
 print(Settings().model_dump())
@@ -273,7 +273,7 @@ You may also populate a complex type by providing your own source class.
 ```py
 import json
 import os
-from typing import Any, List, Tuple, Type
+from typing import Any, List, Mapping, Tuple, Type
 
 from pydantic.fields import FieldInfo
 
@@ -285,8 +285,15 @@ from pydantic_settings import (
 
 
 class MyCustomSource(EnvSettingsSource):
-    def prepare_field_value(
-        self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool
+    @classmethod
+    def prepare_field_value_from_env_vars(
+        cls,
+        field_name: str,
+        field: FieldInfo,
+        value: Any,
+        value_is_complex: bool,
+        env_vars: Mapping[str, str | None],
+        config: EnvSettingsSource._EnvSettingsSource__SourceConfig,
     ) -> Any:
         if field_name == 'numbers':
             return [int(x) for x in value.split(',')]

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -7,9 +7,9 @@ from abc import ABC, abstractmethod
 from collections import deque
 from dataclasses import is_dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Mapping, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, List, Mapping, Sequence, Tuple, Union, cast, Literal
 
-from pydantic import AliasChoices, AliasPath, BaseModel, Json
+from pydantic import AliasChoices, AliasPath, BaseModel, Json, ConfigDict
 from pydantic._internal._typing_extra import origin_is_union
 from pydantic._internal._utils import deep_update, lenient_issubclass
 from pydantic.fields import FieldInfo
@@ -127,57 +127,95 @@ class InitSettingsSource(PydanticBaseSettingsSource):
 
 
 class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
+    class __SourceConfig(ConfigDict):
+        case_sensitive: bool
+        env_prefix: str
+
     def __init__(
         self, settings_cls: type[BaseSettings], case_sensitive: bool | None = None, env_prefix: str | None = None
     ) -> None:
         super().__init__(settings_cls)
-        self.case_sensitive = case_sensitive if case_sensitive is not None else self.config.get('case_sensitive', False)
-        self.env_prefix = env_prefix if env_prefix is not None else self.config.get('env_prefix', '')
+        self.source_config = self.__init_source_config(case_sensitive=case_sensitive, env_prefix=env_prefix)
 
-    def _apply_case_sensitive(self, value: str) -> str:
-        return value.lower() if not self.case_sensitive else value
+    def __init_source_config(
+        self, *, case_sensitive: bool | None = None, env_prefix: str | None = None
+    ) -> Self.__SourceConfig:
+        case_sensitive = case_sensitive if case_sensitive is not None else self.config.get('case_sensitive', False)
+        env_prefix = env_prefix if env_prefix is not None else self.config.get('env_prefix', '')
+        return self.__SourceConfig(env_prefix=env_prefix, case_sensitive=case_sensitive)
 
-    def _extract_field_info(self, field: FieldInfo, field_name: str) -> list[tuple[str, str, bool]]:
+    def load_env_vars(self) -> Mapping[str, Any]:
+        raise NotImplementedError()
+
+    @classmethod
+    def prepare_field_value_from_env_vars(
+        cls,
+        field_name: str,
+        field: FieldInfo,
+        value: Any,
+        value_is_complex: bool,
+        env_vars: Mapping[str, Any],
+        config: Self.__SourceConfig,
+    ) -> Any:
+        raise NotImplementedError()
+
+    @classmethod
+    def read_model_fields(
+        cls, model_fields: Mapping[str, Any], env_vars: Mapping[str, str | None], config: Self.__SourceConfig
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        for field_name, field in model_fields.items():
+            try:
+                field_value, field_key, value_is_complex = cls.get_field_value_from_env_vars(
+                    field, field_name, env_vars, config
+                )
+            except Exception as e:
+                raise SettingsError(f'error getting value for field "{field_name}" from source "{cls.__name__}"') from e
+
+            try:
+                field_value = cls.prepare_field_value_from_env_vars(
+                    field_name, field, field_value, value_is_complex, env_vars, config
+                )
+            except ValueError as e:
+                raise SettingsError(f'error parsing value for field "{field_name}" from source "{cls.__name__}"') from e
+
+            if field_value is not None:
+                if (
+                    not config["case_sensitive"]
+                    and lenient_issubclass(field.annotation, BaseModel)
+                    and isinstance(field_value, dict)
+                ):
+                    data[field_key] = cls._replace_field_names_case_insensitively(field, field_value)
+                else:
+                    data[field_key] = field_value
+        return data
+
+    @classmethod
+    def get_field_value_from_env_vars(
+        cls, field: FieldInfo, field_name: str, env_vars: Mapping[str, Any], config: Self.__SourceConfig
+    ) -> tuple[Any, str, bool]:
         """
-        Extracts field info. This info is used to get the value of field from environment variables.
-
-        It returns a list of tuples, each tuple contains:
-            * field_key: The key of field that has to be used in model creation.
-            * env_name: The environment variable name of the field.
-            * value_is_complex: A flag to determine whether the value from environment variable
-              is complex and has to be parsed.
+        Gets the value for field from environment variables and a flag to determine whether value is complex.
 
         Args:
-            field (FieldInfo): The field.
-            field_name (str): The field name.
+            field: The field.
+            field_name: The field name.
 
         Returns:
-            list[tuple[str, str, bool]]: List of tuples, each tuple contains field_key, env_name, and value_is_complex.
+            A tuple contains the key, value if the file exists otherwise `None`, and
+                a flag to determine whether value is complex.
         """
-        field_info: list[tuple[str, str, bool]] = []
-        if isinstance(field.validation_alias, (AliasChoices, AliasPath)):
-            v_alias: str | list[str | int] | list[list[str | int]] | None = field.validation_alias.convert_to_aliases()
-        else:
-            v_alias = field.validation_alias
 
-        if v_alias:
-            if isinstance(v_alias, list):  # AliasChoices, AliasPath
-                for alias in v_alias:
-                    if isinstance(alias, str):  # AliasPath
-                        field_info.append((alias, self._apply_case_sensitive(alias), True if len(alias) > 1 else False))
-                    elif isinstance(alias, list):  # AliasChoices
-                        first_arg = cast(str, alias[0])  # first item of an AliasChoices must be a str
-                        field_info.append(
-                            (first_arg, self._apply_case_sensitive(first_arg), True if len(alias) > 1 else False)
-                        )
-            else:  # string validation alias
-                field_info.append((v_alias, self._apply_case_sensitive(v_alias), False))
-        else:
-            field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), False))
+        env_val: str | None = None
+        for field_key, env_name, value_is_complex in cls._extract_field_info(field, field_name, config):
+            env_val = env_vars.get(env_name)
+            if env_val is not None:
+                break
 
-        return field_info
+        return env_val, field_key, value_is_complex
 
-    def _replace_field_names_case_insensitively(self, field: FieldInfo, field_values: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def _replace_field_names_case_insensitively(cls, field: FieldInfo, field_values: dict[str, Any]) -> dict[str, Any]:
         """
         Replace field names in values dict by looking in models fields insensitively.
 
@@ -230,40 +268,87 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                 continue
 
             if lenient_issubclass(sub_model_field.annotation, BaseModel) and isinstance(value, dict):
-                values[sub_model_field_name] = self._replace_field_names_case_insensitively(sub_model_field, value)
+                values[sub_model_field_name] = cls._replace_field_names_case_insensitively(sub_model_field, value)
             else:
                 values[sub_model_field_name] = value
 
         return values
 
+    @classmethod
+    def _extract_field_info(
+        cls, field: FieldInfo, field_name: str, config: Self.__SourceConfig
+    ) -> list[tuple[Any, str, bool]]:
+        """
+        Extracts field info. This info is used to get the value of field from environment variables.
+
+        It returns a list of tuples, each tuple contains:
+            * field_key: The key of field that has to be used in model creation.
+            * env_name: The environment variable name of the field.
+            * value_is_complex: A flag to determine whether the value from environment variable
+              is complex and has to be parsed.
+
+        Args:
+            field (FieldInfo): The field.
+            field_name (str): The field name.
+
+        Returns:
+            list[tuple[str, str, bool]]: List of tuples, each tuple contains field_key, env_name, and value_is_complex.
+        """
+        field_info: list[tuple[str, str, bool]] = []
+        if isinstance(field.validation_alias, (AliasChoices, AliasPath)):
+            v_alias: str | list[str | int] | list[list[str | int]] | None = field.validation_alias.convert_to_aliases()
+        else:
+            v_alias = field.validation_alias
+
+        if v_alias:
+            if isinstance(v_alias, list):  # AliasChoices, AliasPath
+                for alias in v_alias:
+                    if isinstance(alias, str):  # AliasPath
+                        field_info.append(
+                            (alias, cls._apply_case_sensitive(alias, config), True if len(alias) > 1 else False)
+                        )
+                    elif isinstance(alias, list):  # AliasChoices
+                        first_arg = cast(str, alias[0])  # first item of an AliasChoices must be a str
+                        field_info.append(
+                            (first_arg, cls._apply_case_sensitive(first_arg, config), True if len(alias) > 1 else False)
+                        )
+            else:  # string validation alias
+                field_info.append((v_alias, cls._apply_case_sensitive(v_alias, config), False))
+        else:
+            field_info.append((field_name, cls._apply_case_sensitive(config["env_prefix"] + field_name, config), False))
+
+        return field_info
+
+    def field_is_complex(self, field: FieldInfo) -> bool:
+        return self._field_is_complex(field)
+
+    @classmethod
+    def _field_is_complex(cls, field: FieldInfo) -> bool:
+        """
+        Checks whether a field is complex, in which case it will attempt to be parsed as JSON.
+
+        Args:
+            field: The field.
+
+        Returns:
+            Whether the field is complex.
+        """
+        return _annotation_is_complex(field.annotation, field.metadata)
+
+    @staticmethod
+    def _apply_case_sensitive(value: str, config: Self.__SourceConfig) -> str:
+        return value.lower() if not config["case_sensitive"] else value
+
+    def decode_complex_value(self, field_name: str, field: FieldInfo, value: Any) -> Any:
+        return self._decode_complex_value(field_name, field, value)
+
+    @classmethod
+    def _decode_complex_value(cls, field_name: str, field: FieldInfo, value: Any) -> Any:
+        return json.loads(value)
+
     def __call__(self) -> dict[str, Any]:
-        data: dict[str, Any] = {}
-
-        for field_name, field in self.settings_cls.model_fields.items():
-            try:
-                field_value, field_key, value_is_complex = self.get_field_value(field, field_name)
-            except Exception as e:
-                raise SettingsError(
-                    f'error getting value for field "{field_name}" from source "{self.__class__.__name__}"'
-                ) from e
-
-            try:
-                field_value = self.prepare_field_value(field_name, field, field_value, value_is_complex)
-            except ValueError as e:
-                raise SettingsError(
-                    f'error parsing value for field "{field_name}" from source "{self.__class__.__name__}"'
-                ) from e
-
-            if field_value is not None:
-                if (
-                    not self.case_sensitive
-                    and lenient_issubclass(field.annotation, BaseModel)
-                    and isinstance(field_value, dict)
-                ):
-                    data[field_key] = self._replace_field_names_case_insensitively(field, field_value)
-                else:
-                    data[field_key] = field_value
-
+        model_fields = self.settings_cls.model_fields
+        data: dict[str, Any] = self.read_model_fields(model_fields, self.load_env_vars(), self.source_config)
         return data
 
 
@@ -271,6 +356,11 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
     """
     Source class for loading settings values from secret files.
     """
+
+    class __SourceConfig(ConfigDict):
+        secrets_dir: str | Path | None
+        case_sensitive: bool
+        env_prefix: str
 
     def __init__(
         self,
@@ -280,47 +370,51 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
         env_prefix: str | None = None,
     ) -> None:
         super().__init__(settings_cls, case_sensitive, env_prefix)
-        self.secrets_dir = secrets_dir if secrets_dir is not None else self.config.get('secrets_dir')
+        self.source_config = self.__init_source_config(
+            secrets_dir=secrets_dir, case_sensitive=case_sensitive, env_prefix=env_prefix
+        )
+        self.__env_vars_cache: Any = None
+        self.env_vars = self.__load_env_vars()
 
-    def __call__(self) -> dict[str, Any]:
-        """
-        Build fields from "secrets" files.
-        """
-        secrets: dict[str, str | None] = {}
+    def __init_source_config(
+        self,
+        *,
+        secrets_dir: str | Path | None = None,
+        case_sensitive: bool | None = None,
+        env_prefix: str | None = None,
+    ) -> Self.__SourceConfig:
+        secrets_dir = secrets_dir if secrets_dir is not None else self.config.get('secrets_dir')
+        case_sensitive = (
+            case_sensitive if case_sensitive is not None else self.source_config.get("case_sensitive", False)
+        )
+        env_prefix = env_prefix if env_prefix is not None else self.source_config.get("env_prefix", "")
+        return self.__SourceConfig(secrets_dir=secrets_dir, env_prefix=env_prefix, case_sensitive=case_sensitive)
 
-        if self.secrets_dir is None:
-            return secrets
+    def load_env_vars(self) -> dict[str, Path]:
+        return self.__load_env_vars()
 
-        self.secrets_path = Path(self.secrets_dir).expanduser()
-
-        if not self.secrets_path.exists():
-            warnings.warn(f'directory "{self.secrets_path}" does not exist')
-            return secrets
-
-        if not self.secrets_path.is_dir():
-            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type_label(self.secrets_path)}')
-
-        return super().__call__()
-
-    @classmethod
-    def find_case_path(cls, dir_path: Path, file_name: str, case_sensitive: bool) -> Path | None:
-        """
-        Find a file within path's directory matching filename, optionally ignoring case.
-
-        Args:
-            dir_path: Directory path.
-            file_name: File name.
-            case_sensitive: Whether to search for file name case sensitively.
-
-        Returns:
-            Whether file path or `None` if file does not exist in directory.
-        """
-        for f in dir_path.iterdir():
-            if f.name == file_name:
-                return f
-            elif not case_sensitive and f.name.lower() == file_name.lower():
-                return f
-        return None
+    def __load_env_vars(self) -> dict[str, Path]:
+        if self.__env_vars_cache is not None:
+            return self.__env_vars_cache
+        if self.source_config["secrets_dir"] is None:
+            self.__env_vars_cache = {}
+            return {}
+        secrets_path = Path(self.source_config["secrets_dir"]).expanduser()
+        if not secrets_path.exists():
+            warnings.warn(f'directory "{secrets_path}" does not exist')
+            self.__env_vars_cache = {}
+            return {}
+        if not secrets_path.is_dir():
+            raise SettingsError(f'secrets_dir must reference a directory, not a {path_type_label(secrets_path)}')
+        res: dict[str, Path] = {}
+        if self.source_config["secrets_dir"] is None:
+            self.__env_vars_cache = {}
+            return res
+        for f in secrets_path.iterdir():
+            fname = self._apply_case_sensitive(f.name, self.source_config)
+            res[fname] = f
+        self.__env_vars_cache = res
+        return res
 
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         """
@@ -335,52 +429,17 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
                 a flag to determine whether value is complex.
         """
 
-        for field_key, env_name, value_is_complex in self._extract_field_info(field, field_name):
-            path = self.find_case_path(self.secrets_path, env_name, self.case_sensitive)
-            if not path:
-                # path does not exist, we currently don't return a warning for this
-                continue
-
-            if path.is_file():
-                return path.read_text().strip(), field_key, value_is_complex
-            else:
-                warnings.warn(
-                    f'attempted to load secret file "{path}" but found a {path_type_label(path)} instead.',
-                    stacklevel=4,
-                )
-
-        return None, field_key, value_is_complex
-
-    def __repr__(self) -> str:
-        return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
-
-
-class EnvSettingsSource(PydanticBaseEnvSettingsSource):
-    """
-    Source class for loading settings values from environment variables.
-    """
-
-    def __init__(
-        self,
-        settings_cls: type[BaseSettings],
-        case_sensitive: bool | None = None,
-        env_prefix: str | None = None,
-        env_nested_delimiter: str | None = None,
-    ) -> None:
-        super().__init__(settings_cls, case_sensitive, env_prefix)
-        self.env_nested_delimiter = (
-            env_nested_delimiter if env_nested_delimiter is not None else self.config.get('env_nested_delimiter')
+        path, field_key, value_is_complex = self.get_field_value_from_env_vars(
+            field, field_name, self.env_vars, self.source_config
         )
-        self.env_prefix_len = len(self.env_prefix)
+        if path is None:
+            return None, field_key, value_is_complex
+        return path.read_text().strip(), field_key, value_is_complex
 
-        self.env_vars = self._load_env_vars()
-
-    def _load_env_vars(self) -> Mapping[str, str | None]:
-        if self.case_sensitive:
-            return os.environ
-        return {k.lower(): v for k, v in os.environ.items()}
-
-    def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+    @classmethod
+    def get_field_value_from_env_vars(
+        cls, field: FieldInfo, field_name: str, env_vars: Mapping[str, Path], config: Self.__SourceConfig
+    ) -> tuple[Any, str, bool]:
         """
         Gets the value for field from environment variables and a flag to determine whether value is complex.
 
@@ -393,69 +452,203 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                 a flag to determine whether value is complex.
         """
 
-        env_val: str | None = None
-        for field_key, env_name, value_is_complex in self._extract_field_info(field, field_name):
-            env_val = self.env_vars.get(env_name)
-            if env_val is not None:
-                break
+        env_val: Path | None = None
+        for field_key, env_name, value_is_complex in cls._extract_field_info(field, field_name, config):
+            env_val = env_vars.get(env_name)
+            if env_val is None:
+                continue
+            if env_val.is_file():
+                payload = env_val.read_text().strip()
+                return payload, field_key, value_is_complex
+            else:
+                warnings.warn(
+                    f'attempted to load secret file "{env_val}" but found a {path_type_label(env_val)} instead.',
+                    stacklevel=4,
+                )
 
-        return env_val, field_key, value_is_complex
+        return None, field_key, value_is_complex
 
     def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
-        """
-        Prepare value for the field.
+        self.prepare_field_value_from_env_vars(
+            field_name,
+            field,
+            value,
+            value_is_complex,
+            self.env_vars,
+            self.source_config,
+        )
 
-        * Extract value for nested field.
-        * Deserialize value to python object for complex field.
+    @classmethod
+    def prepare_field_value_from_env_vars(
+        cls,
+        field_name: str,
+        field: FieldInfo,
+        value: str | None,
+        value_is_complex: bool,
+        env_vars: Mapping[str, Path | None],
+        config: Self.__SourceConfig,
+    ) -> Any:
+        if value is None:
+            return value
+        if cls._field_is_complex(field) or value_is_complex:
+            return cls._decode_complex_value(field_name, field, value)
+        return value
 
-        Args:
-            field: The field.
-            field_name: The field name.
+    def __repr__(self) -> str:
+        return f'SecretsSettingsSource(secrets_dir={self.source_config["secrets_dir"]!r})'
 
-        Returns:
-            A tuple contains prepared value for the field.
 
-        Raises:
-            ValuesError: When There is an error in deserializing value for complex field.
-        """
-        is_complex, allow_parse_failure = self._field_is_complex(field)
+class EnvSettingsSource(PydanticBaseEnvSettingsSource):
+    """
+    Source class for loading settings values from environment variables.
+    """
+
+    class __SourceConfig(ConfigDict):
+        case_sensitive: bool
+        env_prefix: str
+        env_nested_delimiter: str | None
+
+    def __init__(
+        self,
+        settings_cls: type[BaseSettings],
+        case_sensitive: bool | None = None,
+        env_prefix: str | None = None,
+        env_nested_delimiter: str | None = None,
+    ) -> None:
+        super().__init__(settings_cls, case_sensitive, env_prefix)
+        self.source_config = self.__init_source_config(
+            case_sensitive=case_sensitive, env_prefix=env_prefix, env_nested_delimiter=env_nested_delimiter
+        )
+        self.__env_vars_cache: Any = None
+        self.env_vars = self.__load_env_vars()
+
+    def __init_source_config(
+        self, *, case_sensitive: bool | None = None, env_prefix: str | None = None, env_nested_delimiter: str | None
+    ) -> Self.__SourceConfig:
+        env_nested_delimiter = (
+            env_nested_delimiter if env_nested_delimiter is not None else self.config.get('env_nested_delimiter')
+        )
+        case_sensitive = (
+            case_sensitive if case_sensitive is not None else self.source_config.get('case_sensitive', False)
+        )
+        env_prefix = env_prefix if env_prefix is not None else self.source_config.get('env_prefix', '')
+        return self.__SourceConfig(
+            env_nested_delimiter=env_nested_delimiter, env_prefix=env_prefix, case_sensitive=case_sensitive
+        )
+
+    def load_env_vars(self) -> dict[str, str | None]:
+        return self.__load_env_vars()
+
+    def __load_env_vars(self) -> dict[str, str | None]:
+        if self.__env_vars_cache is not None:
+            return self.__env_vars_cache
+        res: dict[str, str | None] = {}
+        res = {self._apply_case_sensitive(k, self.source_config): v for k, v in os.environ.items()}
+        self.__env_vars_cache = res
+        return res
+
+    def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+        return self.get_field_value_from_env_vars(field, field_name, self.env_vars, self.source_config)
+
+    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
+        self.prepare_field_value_from_env_vars(
+            field_name,
+            field,
+            value,
+            value_is_complex,
+            self.env_vars,
+            self.source_config,
+        )
+
+    @classmethod
+    def prepare_field_value_from_env_vars(
+        cls,
+        field_name: str,
+        field: FieldInfo,
+        value: Any,
+        value_is_complex: bool,
+        env_vars: Mapping[str, str | Any],
+        config: Self.__SourceConfig,
+    ) -> Any:
+        is_complex, allow_parse_failure = cls._field_is_complex_with_failflag(field)
         if is_complex or value_is_complex:
             if value is None:
                 # field is complex but no value found so far, try explode_env_vars
-                env_val_built = self.explode_env_vars(field_name, field, self.env_vars)
+                env_val_built = cls.explode_env_vars(field_name, field, env_vars, config)
                 if env_val_built:
                     return env_val_built
             else:
                 # field is complex and there's a value, decode that as JSON, then add explode_env_vars
                 try:
-                    value = self.decode_complex_value(field_name, field, value)
+                    value = cls._decode_complex_value(field_name, field, value)
                 except ValueError as e:
                     if not allow_parse_failure:
                         raise e
 
                 if isinstance(value, dict):
-                    return deep_update(value, self.explode_env_vars(field_name, field, self.env_vars))
+                    return deep_update(
+                        value,
+                        cls.explode_env_vars(field_name, field, env_vars, config),
+                    )
                 else:
                     return value
         elif value is not None:
             # simplest case, field is not complex, we only need to add the value if it was found
             return value
 
-    def _union_is_complex(self, annotation: type[Any] | None, metadata: list[Any]) -> bool:
-        return any(_annotation_is_complex(arg, metadata) for arg in get_args(annotation))
-
-    def _field_is_complex(self, field: FieldInfo) -> tuple[bool, bool]:
+    @classmethod
+    def explode_env_vars(
+        cls,
+        field_name: str,
+        field: FieldInfo,
+        env_vars: Mapping[str, str | None],
+        config: Self.__SourceConfig,
+    ) -> dict[str, Any]:
         """
-        Find out if a field is complex, and if so whether JSON errors should be ignored
-        """
-        if self.field_is_complex(field):
-            allow_parse_failure = False
-        elif origin_is_union(get_origin(field.annotation)) and self._union_is_complex(field.annotation, field.metadata):
-            allow_parse_failure = True
-        else:
-            return False, False
+        Process env_vars and extract the values of keys containing env_nested_delimiter into nested dictionaries.
 
-        return True, allow_parse_failure
+        This is applied to a single field, hence filtering by env_var prefix.
+
+        Args:
+            field_name: The field name.
+            field: The field.
+            env_vars: Environment variables.
+
+        Returns:
+            A dictionaty contains extracted values from nested env values.
+        """
+        prefixes = [
+            f'{env_name}{config["env_nested_delimiter"]}'
+            for _, env_name, _ in cls._extract_field_info(field, field_name, config)
+        ]
+        result: dict[str, Any] = {}
+        for env_name, env_val in env_vars.items():
+            if not any(env_name.startswith(prefix) for prefix in prefixes):
+                continue
+            # we remove the prefix before splitting in case the prefix has characters in common with the delimiter
+            env_name_without_prefix = env_name[len(config["env_prefix"]) :]
+            _, *keys, last_key = env_name_without_prefix.split(config["env_nested_delimiter"])
+            env_var = result
+            target_field: FieldInfo | None = field
+            for key in keys:
+                target_field = cls.next_field(target_field, key)
+                env_var = env_var.setdefault(key, {})
+
+            # get proper field with last_key
+            target_field = cls.next_field(target_field, last_key)
+
+            # check if env_val maps to a complex field and if so, parse the env_val
+            if target_field and env_val:
+                is_complex, allow_json_failure = cls._field_is_complex_with_failflag(target_field)
+                if is_complex:
+                    try:
+                        env_val = cls._decode_complex_value(last_key, target_field, env_val)
+                    except ValueError as e:
+                        if not allow_json_failure:
+                            raise e
+            env_var[last_key] = env_val
+
+        return result
 
     @staticmethod
     def next_field(field: FieldInfo | None, key: str) -> FieldInfo | None:
@@ -495,56 +688,28 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
 
         return None
 
-    def explode_env_vars(self, field_name: str, field: FieldInfo, env_vars: Mapping[str, str | None]) -> dict[str, Any]:
+    @classmethod
+    def _union_is_complex(cls, annotation: type[Any] | None, metadata: list[Any]) -> bool:
+        return any(_annotation_is_complex(arg, metadata) for arg in get_args(annotation))
+
+    @classmethod
+    def _field_is_complex_with_failflag(cls, field: FieldInfo) -> tuple[bool, bool]:
         """
-        Process env_vars and extract the values of keys containing env_nested_delimiter into nested dictionaries.
-
-        This is applied to a single field, hence filtering by env_var prefix.
-
-        Args:
-            field_name: The field name.
-            field: The field.
-            env_vars: Environment variables.
-
-        Returns:
-            A dictionaty contains extracted values from nested env values.
+        Find out if a field is complex, and if so whether JSON errors should be ignored
         """
-        prefixes = [
-            f'{env_name}{self.env_nested_delimiter}' for _, env_name, _ in self._extract_field_info(field, field_name)
-        ]
-        result: dict[str, Any] = {}
-        for env_name, env_val in env_vars.items():
-            if not any(env_name.startswith(prefix) for prefix in prefixes):
-                continue
-            # we remove the prefix before splitting in case the prefix has characters in common with the delimiter
-            env_name_without_prefix = env_name[self.env_prefix_len :]
-            _, *keys, last_key = env_name_without_prefix.split(self.env_nested_delimiter)
-            env_var = result
-            target_field: FieldInfo | None = field
-            for key in keys:
-                target_field = self.next_field(target_field, key)
-                env_var = env_var.setdefault(key, {})
+        if cls._field_is_complex(field):
+            allow_parse_failure = False
+        elif origin_is_union(get_origin(field.annotation)) and cls._union_is_complex(field.annotation, field.metadata):
+            allow_parse_failure = True
+        else:
+            return False, False
 
-            # get proper field with last_key
-            target_field = self.next_field(target_field, last_key)
-
-            # check if env_val maps to a complex field and if so, parse the env_val
-            if target_field and env_val:
-                is_complex, allow_json_failure = self._field_is_complex(target_field)
-                if is_complex:
-                    try:
-                        env_val = self.decode_complex_value(last_key, target_field, env_val)
-                    except ValueError as e:
-                        if not allow_json_failure:
-                            raise e
-            env_var[last_key] = env_val
-
-        return result
+        return True, allow_parse_failure
 
     def __repr__(self) -> str:
         return (
-            f'EnvSettingsSource(env_nested_delimiter={self.env_nested_delimiter!r}, '
-            f'env_prefix_len={self.env_prefix_len!r})'
+            f'EnvSettingsSource(env_nested_delimiter={self.source_config["env_nested_delimiter"]!r}, '
+            f'env_prefix_len={len(self.source_config["env_prefix"])!r})'
         )
 
 
@@ -552,6 +717,13 @@ class DotEnvSettingsSource(EnvSettingsSource):
     """
     Source class for loading settings values from env files.
     """
+
+    class __SourceConfig(ConfigDict):
+        case_sensitive: bool
+        env_prefix: str
+        env_nested_delimiter: str | None
+        env_file: DotenvType | None
+        env_file_encoding: str | None
 
     def __init__(
         self,
@@ -561,18 +733,59 @@ class DotEnvSettingsSource(EnvSettingsSource):
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,
         env_nested_delimiter: str | None = None,
+        extra: Literal["allow", "ignore", "forbid"] | None = None,
     ) -> None:
-        self.env_file = env_file if env_file != ENV_FILE_SENTINEL else settings_cls.model_config.get('env_file')
-        self.env_file_encoding = (
-            env_file_encoding if env_file_encoding is not None else settings_cls.model_config.get('env_file_encoding')
-        )
         super().__init__(settings_cls, case_sensitive, env_prefix, env_nested_delimiter)
+        self.source_config = self.__init_source_config(
+            case_sensitive=case_sensitive,
+            env_prefix=env_prefix,
+            env_nested_delimiter=env_nested_delimiter,
+            env_file=env_file,
+            env_file_encoding=env_file_encoding,
+            extra=extra,
+        )
+        self.__env_vars_cache = None
+        self.env_vars = self.load_env_vars()
 
-    def _load_env_vars(self) -> Mapping[str, str | None]:
-        return self._read_env_files(self.case_sensitive)
+    def __init_source_config(
+        self,
+        *,
+        case_sensitive: bool | None = None,
+        env_prefix: str | None = None,
+        env_nested_delimiter: str | None,
+        env_file: DotenvType | None,
+        env_file_encoding: str | None,
+        extra: Literal["allow", "ignore", "forbid"] | None,
+    ) -> Self.__SourceConfig:
+        env_nested_delimiter = (
+            env_nested_delimiter if env_nested_delimiter is not None else self.source_config["env_nested_delimiter"]
+        )
+        case_sensitive = case_sensitive if case_sensitive is not None else self.source_config["case_sensitive"]
+        env_prefix = env_prefix if env_prefix is not None else self.source_config["env_prefix"]
+        env_file = env_file if env_file != ENV_FILE_SENTINEL else self.config.get('env_file')
+        extra = extra if extra is not None else self.config.get('extra', 'forbid')
+        env_file_encoding = env_file_encoding if env_file_encoding is not None else self.config.get('env_file_encoding')
+        return self.__SourceConfig(
+            env_nested_delimiter=env_nested_delimiter,
+            env_prefix=env_prefix,
+            case_sensitive=case_sensitive,
+            env_file=env_file,
+            env_file_encoding=env_file_encoding,
+            extra=extra,
+        )
 
-    def _read_env_files(self, case_sensitive: bool) -> Mapping[str, str | None]:
-        env_files = self.env_file
+    def load_env_vars(self) -> dict[str, str | None]:
+        return self.__load_env_vars()
+
+    def __load_env_vars(self) -> dict[str, str | None]:
+        if self.__env_vars_cache is not None:
+            return self.__env_vars_cache
+        res = self._read_env_files(self.source_config["case_sensitive"])
+        self.__env_vars_cache = res
+        return res
+
+    def _read_env_files(self, case_sensitive: bool) -> dict[str, str | None]:
+        env_files = self.source_config["env_file"]
         if env_files is None:
             return {}
 
@@ -584,7 +797,9 @@ class DotEnvSettingsSource(EnvSettingsSource):
             env_path = Path(env_file).expanduser()
             if env_path.is_file():
                 dotenv_vars.update(
-                    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=case_sensitive)
+                    read_env_file(
+                        env_path, encoding=self.source_config["env_file_encoding"], case_sensitive=case_sensitive
+                    )
                 )
 
         return dotenv_vars
@@ -593,15 +808,18 @@ class DotEnvSettingsSource(EnvSettingsSource):
         data: dict[str, Any] = super().__call__()
 
         data_lower_keys: list[str] = []
-        if not self.case_sensitive:
+        if not self.source_config["case_sensitive"]:
             data_lower_keys = [x.lower() for x in data.keys()]
+
+        if self.source_config["extra"] == "ignore":
+            return data
 
         # As `extra` config is allowed in dotenv settings source, We have to
         # update data with extra env variabels from dotenv file.
         for env_name, env_value in self.env_vars.items():
-            if env_name.startswith(self.env_prefix) and env_value is not None:
-                env_name_without_prefix = env_name[self.env_prefix_len :]
-                first_key, *_ = env_name_without_prefix.split(self.env_nested_delimiter)
+            if env_name.startswith(self.source_config["env_prefix"]) and env_value is not None:
+                env_name_without_prefix = env_name[len(self.source_config["env_prefix"]) :]
+                first_key, *_ = env_name_without_prefix.split(self.source_config["env_nested_delimiter"])
 
                 if (data_lower_keys and first_key not in data_lower_keys) or (
                     not data_lower_keys and first_key not in data
@@ -612,8 +830,8 @@ class DotEnvSettingsSource(EnvSettingsSource):
 
     def __repr__(self) -> str:
         return (
-            f'DotEnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
-            f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r})'
+            f'DotEnvSettingsSource(env_file={self.source_config["env_file"]!r}, env_file_encoding={self.source_config["env_file_encoding"]!r}, '
+            f'env_nested_delimiter={self.source_config["env_nested_delimiter"]!r}, env_prefix_len={len(self.source_config["env_prefix"])!r})'
         )
 
 


### PR DESCRIPTION
Hi all! Thank you for a great project :) Its irreplaceability was motivating me all the way to opening this PR. I understand that my explanation may be hard to digest, please ask questions and make comments, I'm really motivated to make this change come true :)

Big goal: be able to nest settings while preserving encapsulation of the nested setting classes. In other words, to be able to re-use the settings file of my script when I plug the script to a bigger project. The only change - env_prefix.

Motivation: nested env variables were included a bit of ad-hoc, making parent Settings class majorly responsible for parsing nested fields. I understand, a part of the reason is that parent class is instantiated, while nested classes are not, but the extraction logic was tightly bound to instance methods/variables.

Change: make extraction logic (i.e. `__call__` method) a classmethod `read_model_fields`. Example

```
res = {}
for field in settings.fields:
    env_prefix = env_prefix_from_field(field)
    res[field.name] = field.annotation.model.read_fields(env_prefix=env_prefix)
```

This naturally would allow using a python script with PydanticSettings, and then seamlessly plug it into a bigger code without modification of the script and its config themselves (even if the script used env_prefix, or included some other nested settings, we dont care anymore).

---

In this PR I tried to make a first step towards the big goal. It is still quite large, that's why I'm explaining the motivation as best as I can.

Some things I though of:

1. PydanticBaseSettingsSource - I left unchanged, although most of the methods became `@classmethods` in the child sources.
2. I worked mainly inside  `PydanticBaseEnvSettingsSource` and children.
3. `PydanticBaseEnvSettingsSource` supports `read_model_fields` which is a classmethod and its output is equivalent to output of `__call__` for each child source. Most of the changes in the code were caused to make this possible.
4. New methods are equivalents of the corresponding instance methods
    * prepare_field_value_from_env_vars
    * get_field_value_from_env_vars
    now to create a custom source, one has to implement these for BaseEnvSource. Instance methods are not used for extraction there.
5. I introduced SourceConfig for each source, to be able to pass the config to classmethods. Now it is a bit odd mixture of private classes / methods which could possibly be moved outside.
6. I preserved `load_env_vars` instance methods, and I use them in the root settings class, which is instantiated, to read in advance all the variables (either from secret dir, dotenv or env vars). Then the goal is to pass subsets of the "loaded env vars" when extraction of variables from the nested fields is needed.

---

Nice side-effects:

* Now all EnvSettings support aliases


Thank you very much for your attention!