### PR TITLE
feat: ignore empty env vars

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -253,7 +253,10 @@ except ValidationError as e:
 
 ## Parsing environment variable values
 
-By default environment variables are parsed verbatim, including if the value is empty. You can choose to ignore empty environment variables by setting the `env_ignore_empty` config setting to `True`. This can be useful if you would prefer to use the default value rather than an empty value in the environment.
+By default environment variables are parsed verbatim, including if the value is empty. You can choose to 
+ignore empty environment variables by setting the `env_ignore_empty` config setting to `True`. This can be 
+useful if you would prefer to use the default value for a field rather than an empty value from the 
+environment.
 
 For most simple field types (such as `int`, `float`, `str`, etc.), the environment variable value is parsed
 the same way it would be if passed directly to the initialiser (as a string).

--- a/docs/index.md
+++ b/docs/index.md
@@ -253,6 +253,8 @@ except ValidationError as e:
 
 ## Parsing environment variable values
 
+By default environment variables are parsed verbatim, including if the value is empty. You can choose to ignore empty environment variables by setting the `env_ignore_empty` config setting to `True`. This can be useful if you would prefer to use the default value rather than an empty value in the environment.
+
 For most simple field types (such as `int`, `float`, `str`, etc.), the environment variable value is parsed
 the same way it would be if passed directly to the initialiser (as a string).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -253,9 +253,9 @@ except ValidationError as e:
 
 ## Parsing environment variable values
 
-By default environment variables are parsed verbatim, including if the value is empty. You can choose to 
-ignore empty environment variables by setting the `env_ignore_empty` config setting to `True`. This can be 
-useful if you would prefer to use the default value for a field rather than an empty value from the 
+By default environment variables are parsed verbatim, including if the value is empty. You can choose to
+ignore empty environment variables by setting the `env_ignore_empty` config setting to `True`. This can be
+useful if you would prefer to use the default value for a field rather than an empty value from the
 environment.
 
 For most simple field types (such as `int`, `float`, `str`, etc.), the environment variable value is parsed

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -24,6 +24,7 @@ class SettingsConfigDict(ConfigDict, total=False):
     env_prefix: str
     env_file: DotenvType | None
     env_file_encoding: str | None
+    env_ignore_empty: bool
     env_nested_delimiter: str | None
     secrets_dir: str | Path | None
 
@@ -53,6 +54,7 @@ class BaseSettings(BaseModel):
             means that the value from `model_config['env_file']` should be used. You can also pass
             `None` to indicate that environment variables should not be loaded from an env file.
         _env_file_encoding: The env file encoding, e.g. `'latin-1'`. Defaults to `None`.
