### PR TITLE
Fix command line help from `argparse` formatting problem

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1407,6 +1407,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             elif field_info.default_factory is not None:
                 default = f'(default: {field_info.default_factory})'
             _help += f' {default}' if _help else default
+        _help = _help.replace('%', '%%')
         return _help
 
 

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1407,8 +1407,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             elif field_info.default_factory is not None:
                 default = f'(default: {field_info.default_factory})'
             _help += f' {default}' if _help else default
-        _help = _help.replace('%', '%%')
-        return _help
+        return _help.replace('%', '%%') if issubclass(type(self._root_parser), ArgumentParser) else _help
 
 
 class ConfigFileSourceMixin(ABC):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2261,6 +2261,29 @@ def test_cli_help_differentiation(capsys, monkeypatch):
         )
 
 
+def test_cli_help_string_format(capsys, monkeypatch):
+    class Cfg(BaseSettings):
+        date_str: str = '%Y-%m-%d'
+
+    argparse_options_text = 'options' if sys.version_info >= (3, 10) else 'optional arguments'
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['example.py', '--help'])
+
+        with pytest.raises(SystemExit):
+            Cfg(_cli_parse_args=True)
+
+        assert (
+            re.sub(r'0x\w+', '0xffffffff', capsys.readouterr().out, re.MULTILINE)
+            == f"""usage: example.py [-h] [--date_str str]
+
+{argparse_options_text}:
+  -h, --help      show this help message and exit
+  --date_str str  (default: %Y-%m-%d)
+"""
+        )
+
+
 def test_cli_nested_dataclass_arg():
     @pydantic_dataclasses.dataclass
     class MyDataclass:


### PR DESCRIPTION
Closes #304 