### PR TITLE
Fix typing syntax for compatibility with python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: set up python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.8'
 
     - run: pip install -r requirements/linting.txt -r requirements/pyproject.txt
 
@@ -101,7 +101,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.8'
 
       - name: install
         run: pip install -U build

--- a/docs/index.md
+++ b/docs/index.md
@@ -599,7 +599,7 @@ nested_field = "world!"
 [PEP 518](https://peps.python.org/pep-0518/#tool-table) defines a `[tool]` table that can be used to provide arbitrary tool configuration.
 While encouraged to use the `[tool]` table, `PyprojectTomlConfigSettingsSource` can be used to load variables from any location with in "pyproject.toml" file.
 
-This is controlled by providing `SettingsConfigDict(pyproject_toml_table_header=tuple[str, ...])` where the value is a tuple of header parts.
+This is controlled by providing `SettingsConfigDict(pyproject_toml_table_header=Tuple[str, ...])` where the value is a tuple of header parts.
 By default, `pyproject_toml_table_header=('tool', 'pydantic-settings')` which will load variables from the `[tool.pydantic-settings]` table.
 
 ```python

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Dict, Optional, Tuple, Type, Union
 
 from pydantic import ConfigDict
 from pydantic._internal._config import config_keys
@@ -23,17 +23,17 @@ from .sources import (
 class SettingsConfigDict(ConfigDict, total=False):
     case_sensitive: bool
     env_prefix: str
-    env_file: DotenvType | None
-    env_file_encoding: str | None
+    env_file: Optional[DotenvType]
+    env_file_encoding: Optional[str]
     env_ignore_empty: bool
-    env_nested_delimiter: str | None
-    env_parse_none_str: str | None
-    env_parse_enums: bool | None
-    secrets_dir: str | Path | None
-    json_file: PathType | None
-    json_file_encoding: str | None
-    yaml_file: PathType | None
-    yaml_file_encoding: str | None
+    env_nested_delimiter: Optional[str]
+    env_parse_none_str: Optional[str]
+    env_parse_enums: Optional[bool]
+    secrets_dir: Optional[Union[str, Path]]
+    json_file: Optional[PathType]
+    json_file_encoding: Optional[str]
+    yaml_file: Optional[PathType]
+    yaml_file_encoding: Optional[str]
     pyproject_toml_depth: int
     """
     Number of levels **up** from the current working directory to attempt to find a pyproject.toml
@@ -42,10 +42,10 @@ class SettingsConfigDict(ConfigDict, total=False):
     This is only used when a pyproject.toml file is not found in the current working directory.
     """
 
-    pyproject_toml_table_header: tuple[str, ...]
+    pyproject_toml_table_header: Tuple[str, ...]
     """
     Header of the TOML table within a pyproject.toml file to use when filling variables.
-    This is supplied as a `tuple[str, ...]` instead of a `str` to accommodate for headers
+    This is supplied as a `Tuple[str, ...]` instead of a `str` to accommodate for headers
     containing a `.`.
 
     For example, `toml_table_header = ("tool", "my.tool", "foo")` can be used to fill variable
@@ -54,7 +54,7 @@ class SettingsConfigDict(ConfigDict, total=False):
     To use the root table, exclude this config setting or provide an empty tuple.
     """
 
-    toml_file: PathType | None
+    toml_file: Optional[PathType]
 
 
 # Extend `config_keys` by pydantic settings config keys to
@@ -92,15 +92,15 @@ class BaseSettings(BaseModel):
 
     def __init__(
         __pydantic_self__,
-        _case_sensitive: bool | None = None,
-        _env_prefix: str | None = None,
-        _env_file: DotenvType | None = ENV_FILE_SENTINEL,
-        _env_file_encoding: str | None = None,
-        _env_ignore_empty: bool | None = None,
-        _env_nested_delimiter: str | None = None,
-        _env_parse_none_str: str | None = None,
-        _env_parse_enums: bool | None = None,
-        _secrets_dir: str | Path | None = None,
+        _case_sensitive: Optional[bool] = None,
+        _env_prefix: Optional[str] = None,
+        _env_file: Optional[DotenvType] = ENV_FILE_SENTINEL,
+        _env_file_encoding: Optional[str] = None,
+        _env_ignore_empty: Optional[bool] = None,
+        _env_nested_delimiter: Optional[str] = None,
+        _env_parse_none_str: Optional[str] = None,
+        _env_parse_enums: Optional[bool] = None,
+        _secrets_dir: Optional[Union[str, Path]] = None,
         **values: Any,
     ) -> None:
         # Uses something other than `self` the first arg to allow "self" as a settable attribute
@@ -122,12 +122,12 @@ class BaseSettings(BaseModel):
     @classmethod
     def settings_customise_sources(
         cls,
-        settings_cls: type[BaseSettings],
+        settings_cls: Type[BaseSettings],
         init_settings: PydanticBaseSettingsSource,
         env_settings: PydanticBaseSettingsSource,
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
-    ) -> tuple[PydanticBaseSettingsSource, ...]:
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
         """
         Define the sources and their order for loading the settings values.
 
@@ -145,17 +145,17 @@ class BaseSettings(BaseModel):
 
     def _settings_build_values(
         self,
-        init_kwargs: dict[str, Any],
-        _case_sensitive: bool | None = None,
-        _env_prefix: str | None = None,
-        _env_file: DotenvType | None = None,
-        _env_file_encoding: str | None = None,
-        _env_ignore_empty: bool | None = None,
-        _env_nested_delimiter: str | None = None,
-        _env_parse_none_str: str | None = None,
-        _env_parse_enums: bool | None = None,
-        _secrets_dir: str | Path | None = None,
-    ) -> dict[str, Any]:
+        init_kwargs: Dict[str, Any],
+        _case_sensitive: Optional[bool] = None,
+        _env_prefix: Optional[str] = None,
+        _env_file: Optional[DotenvType] = None,
+        _env_file_encoding: Optional[str] = None,
+        _env_ignore_empty: Optional[bool] = None,
+        _env_nested_delimiter: Optional[str] = None,
+        _env_parse_none_str: Optional[str] = None,
+        _env_parse_enums: Optional[bool] = None,
+        _secrets_dir: Optional[Union[str, Path]] = None,
+    ) -> Dict[str, Any]:
         # Determine settings config values
         case_sensitive = _case_sensitive if _case_sensitive is not None else self.model_config.get('case_sensitive')
         env_prefix = _env_prefix if _env_prefix is not None else self.model_config.get('env_prefix')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,11 +85,13 @@ source = [
 
 [tool.ruff]
 line-length = 120
+target-version = 'py38'
+
+[tool.ruff.lint]
 extend-select = ['Q', 'RUF100', 'C90', 'UP', 'I']
 flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
 mccabe = { max-complexity = 14 }
 isort = { known-first-party = ['pydantic_settings', 'tests'] }
-target-version = 'py38'
 
 [tool.black]
 color = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,11 @@ target-version = 'py38'
 [tool.black]
 color = true
 line-length = 120
-target-version = ['py310']
+target-version = ['py38']
 skip-string-normalization = true
 
 [tool.mypy]
-python_version = '3.10'
+python_version = '3.8'
 show_error_codes = true
 follow_imports = 'silent'
 strict_optional = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Iterator
 
 import pytest
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
 
 
 class SetEnv:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -4,6 +4,7 @@ import platform
 import re
 import sys
 from pathlib import Path
+from typing import Dict, Optional
 
 import pytest
 from pytest_examples import CodeExample, EvalExample, find_examples
@@ -24,13 +25,13 @@ def skip_docs_tests():
 class GroupModuleGlobals:
     def __init__(self) -> None:
         self.name = None
-        self.module_dict: dict[str, str] = {}
+        self.module_dict: Dict[str, str] = {}
 
-    def get(self, name: str | None):
+    def get(self, name: Optional[str]):
         if name is not None and name == self.name:
             return self.module_dict
 
-    def set(self, name: str | None, module_dict: dict[str, str]):
+    def set(self, name: Optional[str], module_dict: Dict[str, str]):
         self.name = name
         if self.name is None:
             self.module_dict = None


### PR DESCRIPTION
Typing issues were brought to light when attempting to override `BaseSettings.settings_customise_sources()` as per [the documentation](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#parsing-environment-variable-values:~:text=You%20may%20also%20populate%20a%20complex%20type%20by%20providing%20your%20own%20source%20class.).

On python 3.8, this raised the `TypeError: 'type' object is not subscriptable` exception from [this line](https://github.com/pydantic/pydantic-settings/blob/c2fd92ffa74b14ed38fd8fcb1f77d087ca4a960e/pydantic_settings/main.py#L125)

Is this the only way forward? Or am I missing something and hitting an edge case with python 3.8 and `type`?