+        _env_ignore_empty: Ignore environment variables where the value is an empty string. Default to `False`.
         _env_nested_delimiter: The nested env values delimiter. Defaults to `None`.
         _secrets_dir: The secret files directory. Defaults to `None`.
     """
@@ -63,6 +65,7 @@ class BaseSettings(BaseModel):
         _env_prefix: str | None = None,
         _env_file: DotenvType | None = ENV_FILE_SENTINEL,
         _env_file_encoding: str | None = None,
+        _env_ignore_empty: bool | None = None,
         _env_nested_delimiter: str | None = None,
         _secrets_dir: str | Path | None = None,
         **values: Any,
@@ -75,6 +78,7 @@ class BaseSettings(BaseModel):
                 _env_prefix=_env_prefix,
                 _env_file=_env_file,
                 _env_file_encoding=_env_file_encoding,
+                _env_ignore_empty=_env_ignore_empty,
                 _env_nested_delimiter=_env_nested_delimiter,
                 _secrets_dir=_secrets_dir,
             )
@@ -111,6 +115,7 @@ class BaseSettings(BaseModel):
         _env_prefix: str | None = None,
         _env_file: DotenvType | None = None,
         _env_file_encoding: str | None = None,
+        _env_ignore_empty: bool | None = None,
         _env_nested_delimiter: str | None = None,
         _secrets_dir: str | Path | None = None,
     ) -> dict[str, Any]:
@@ -120,6 +125,9 @@ class BaseSettings(BaseModel):
         env_file = _env_file if _env_file != ENV_FILE_SENTINEL else self.model_config.get('env_file')
         env_file_encoding = (
             _env_file_encoding if _env_file_encoding is not None else self.model_config.get('env_file_encoding')
+        )
+        env_ignore_empty = (
+            _env_ignore_empty if _env_ignore_empty is not None else self.model_config.get('env_ignore_empty')
         )
         env_nested_delimiter = (
             _env_nested_delimiter
@@ -135,6 +143,7 @@ class BaseSettings(BaseModel):
             case_sensitive=case_sensitive,
             env_prefix=env_prefix,
             env_nested_delimiter=env_nested_delimiter,
+            env_ignore_empty=env_ignore_empty,
         )
         dotenv_settings = DotEnvSettingsSource(
             self.__class__,
@@ -143,6 +152,7 @@ class BaseSettings(BaseModel):
             case_sensitive=case_sensitive,
             env_prefix=env_prefix,
             env_nested_delimiter=env_nested_delimiter,
+            env_ignore_empty=env_ignore_empty,
         )
 
         file_secret_settings = SecretsSettingsSource(
@@ -171,6 +181,7 @@ class BaseSettings(BaseModel):
         env_prefix='',
         env_file=None,
         env_file_encoding=None,
+        env_ignore_empty=False,
         env_nested_delimiter=None,
         secrets_dir=None,
         protected_namespaces=('model_', 'settings_'),

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -593,7 +593,12 @@ class DotEnvSettingsSource(EnvSettingsSource):
             env_path = Path(env_file).expanduser()
             if env_path.is_file():
                 dotenv_vars.update(
-                    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=self.case_sensitive, ignore_empty=self.env_ignore_empty)
+                    read_env_file(
+                        env_path, 
+                        encoding=self.env_file_encoding, 
+                        case_sensitive=self.case_sensitive, 
+                        ignore_empty=self.env_ignore_empty
+                    )
                 )
 
         return dotenv_vars

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -593,7 +593,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
             env_path = Path(env_file).expanduser()
             if env_path.is_file():
                 dotenv_vars.update(
-                    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=self.case_sensitive)
+                    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=self.case_sensitive, ignore_empty=self.env_ignore_empty)
                 )
 
         return dotenv_vars

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -129,10 +129,10 @@ class InitSettingsSource(PydanticBaseSettingsSource):
 
 class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
     def __init__(
-        self, 
-        settings_cls: type[BaseSettings], 
-        case_sensitive: bool | None = None, 
-        env_prefix: str | None = None, 
+        self,
+        settings_cls: type[BaseSettings],
+        case_sensitive: bool | None = None,
+        env_prefix: str | None = None,
         env_ignore_empty: bool | None = None,
     ) -> None:
         super().__init__(settings_cls)
@@ -594,10 +594,10 @@ class DotEnvSettingsSource(EnvSettingsSource):
             if env_path.is_file():
                 dotenv_vars.update(
                     read_env_file(
-                        env_path, 
-                        encoding=self.env_file_encoding, 
-                        case_sensitive=self.case_sensitive, 
-                        ignore_empty=self.env_ignore_empty
+                        env_path,
+                        encoding=self.env_file_encoding,
+                        case_sensitive=self.case_sensitive,
+                        ignore_empty=self.env_ignore_empty,
                     )
                 )
 
@@ -642,10 +642,10 @@ def parse_env_vars(
 
 
 def read_env_file(
-    file_path: Path, 
-    *, 
-    encoding: str | None = None, 
-    case_sensitive: bool = False, 
+    file_path: Path,
+    *,
+    encoding: str | None = None,
+    case_sensitive: bool = False,
     ignore_empty: bool = False,
 ) -> Mapping[str, str | None]:
     file_vars: dict[str, str | None] = dotenv_values(file_path, encoding=encoding or 'utf8')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -87,6 +87,30 @@ def test_ignore_empty_when_not_empty_uses_value(env):
     s = SettingWithIgnoreEmpty()
     assert s.apple == 'a'
 
+def test_ignore_empty_with_dotenv_when_empty_uses_default(tmp_path):
+    p = tmp_path / '.env'
+    p.write_text('a=')
+
+    class Settings(BaseSettings):
+        a: str = "default"
+
+        model_config = SettingsConfigDict(env_file=p, env_ignore_empty=True)
+
+    s = Settings()
+    assert s.a == "default"
+
+def test_ignore_empty_with_dotenv_when_not_empty_uses_value(tmp_path):
+    p = tmp_path / '.env'
+    p.write_text('a=b')
+
+    class Settings(BaseSettings):
+        a: str = "default"
+
+        model_config = SettingsConfigDict(env_file=p, env_ignore_empty=True)
+
+    s = Settings()
+    assert s.a == "b"
+
 def test_with_prefix(env):
     class Settings(BaseSettings):
         apple: str
@@ -867,7 +891,7 @@ def test_env_file_not_a_file(env):
     assert s.a == 'ignore non-file'
 
 
-def test_read_env_file_cast_sensitive(tmp_path):
+def test_read_env_file_case_sensitive(tmp_path):
     p = tmp_path / '.env'
     p.write_text('a="test"\nB=123')
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -47,7 +47,7 @@ class SimpleSettings(BaseSettings):
 
 
 class SettingWithIgnoreEmpty(BaseSettings):
-    apple: str = "default"
+    apple: str = 'default'
 
     model_config = SettingsConfigDict(env_ignore_empty=True)
 
@@ -82,34 +82,38 @@ def test_ignore_empty_when_empty_uses_default(env):
     s = SettingWithIgnoreEmpty()
     assert s.apple == 'default'
 
+
 def test_ignore_empty_when_not_empty_uses_value(env):
     env.set('apple', 'a')
     s = SettingWithIgnoreEmpty()
     assert s.apple == 'a'
+
 
 def test_ignore_empty_with_dotenv_when_empty_uses_default(tmp_path):
     p = tmp_path / '.env'
     p.write_text('a=')
 
     class Settings(BaseSettings):
-        a: str = "default"
+        a: str = 'default'
 
         model_config = SettingsConfigDict(env_file=p, env_ignore_empty=True)
 
     s = Settings()
-    assert s.a == "default"
+    assert s.a == 'default'
+
 
 def test_ignore_empty_with_dotenv_when_not_empty_uses_value(tmp_path):
     p = tmp_path / '.env'
     p.write_text('a=b')
 
     class Settings(BaseSettings):
-        a: str = "default"
+        a: str = 'default'
 
         model_config = SettingsConfigDict(env_file=p, env_ignore_empty=True)
 
     s = Settings()
-    assert s.a == "b"
+    assert s.a == 'b'
+
 
 def test_with_prefix(env):
     class Settings(BaseSettings):
@@ -1016,14 +1020,18 @@ def test_read_dotenv_vars(tmp_path):
     prod_env = tmp_path / '.env.prod'
     prod_env.write_text(test_prod_env_file)
 
-    source = DotEnvSettingsSource(BaseSettings(), env_file=[base_env, prod_env], env_file_encoding='utf8', case_sensitive=False)
+    source = DotEnvSettingsSource(
+        BaseSettings(), env_file=[base_env, prod_env], env_file_encoding='utf8', case_sensitive=False
+    )
     assert source._read_env_files() == {
         'debug_mode': 'false',
         'host': 'https://example.com/services',
         'port': '8000',
     }
 
-    source = DotEnvSettingsSource(BaseSettings(), env_file=[base_env, prod_env], env_file_encoding='utf8', case_sensitive=True)
+    source = DotEnvSettingsSource(
+        BaseSettings(), env_file=[base_env, prod_env], env_file_encoding='utf8', case_sensitive=True
+    )
     assert source._read_env_files() == {
         'debug_mode': 'false',
         'host': 'https://example.com/services',
@@ -1033,8 +1041,10 @@ def test_read_dotenv_vars(tmp_path):
 
 def test_read_dotenv_vars_when_env_file_is_none():
     assert (
-        DotEnvSettingsSource(BaseSettings(), env_file=None, env_file_encoding=None, case_sensitive=False)
-            ._read_env_files() == {}
+        DotEnvSettingsSource(
+            BaseSettings(), env_file=None, env_file_encoding=None, case_sensitive=False
+        )._read_env_files()
+        == {}
     )
 
 


### PR DESCRIPTION
As suggested at https://github.com/pydantic/pydantic/discussions/3796, we often have environment variables set but empty, and would prefer to use the default value for the field instead of raising an exception.

This adds the ability to ignore empty environment variables by setting `env_ignore_empty=True`, e.g.

```
os.environ['app_a'] = ''

class Settings(BaseSettings):
        a: str = 'default'

        model_config = SettingsConfigDict(env_prefix="app_", env_ignore_empty=True)

assert Settings().a == 'default'
```