### PR TITLE
fix: superfluous deep env conflicts with non-dict model leaf

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -638,7 +638,8 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                     except ValueError as e:
                         if not allow_json_failure:
                             raise e
-            env_var[last_key] = env_val
+            if isinstance(env_var, dict):
+                env_var[last_key] = env_val
 
         return result
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2586,3 +2586,21 @@ def test_nested_models_as_dict_value(env):
     env.set('sub_dict__bar__foo', '{"b": 2}')
     s = Settings()
     assert s.model_dump() == {'nested': {'foo': {'a': 1}}, 'sub_dict': {'bar': {'foo': {'b': 2}}}}
+
+
+def test_nested_models_leaf_vs_deeper_env_dict_assumed(env):
+    class NestedSettings(BaseModel):
+        foo: str
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_nested_delimiter='__')
+
+        nested: NestedSettings
+
+    env.set('nested__foo', 'string')
+    env.set(
+        'nested__foo__bar',
+        'this should not be evaluated, since foo is a string by annotation and not a dict',
+    )
+    s = Settings()
+    assert s.model_dump() == {'nested': {'foo': 'string'}}


### PR DESCRIPTION
If a model defines a leaf as e.g. a string and the user or system sets an environment var with an additional `env_nested_delimiter + suffix`, `explode_env_vars` was treating the string as a `dict` (trying to add an item to it).

This fix checks if the target is indeed a `dict`.

In that regard, the whole `explode_env_vars` seems a bit wasteful, in terms of possible throwing away already computed values, if a deeper environment variable is processed earlier (which is possible, since the iteration order of `os.environ` seems unpredictable).

resolves #275