### PR TITLE
Allow nested env var source to override nested init source.

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Mapping, Sequence, Tuple, Union, cast
 
 from dotenv import dotenv_values
-from pydantic import AliasChoices, AliasPath, BaseModel, Json
+from pydantic import AliasChoices, AliasPath, BaseModel, Json, TypeAdapter
 from pydantic._internal._typing_extra import origin_is_union
 from pydantic._internal._utils import deep_update, lenient_issubclass
 from pydantic.fields import FieldInfo
@@ -121,7 +121,7 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         return None, '', False
 
     def __call__(self) -> dict[str, Any]:
-        return self.init_kwargs
+        return TypeAdapter(dict[str, Any]).dump_python(self.init_kwargs)
 
     def __repr__(self) -> str:
         return f'InitSettingsSource(init_kwargs={self.init_kwargs!r})'


### PR DESCRIPTION
Resolves #203

Allows for nested `EnvSettingsSource` to override nested `InitSettingsSource`.