### PR TITLE
Fix for JSON on optional nested types.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -324,9 +324,6 @@ print(Settings().model_dump())
 `env_nested_delimiter` can be configured via the `model_config` as shown above, or via the
 `_env_nested_delimiter` keyword argument on instantiation.
 
-JSON is only parsed in top-level fields, if you need to parse JSON in sub-models, you will need to implement
-validators on those models.
-
 Nested environment variables take precedence over the top-level environment variable JSON
 (e.g. in the example above, `SUB_MODEL__V2` trumps `SUB_MODEL`).
 

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -11,8 +11,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Sequence, Tuple, Uni
 
 from dotenv import dotenv_values
 from pydantic import AliasChoices, AliasPath, BaseModel, Json, TypeAdapter
-from pydantic._internal._typing_extra import origin_is_union
-from pydantic._internal._utils import deep_update, lenient_issubclass
+from pydantic._internal._typing_extra import WithArgsTypes, origin_is_union
+from pydantic._internal._utils import deep_update, is_model_class, lenient_issubclass
 from pydantic.fields import FieldInfo
 from typing_extensions import get_args, get_origin
 
@@ -534,9 +534,6 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             annotation = field
 
         if origin_is_union(get_origin(annotation)) or isinstance(annotation, WithArgsTypes):
-            type_ = get_origin(annotation)
-            if is_model_class(type_) and type_.model_fields.get(key):
-                return type_.model_fields.get(key)
             for type_ in get_args(annotation):
                 type_has_key = EnvSettingsSource.next_field(type_, key)
                 if type_has_key:

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -526,13 +526,8 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         """
         if not field:
             return None
-        if isinstance(field, FieldInfo):
-            if not hasattr(field, 'annotation'):
-                return None
-            annotation = field.annotation
-        else:
-            annotation = field
 
+        annotation = field.annotation if isinstance(field, FieldInfo) else field
         if origin_is_union(get_origin(annotation)) or isinstance(annotation, WithArgsTypes):
             for type_ in get_args(annotation):
                 type_has_key = EnvSettingsSource.next_field(type_, key)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1233,7 +1233,7 @@ def test_secrets_nested_optional_json(tmp_path):
         a: int
 
     class Settings(BaseSettings):
-        foo: Foo | None = None
+        foo: Optional[Foo] = None
 
     p = tmp_path / 'foo'
     p.write_text('{"a": 10}')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1229,16 +1229,18 @@ def test_secrets_path_json(tmp_path):
 
 
 def test_secrets_nested_optional_json(tmp_path):
+    p = tmp_path / 'foo'
+    p.write_text('{"a": 10}')
+
     class Foo(BaseModel):
         a: int
 
     class Settings(BaseSettings):
         foo: Optional[Foo] = None
 
-    p = tmp_path / 'foo'
-    p.write_text('{"a": 10}')
+        model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
-    assert Settings(_secrets_dir=tmp_path).model_dump() == {'foo': {'a': 10}}
+    assert Settings().model_dump() == {'foo': {'a': 10}}
 
 
 def test_secrets_path_invalid_json(tmp_path):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -198,6 +198,22 @@ def test_nested_env_delimiter(env):
     }
 
 
+def test_nested_optional_json(env):
+    class Child(BaseModel):
+        num_list: Optional[List[int]] = None
+
+    class Cfg(BaseSettings, env_nested_delimiter='__'):
+        child: Optional[Child] = None
+
+    env.set('CHILD__NUM_LIST', '[1,2,3]')
+    cfg = Cfg()
+    assert cfg.model_dump() == {
+        'child': {
+            'num_list': [1, 2, 3],
+        },
+    }
+
+
 def test_nested_env_delimiter_with_prefix(env):
     class Subsettings(BaseSettings):
         banana: str

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -198,7 +198,7 @@ def test_nested_env_delimiter(env):
     }
 
 
-def test_nested_optional_json(env):
+def test_nested_env_optional_json(env):
     class Child(BaseModel):
         num_list: Optional[List[int]] = None
 
@@ -1226,6 +1226,19 @@ def test_secrets_path_json(tmp_path):
         model_config = SettingsConfigDict(secrets_dir=tmp_path)
 
     assert Settings().model_dump() == {'foo': {'a': 'b'}}
+
+
+def test_secrets_nested_optional_json(tmp_path):
+    class Foo(BaseModel):
+        a: int
+
+    class Settings(BaseSettings):
+        foo: Foo | None = None
+
+    p = tmp_path / 'foo'
+    p.write_text('{"a": 10}')
+
+    assert Settings(_secrets_dir=tmp_path).model_dump() == {'foo': {'a': 10}}
 
 
 def test_secrets_path_invalid_json(tmp_path):


### PR DESCRIPTION
Resolves https://github.com/pydantic/pydantic-settings/issues/196

Updated to recursively search the annotation for any model that matches key. Note that there is a possibility that it could get the wrong field in case of union with complex types that both have the same key. Not sure how that case should be handled. For now, it picks first match.