### PR TITLE
Fix regex flags accidentally passed as count

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2350,7 +2350,7 @@ def test_cli_help_differentiation(capsys, monkeypatch):
             Cfg(_cli_parse_args=True)
 
         assert (
-            re.sub(r'0x\w+', '0xffffffff', capsys.readouterr().out, re.MULTILINE)
+            re.sub(r'0x\w+', '0xffffffff', capsys.readouterr().out, flags=re.MULTILINE)
             == f"""usage: example.py [-h] [--foo str] [--bar int] [--boo int]
 
 {ARGPARSE_OPTIONS_TEXT}:
@@ -2377,7 +2377,7 @@ def test_cli_help_string_format(capsys, monkeypatch):
             Cfg(_cli_parse_args=True)
 
         assert (
-            re.sub(r'0x\w+', '0xffffffff', capsys.readouterr().out, re.MULTILINE)
+            re.sub(r'0x\w+', '0xffffffff', capsys.readouterr().out, flags=re.MULTILINE)
             == f"""usage: example.py [-h] [--date_str str]
 
 {argparse_options_text}:


### PR DESCRIPTION
The `flags` argument to `re.sub()` was accidentally passed positionally in the place of the `count` argument in `tests/test_settings.py`. Fix this by passing it as a keyword argument, which additionally fixes a `DeprecationWarning` in Python 3.13+ due to passing `flags` and/or `count` as positional arguments. See: https://docs.python.org/3.13/library/re.html#re.sub