### PR TITLE
resolve nested code fence line numbering

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -482,7 +482,6 @@ Once you have your secret files, *pydantic* supports loading it in two ways:
        database_password: str
    ````
 2. Instantiating the `BaseSettings` derived class with the `_secrets_dir` keyword argument:
-
    ````
    settings = Settings(_secrets_dir='/var/run')
    ````


### PR DESCRIPTION
# Summary of changes

## [index.md](https://github.com/pydantic/pydantic-settings/blob/e529615c3b3d8fe98f42a9e6a1ce3891a0aba3a4/docs/index.md)

Correct line numbering by adding by adding one backquote (min four) to code fences **_and_** indent code fences with _three_ spaces 
1. Resolve rendering of [pydantic/pydantic/docs/concepts/pydantic_settings.md](https://github.com/pydantic/pydantic/blob/9c91f856d8710a4f5e8cf34a7662b9324020db1e/docs/concepts/pydantic_settings.md):
> <img width="785" alt="pydantic-external-markdown" src="https://github.com/pydantic/pydantic/assets/1088664/d65de90d-7c1e-41f0-b0dd-1afde7c85884">
2. Intent nested code fences using **three** spaces
  
    Fixes list items numbering: _fenced code blocks_, within item lists:
    <img width="95" alt="pydantic-item-numbering" src="https://github.com/pydantic/pydantic/assets/1088664/77afd811-840c-4549-81b6-d34af3d507ba">

3. ~~Remove~~ [renumbered] ~~duplicate~~ line:
> <img width="708" alt="pydantic-dup-line" src="https://github.com/pydantic/pydantic/assets/1088664/36c0cdca-2867-4312-8fd7-7cf5f6cc052d">

4. Remove newlines between code blocks and numbered list items to fix markdown number sequences.
