### PR TITLE
Ensure extra='forbid' is enforced in DotEnvSettingsSource when env_prefix is specified

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -647,7 +647,10 @@ class DotEnvSettingsSource(EnvSettingsSource):
         # update data with extra env variabels from dotenv file.
         for env_name, env_value in self.env_vars.items():
             if not is_extra_allowed and not env_name.startswith(self.env_prefix):
-                raise SettingsError(f'unable to load environment variables from \'{self.env_file}\' file due to the presence of variables without the specified prefix - \'{self.env_prefix}\'')
+                raise SettingsError(
+                    f"unable to load environment variables from '{self.env_file}' file "
+                    f"due to the presence of variables without the specified prefix - '{self.env_prefix}'"
+                )
             if env_name.startswith(self.env_prefix) and env_value is not None:
                 env_name_without_prefix = env_name[self.env_prefix_len :]
                 first_key, *_ = env_name_without_prefix.split(self.env_nested_delimiter)

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -640,12 +640,14 @@ class DotEnvSettingsSource(EnvSettingsSource):
         data: dict[str, Any] = super().__call__()
 
         data_lower_keys: list[str] = []
+        is_extra_allowed = self.config.get('extra') != 'forbid'
         if not self.case_sensitive:
             data_lower_keys = [x.lower() for x in data.keys()]
-
         # As `extra` config is allowed in dotenv settings source, We have to
         # update data with extra env variabels from dotenv file.
         for env_name, env_value in self.env_vars.items():
+            if not is_extra_allowed and not env_name.startswith(self.env_prefix):
+                raise SettingsError(f'unable to load environment variables from \'{self.env_file}\' file due to the presence of variables without the specified prefix - \'{self.env_prefix}\'')
             if env_name.startswith(self.env_prefix) and env_value is not None:
                 env_name_without_prefix = env_name[self.env_prefix_len :]
                 first_key, *_ = env_name_without_prefix.split(self.env_nested_delimiter)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -759,7 +759,6 @@ def test_env_file_config(env, tmp_path):
     assert s.b == 'better string'
     assert s.c == 'best string'
 
-
 prefix_test_env_file = """\
 # this is a comment
 prefix_A=good string
@@ -767,7 +766,6 @@ prefix_A=good string
 
 prefix_b='better string'
 prefix_c="best string"
-f="random value"
 """
 
 
@@ -789,6 +787,50 @@ def test_env_file_with_env_prefix(env, tmp_path):
     assert s.b == 'better string'
     assert s.c == 'best string'
 
+
+prefix_test_env_invalid_file = """\
+# this is a comment
+prefix_A=good string
+# another one, followed by whitespace
+
+prefix_b='better string'
+prefix_c="best string"
+f="random value"
+"""
+
+
+def test_env_file_with_env_prefix_invalid(tmp_path):
+    p = tmp_path / '.env'
+    p.write_text(prefix_test_env_invalid_file)
+
+    class Settings(BaseSettings):
+        a: str
+        b: str
+        c: str
+
+        model_config = SettingsConfigDict(env_file=p, env_prefix='prefix_')
+    err_msg = f'unable to load environment variables from \'{p}\' file due to the presence \
+of variables without the specified prefix - \'prefix_\''
+    with pytest.raises(SettingsError, match=err_msg):
+        Settings()
+
+
+def test_ignore_env_file_with_env_prefix_invalid(tmp_path):
+    p = tmp_path / '.env'
+    p.write_text(prefix_test_env_invalid_file)
+
+    class Settings(BaseSettings):
+        a: str
+        b: str
+        c: str
+
+        model_config = SettingsConfigDict(env_file=p, env_prefix='prefix_', extra='ignore')
+    
+    s = Settings()
+
+    assert s.a == 'good string'
+    assert s.b == 'better string'
+    assert s.c == 'best string'
 
 def test_env_file_config_case_sensitive(tmp_path):
     p = tmp_path / '.env'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -759,6 +759,7 @@ def test_env_file_config(env, tmp_path):
     assert s.b == 'better string'
     assert s.c == 'best string'
 
+
 prefix_test_env_file = """\
 # this is a comment
 prefix_A=good string
@@ -809,8 +810,11 @@ def test_env_file_with_env_prefix_invalid(tmp_path):
         c: str
 
         model_config = SettingsConfigDict(env_file=p, env_prefix='prefix_')
-    err_msg = f'unable to load environment variables from \'{p}\' file due to the presence \
-of variables without the specified prefix - \'prefix_\''
+
+    err_msg = (
+        f"unable to load environment variables from '{p}' file "
+        f"due to the presence of variables without the specified prefix - 'prefix_'"
+    )
     with pytest.raises(SettingsError, match=err_msg):
         Settings()
 
@@ -825,12 +829,13 @@ def test_ignore_env_file_with_env_prefix_invalid(tmp_path):
         c: str
 
         model_config = SettingsConfigDict(env_file=p, env_prefix='prefix_', extra='ignore')
-    
+
     s = Settings()
 
     assert s.a == 'good string'
     assert s.b == 'better string'
     assert s.c == 'best string'
+
 
 def test_env_file_config_case_sensitive(tmp_path):
     p = tmp_path / '.env'


### PR DESCRIPTION
Fix #215 

The current implementation in DotEnvSettingsSource allows non-prefixed variables even when extra='forbid'(default) is set . This commit addresses the issue by raising a SettingsError when extra is set to 'forbid' and variables are encountered without using the specified prefix.