### PR TITLE
feat: Enable access to the current state in settings sources

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1488,30 +1488,32 @@ print(Settings())
 
 #### Accesing the result of previous sources
 
-Each source of settings can access the output of the previous ones:
+Each source of settings can access the output of the previous ones.
 
 ```python
 from typing import Any, Dict, Tuple
 
-from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+from pydantic.fields import FieldInfo
+
+from pydantic_settings import PydanticBaseSettingsSource
 
 
 class MyCustomSource(PydanticBaseSettingsSource):
     def get_field_value(
         self, field: FieldInfo, field_name: str
-    ) -> Tuple[Any, str, bool]:
-        ...
+    ) -> Tuple[Any, str, bool]: ...
 
     def __call__(self) -> Dict[str, Any]:
         # Retrieve the aggregated settings from previous sources
         previous_state = self.previous_state
+        previous_state.get('some_setting')
 
         # Retrive settings from all sources individually
         # self.previous_state["SettingsSourceName"]: Dict[str, Any]
-        previous_states = self.previous_state
+        previous_states = self.previous_states
+        previous_states['SomeSettingsSource'].get('some_setting')
 
         # Your code here...
-
 ```
 
 ### Removing sources

--- a/docs/index.md
+++ b/docs/index.md
@@ -1505,13 +1505,13 @@ class MyCustomSource(PydanticBaseSettingsSource):
 
     def __call__(self) -> Dict[str, Any]:
         # Retrieve the aggregated settings from previous sources
-        previous_state = self.previous_state
-        previous_state.get('some_setting')
+        current_state = self.current_state
+        current_state.get('some_setting')
 
         # Retrive settings from all sources individually
