### PR TITLE
Fix typo in explode_env_vars() docstring

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -515,7 +515,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             env_vars: Environment variables.
 
         Returns:
-            A dictionaty contains extracted values from nested env values.
+            A dictionary contains extracted values from nested env values.
         """
         prefixes = [
             f'{env_name}{self.env_nested_delimiter}' for _, env_name, _ in self._extract_field_info(field, field_name)


### PR DESCRIPTION
Fixes minor typo in `EnvSettingsSource.explode_env_vars()` docstring; changes `dictionaty` to `dictionary`.