### PR TITLE
Adding optional prefixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -184,6 +184,21 @@ class Settings(BaseSettings):
 
 1. `env_prefix` will be ignored and the value will be read from `FooAlias` environment variable.
 
+#### Optional Environment Variable Prefixes
+
+```py
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix='my_prefix_', prefix_optional=True)
+    environment: str = 'stage'
+```
+
+Sometimes it is useful to share one environment variable between several services, but retain the ability to override 
+certain variables for specific services. By setting ``prefix_optional=True``, environment variables with prefixes will be searched for first. If 
+the variable is not found, the version lacking the prefix will be defaulted to.
+
 ### Case-sensitivity
 
 By default, environment variable names are case-insensitive.

--- a/docs/index.md
+++ b/docs/index.md
@@ -196,8 +196,8 @@ class Settings(BaseSettings):
 ```
 
 Sometimes it is useful to share one environment variable between several services, but retain the ability to override 
-certain variables for specific services. By setting ``prefix_optional=True``, environment variables with prefixes will be searched for first. If 
-the variable is not found, the version lacking the prefix will be defaulted to.
+certain variables for specific services. By setting ``prefix_optional=True``, environment variables with prefixes will 
+be searched for first. If the variable is not found, the version lacking the prefix will be defaulted to.
 
 ### Case-sensitivity
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,14 +189,12 @@ class Settings(BaseSettings):
 ```py
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix='my_prefix_', prefix_optional=True)
     environment: str = 'stage'
 ```
-
-Sometimes it is useful to share one environment variable between several services, but retain the ability to override 
-certain variables for specific services. By setting ``prefix_optional=True``, environment variables with prefixes will 
+Sometimes it is useful to share one environment variable between several services, but retain the ability to override
+certain variables for specific services. By setting ``prefix_optional=True``, environment variables with prefixes will
 be searched for first. If the variable is not found, the version lacking the prefix will be defaulted to.
 
 ### Case-sensitivity

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,6 +189,7 @@ class Settings(BaseSettings):
 ```py
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix='my_prefix_', prefix_optional=True)
     environment: str = 'stage'


### PR DESCRIPTION
There is a common use-case where several services use the same env vars -- i.e. an ENVIRONMENT variable. Occasionally, you want to override this value per service, but do not want to enforce it for every single variable for every single service. I have added an optional argument ``prefix_optional``, wherein the prefixed version of an environment variable will be checked first, but will then fallback to the naked version.