-        # self.previous_state["SettingsSourceName"]: Dict[str, Any]
-        previous_states = self.previous_states
-        previous_states['SomeSettingsSource'].get('some_setting')
+        # self.settings_sources_data["SettingsSourceName"]: Dict[str, Any]
+        settings_sources_data = self.settings_sources_data
+        settings_sources_data['SomeSettingsSource'].get('some_setting')
 
         # Your code here...
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1486,6 +1486,34 @@ print(Settings())
 #> foobar='test'
 ```
 
+#### Accesing the result of previous sources
+
+Each source of settings can access the output of the previous ones:
+
+```python
+from typing import Any, Dict, Tuple
+
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+
+
+class MyCustomSource(PydanticBaseSettingsSource):
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> Tuple[Any, str, bool]:
+        ...
+
+    def __call__(self) -> Dict[str, Any]:
+        # Retrieve the aggregated settings from previous sources
+        previous_state = self.previous_state
+
+        # Retrive settings from all sources individually
+        # self.previous_state["SettingsSourceName"]: Dict[str, Any]
+        previous_states = self.previous_state
+
+        # Your code here...
+
+```
+
 ### Removing sources
 
 You might also want to disable a source:

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -312,8 +312,8 @@ class BaseSettings(BaseModel):
             states: dict[str, dict[str, Any]] = {}
             for source in sources:
                 if isinstance(source, PydanticBaseSettingsSource):
-                    source._set_previous_state(state)
-                    source._set_previous_states(states)
+                    source._set_current_state(state)
+                    source._set_settings_sources_data(states)
 
                 source_name = source.__name__ if hasattr(source, '__name__') else type(source).__name__
                 source_state = source()

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -312,6 +312,7 @@ class BaseSettings(BaseModel):
             states: dict[str, dict[str, Any]] = {}
             for source in sources:
                 if isinstance(source, PydanticBaseSettingsSource):
+                    source._set_previous_state(state)
                     source._set_previous_states(states)
 
                 source_name = source.__name__ if hasattr(source, '__name__') else type(source).__name__

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -308,7 +308,12 @@ class BaseSettings(BaseModel):
                 )
                 sources = (cli_settings,) + sources
         if sources:
-            return deep_update(*reversed([source() for source in sources]))
+            state: dict[str, Any] = {}
+            for source in reversed(sources):
+                if isinstance(source, PydanticBaseSettingsSource):
+                    source._PydanticBaseSettingsSource__set_previous_state(state)  # type: ignore[attr-defined]
+                state = deep_update(state, source())
+            return state
         else:
             # no one should mean to do this, but I think returning an empty dict is marginally preferable
             # to an informative error and much better than a confusing error

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -309,10 +309,10 @@ class BaseSettings(BaseModel):
                 sources = (cli_settings,) + sources
         if sources:
             state: dict[str, Any] = {}
-            for source in reversed(sources):
+            for source in sources:
                 if isinstance(source, PydanticBaseSettingsSource):
                     source._PydanticBaseSettingsSource__set_previous_state(state)  # type: ignore[attr-defined]
-                state = deep_update(state, source())
+                state = deep_update(source(), state)
             return state
         else:
             # no one should mean to do this, but I think returning an empty dict is marginally preferable

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -311,7 +311,7 @@ class BaseSettings(BaseModel):
             state: dict[str, Any] = {}
             for source in sources:
                 if isinstance(source, PydanticBaseSettingsSource):
-                    source._PydanticBaseSettingsSource__set_previous_state(state)  # type: ignore[attr-defined]
+                    source._set_previous_state(state)
                 state = deep_update(source(), state)
             return state
         else:

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -309,10 +309,16 @@ class BaseSettings(BaseModel):
                 sources = (cli_settings,) + sources
         if sources:
             state: dict[str, Any] = {}
+            states: dict[str, dict[str, Any]] = {}
             for source in sources:
                 if isinstance(source, PydanticBaseSettingsSource):
-                    source._set_previous_state(state)
-                state = deep_update(source(), state)
+                    source._set_previous_states(states)
+
+                source_name = source.__name__ if hasattr(source, '__name__') else type(source).__name__
+                source_state = source()
+
+                states[source_name] = source_state
+                state = deep_update(source_state, state)
             return state
         else:
             # no one should mean to do this, but I think returning an empty dict is marginally preferable

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -126,36 +126,36 @@ class PydanticBaseSettingsSource(ABC):
     def __init__(self, settings_cls: type[BaseSettings]):
         self.settings_cls = settings_cls
         self.config = settings_cls.model_config
-        self._previous_state: dict[str, Any] = {}
-        self._previous_states: dict[str, dict[str, Any]] = {}
+        self._current_state: dict[str, Any] = {}
+        self._settings_sources_data: dict[str, dict[str, Any]] = {}
 
-    def _set_previous_state(self, state: dict[str, Any]) -> None:
+    def _set_current_state(self, state: dict[str, Any]) -> None:
         """
         Record the state of settings from the previous settings sources. This should
         be called right before __call__.
         """
-        self._previous_state = state
+        self._current_state = state
 
-    def _set_previous_states(self, states: dict[str, dict[str, Any]]) -> None:
+    def _set_settings_sources_data(self, states: dict[str, dict[str, Any]]) -> None:
         """
         Record the state of settings from all previous settings sources. This should
         be called right before __call__.
         """
-        self._previous_states = states
+        self._settings_sources_data = states
 
     @property
-    def previous_states(self) -> dict[str, dict[str, Any]]:
-        """
-        The state of all previous settings sources.
-        """
-        return self._previous_states
-
-    @property
-    def previous_state(self) -> dict[str, Any]:
+    def current_state(self) -> dict[str, Any]:
         """
         The current state of the settings, populated by the previous settings sources.
         """
-        return self._previous_state
+        return self._current_state
+
+    @property
+    def settings_sources_data(self) -> dict[str, dict[str, Any]]:
+        """
+        The state of all previous settings sources.
+        """
+        return self._settings_sources_data
 
     @abstractmethod
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -126,21 +126,21 @@ class PydanticBaseSettingsSource(ABC):
     def __init__(self, settings_cls: type[BaseSettings]):
         self.settings_cls = settings_cls
         self.config = settings_cls.model_config
-        self.__previous_state: dict[str, Any] = {}
+        self._previous_state: dict[str, Any] = {}
 
-    def __set_previous_state(self, state: dict[str, Any]) -> None:
+    def _set_previous_state(self, state: dict[str, Any]) -> None:
         """
         Record the state of settings from the previous settings sources. This should
         be called right before __call__.
         """
-        self.__previous_state = state
+        self._previous_state = state
 
     @property
     def previous_state(self) -> dict[str, Any]:
         """
         The current state of the settings, populated by the previous settings sources.
         """
-        return self.__previous_state
+        return self._previous_state
 
     @abstractmethod
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -126,6 +126,18 @@ class PydanticBaseSettingsSource(ABC):
     def __init__(self, settings_cls: type[BaseSettings]):
         self.settings_cls = settings_cls
         self.config = settings_cls.model_config
+        self.__previous_state: dict[str, Any] = {}
+
+    def __set_previous_state(self, state: dict[str, Any]) -> None:
+        """
+        Record the state of settings from the previous settings sources. This should
+        be called right before __call__.
+        """
+        self.__previous_state = state
+
+    @property
+    def previous_state(self) -> dict[str, Any]:
+        return self.__previous_state
 
     @abstractmethod
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -137,6 +137,9 @@ class PydanticBaseSettingsSource(ABC):
 
     @property
     def previous_state(self) -> dict[str, Any]:
+        """
+        The current state of the settings, populated by the previous settings sources.
+        """
         return self.__previous_state
 
     @abstractmethod

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -12,6 +12,7 @@ from argparse import SUPPRESS, ArgumentParser, HelpFormatter, Namespace, _SubPar
 from collections import deque
 from dataclasses import is_dataclass
 from enum import Enum
+from functools import reduce
 from pathlib import Path
 from types import FunctionType
 from typing import (
@@ -126,21 +127,28 @@ class PydanticBaseSettingsSource(ABC):
     def __init__(self, settings_cls: type[BaseSettings]):
         self.settings_cls = settings_cls
         self.config = settings_cls.model_config
-        self._previous_state: dict[str, Any] = {}
+        self._previous_states: dict[str, dict[str, Any]] = {}
 
-    def _set_previous_state(self, state: dict[str, Any]) -> None:
+    def _set_previous_states(self, states: dict[str, dict[str, Any]]) -> None:
         """
-        Record the state of settings from the previous settings sources. This should
+        Record the state of settings from all previous settings sources. This should
         be called right before __call__.
         """
-        self._previous_state = state
+        self._previous_states = states
+
+    @property
+    def previous_states(self) -> dict[str, dict[str, Any]]:
+        """
+        The state of all previous settings sources.
+        """
+        return self._previous_states
 
     @property
     def previous_state(self) -> dict[str, Any]:
         """
         The current state of the settings, populated by the previous settings sources.
         """
-        return self._previous_state
+        return reduce(deep_update, self.previous_states.values())
 
     @abstractmethod
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3975,7 +3975,7 @@ def test_case_insensitive_nested_list(env):
 
 def test_settings_source_previous_state(env):
     class SettingsSource(PydanticBaseSettingsSource):
-        def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+        def get_field_value(self, field: FieldInfo, field_name: str) -> Any:
             pass
 
         def __call__(self) -> dict[str, Any]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3998,7 +3998,7 @@ def test_settings_source_previous_state(env):
             dotenv_settings: PydanticBaseSettingsSource,
             file_secret_settings: PydanticBaseSettingsSource,
         ) -> tuple[PydanticBaseSettingsSource, ...]:
-            return (SettingsSource(settings_cls), env_settings)
+            return (env_settings, SettingsSource(settings_cls))
 
     env.set('one', '1')
     s = Settings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4027,14 +4027,14 @@ def test_case_insensitive_nested_list(env):
     assert s.model_dump() == {'nested': {'FOO': ['string1', 'string2']}}
 
 
-def test_settings_source_previous_state(env):
+def test_settings_source_current_state(env):
     class SettingsSource(PydanticBaseSettingsSource):
         def get_field_value(self, field: FieldInfo, field_name: str) -> Any:
             pass
 
         def __call__(self) -> Dict[str, Any]:
-            previous_state = self.previous_state
-            if previous_state.get('one') == '1':
+            current_state = self.current_state
+            if current_state.get('one') == '1':
                 return {'two': '1'}
 
             return {}
@@ -4059,14 +4059,14 @@ def test_settings_source_previous_state(env):
     assert s.two is True
 
 
-def test_settings_source_previous_states(env):
+def test_settings_source_settings_sources_data(env):
     class SettingsSource(PydanticBaseSettingsSource):
         def get_field_value(self, field: FieldInfo, field_name: str) -> Any:
             pass
 
         def __call__(self) -> Dict[str, Any]:
-            previous_states = self.previous_states
-            if previous_states == {
+            settings_sources_data = self.settings_sources_data
+            if settings_sources_data == {
                 'InitSettingsSource': {'one': True, 'two': True},
                 'EnvSettingsSource': {'one': '1'},
                 'function_settings_source': {'three': 'false'},

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3978,7 +3978,7 @@ def test_settings_source_previous_state(env):
         def get_field_value(self, field: FieldInfo, field_name: str) -> Any:
             pass
 
-        def __call__(self) -> dict[str, Any]:
+        def __call__(self) -> Dict[str, Any]:
             previous_state = self.previous_state
             if previous_state.get('one') == '1':
                 return {'two': '1'}
@@ -3997,7 +3997,7 @@ def test_settings_source_previous_state(env):
             env_settings: PydanticBaseSettingsSource,
             dotenv_settings: PydanticBaseSettingsSource,
             file_secret_settings: PydanticBaseSettingsSource,
-        ) -> tuple[PydanticBaseSettingsSource, ...]:
+        ) -> Tuple[PydanticBaseSettingsSource, ...]:
             return (env_settings, SettingsSource(settings_cls))
 
     env.set('one', '1')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4003,3 +4003,44 @@ def test_settings_source_previous_state(env):
     env.set('one', '1')
     s = Settings()
     assert s.two is True
+
+
+def test_settings_source_previous_states(env):
+    class SettingsSource(PydanticBaseSettingsSource):
+        def get_field_value(self, field: FieldInfo, field_name: str) -> Any:
+            pass
+
+        def __call__(self) -> Dict[str, Any]:
+            previous_states = self.previous_states
+            if previous_states == {
+                'InitSettingsSource': {'one': True, 'two': True},
+                'EnvSettingsSource': {'one': '1'},
+                'function_settings_source': {'three': 'false'},
+            }:
+                return {'four': '1'}
+
+            return {}
+
+    def function_settings_source():
+        return {'three': 'false'}
+
+    class Settings(BaseSettings):
+        one: bool = False
+        two: bool = False
+        three: bool = False
+        four: bool = False
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: Type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> Tuple[PydanticBaseSettingsSource, ...]:
+            return (env_settings, init_settings, function_settings_source, SettingsSource(settings_cls))
+
+    env.set('one', '1')
+    s = Settings(one=True, two=True)
+    assert s.four is True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3992,7 +3992,7 @@ def test_settings_source_previous_state(env):
         @classmethod
         def settings_customise_sources(
             cls,
-            settings_cls: type[BaseSettings],
+            settings_cls: Type[BaseSettings],
             init_settings: PydanticBaseSettingsSource,
             env_settings: PydanticBaseSettingsSource,
             dotenv_settings: PydanticBaseSettingsSource,


### PR DESCRIPTION
## Why this PR?

This PR aims at enabling custom settings sources to access the output of the previous sources, through the `.previous_state` property.

The ultimate use-case is the same as #224, however this PR does not introduce a breaking change.

Fixes #223.

## Use-case

My real-life use-case: retrieving settings from AWS Secrets Manager but setting the secret name in environment variables.

## Discussion

_There are a number of things to be discussed about this PR, and I would very much appreciate the input / guidance of the pydantic-settings maintainers._

1. I have reversed the order in which the settings sources are discovered ([here](https://github.com/VictorColomb/pydantic-settings/blob/main/pydantic_settings/main.py#L312-L315)) in order for the output of the sources with the most priority to be available to the ones of lesser importance. This seems like the most intuitive behavior to me, but this is rather subjective. Any preference?
2. Currently, settings sources are being handed the raw output from the previous ones. In other words, nothing has yet been validated by Pydantic. Would it be desired behavior to instead pass a validated instance of `self.settings_cls`? I have not gone this way because imho it adds to much complexity for not that much benefit.
3. I have defined the `__previous_state` setter method as "private", in that Python will perform name mangling on the method. This way, we are almost certain to introduce no breaking changes at all (someone could have defined their own `set_previous_state` method). However, that means calling `_PydanticBaseSettingsSource__set_previous_state` in the sources discovery code, which is neither elegant nor pythonic. My question therefore is should I remove the double-underscore for cleaner code at the marginal risk of introducing a breaking change for some?
4. Should I add a bit of documentation, for example as a subsection of the [Adding sources](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#adding-sources) section?