### PR TITLE
Pass current_state in when calling custom and built-in sources.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -628,7 +628,7 @@ class JsonConfigSettingsSource(PydanticBaseSettingsSource):
     ) -> Any:
         return value
 
-    def __call__(self) -> Dict[str, Any]:
+    def __call__(self, current_state: dict[Any, str] = {}) -> Dict[str, Any]:
         d: Dict[str, Any] = {}
 
         for field_name, field in self.settings_cls.model_fields.items():

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -179,7 +179,7 @@ class BaseSettings(BaseModel):
         )
         if sources:
             # iterate through sources in priority order
-            state = {}
+            state: dict[str, Any] = {}
             for source in reversed(sources):
                 state = deep_update(state, source(state))
             return state

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -178,7 +178,11 @@ class BaseSettings(BaseModel):
             file_secret_settings=file_secret_settings,
         )
         if sources:
-            return deep_update(*reversed([source() for source in sources]))
+            # iterate through sources in priority order
+            state = {}
+            for source in reversed(sources):
+                state = deep_update(state, source(state))
+            return state
         else:
             # no one should mean to do this, but I think returning an empty dict is marginally preferable
             # to an informative error and much better than a confusing error

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -677,7 +677,7 @@ def test_config_file_settings_nornir(env):
     See https://github.com/pydantic/pydantic/pull/341#issuecomment-450378771
     """
 
-    def nornir_settings_source() -> Dict[str, Any]:
+    def nornir_settings_source(current_state: dict[str, Any] = {}) -> Dict[str, Any]:
         return {'param_a': 'config a', 'param_b': 'config b', 'param_c': 'config c'}
 
     class Settings(BaseSettings):
@@ -1371,10 +1371,10 @@ def test_secrets_dotenv_precedence(tmp_path):
 
 
 def test_external_settings_sources_precedence(env):
-    def external_source_0() -> Dict[str, str]:
+    def external_source_0(current_state: dict[str, Any] = {}) -> Dict[str, str]:
         return {'apple': 'value 0', 'banana': 'value 2'}
 
-    def external_source_1() -> Dict[str, str]:
+    def external_source_1(current_state: dict[str, Any] = {}) -> Dict[str, str]:
         return {'apple': 'value 1', 'raspberry': 'value 3'}
 
     class Settings(BaseSettings):
@@ -1416,7 +1416,7 @@ def test_external_settings_sources_filter_env_vars():
         def get_field_value(self, field: FieldInfo, field_name: str) -> Any:
             pass
 
-        def __call__(self) -> Dict[str, str]:
+        def __call__(self, current_state: dict[str, Any] = {}) -> Dict[str, str]:
             vault_vars = vault_storage[f'{self.user}:{self.password}']
             return {
                 field_name: vault_vars[field_name]


### PR DESCRIPTION
This will allow sources to dynamically decided if to provide a value for the attribute.
For example, a higher priority source can decided to leave the low-priority source "as is" if it's not None.

Note: I think this is considered a breaking change as the signature of `__call__` on the source abstract type is changing.

See https://github.com/pydantic/pydantic-settings/issues/223#issuecomment-1913196648 for context
Interested in the maintainers thoughts here :) 