### PR TITLE
Feature/instance level source customization

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1659,7 +1659,7 @@ class Settings(BaseSettings):
     my_api_key: str
 
 
-def settings_use_only_env(sources: tuple[PydanticBaseSettingsSource, ...]):
+def settings_use_only_env(sources: tuple):
     # Do not use unpacking, look for the ``EnvSettingSource`` since it might
     # not be included if ``settings_customise_sources`` is defined.
     _ = (source for source in sources if isinstance(source, EnvSettingsSource))

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Callable, ClassVar
 
@@ -222,106 +221,54 @@ class BaseSettings(BaseModel):
         ) = None,
     ) -> dict[str, Any]:
         # Determine settings config values
-        case_sensitive = (
-            _case_sensitive
-            if _case_sensitive is not None
-            else self.model_config.get("case_sensitive")
-        )
-        env_prefix = (
-            _env_prefix
-            if _env_prefix is not None
-            else self.model_config.get("env_prefix")
-        )
-        env_file = (
-            _env_file
-            if _env_file != ENV_FILE_SENTINEL
-            else self.model_config.get("env_file")
-        )
+        case_sensitive = _case_sensitive if _case_sensitive is not None else self.model_config.get('case_sensitive')
+        env_prefix = _env_prefix if _env_prefix is not None else self.model_config.get('env_prefix')
+        env_file = _env_file if _env_file != ENV_FILE_SENTINEL else self.model_config.get('env_file')
         env_file_encoding = (
-            _env_file_encoding
-            if _env_file_encoding is not None
-            else self.model_config.get("env_file_encoding")
+            _env_file_encoding if _env_file_encoding is not None else self.model_config.get('env_file_encoding')
         )
         env_ignore_empty = (
-            _env_ignore_empty
-            if _env_ignore_empty is not None
-            else self.model_config.get("env_ignore_empty")
+            _env_ignore_empty if _env_ignore_empty is not None else self.model_config.get('env_ignore_empty')
         )
         env_nested_delimiter = (
             _env_nested_delimiter
             if _env_nested_delimiter is not None
-            else self.model_config.get("env_nested_delimiter")
+            else self.model_config.get('env_nested_delimiter')
         )
         env_parse_none_str = (
-            _env_parse_none_str
-            if _env_parse_none_str is not None
-            else self.model_config.get("env_parse_none_str")
+            _env_parse_none_str if _env_parse_none_str is not None else self.model_config.get('env_parse_none_str')
         )
-        env_parse_enums = (
-            _env_parse_enums
-            if _env_parse_enums is not None
-            else self.model_config.get("env_parse_enums")
-        )
+        env_parse_enums = _env_parse_enums if _env_parse_enums is not None else self.model_config.get('env_parse_enums')
 
-        cli_prog_name = (
-            _cli_prog_name
-            if _cli_prog_name is not None
-            else self.model_config.get("cli_prog_name")
-        )
-        cli_parse_args = (
-            _cli_parse_args
-            if _cli_parse_args is not None
-            else self.model_config.get("cli_parse_args")
-        )
+        cli_prog_name = _cli_prog_name if _cli_prog_name is not None else self.model_config.get('cli_prog_name')
+        cli_parse_args = _cli_parse_args if _cli_parse_args is not None else self.model_config.get('cli_parse_args')
         cli_settings_source = (
-            _cli_settings_source
-            if _cli_settings_source is not None
-            else self.model_config.get("cli_settings_source")
+            _cli_settings_source if _cli_settings_source is not None else self.model_config.get('cli_settings_source')
         )
         cli_parse_none_str = (
-            _cli_parse_none_str
-            if _cli_parse_none_str is not None
-            else self.model_config.get("cli_parse_none_str")
+            _cli_parse_none_str if _cli_parse_none_str is not None else self.model_config.get('cli_parse_none_str')
         )
-        cli_parse_none_str = (
-            cli_parse_none_str if not env_parse_none_str else env_parse_none_str
-        )
+        cli_parse_none_str = cli_parse_none_str if not env_parse_none_str else env_parse_none_str
         cli_hide_none_type = (
-            _cli_hide_none_type
-            if _cli_hide_none_type is not None
-            else self.model_config.get("cli_hide_none_type")
+            _cli_hide_none_type if _cli_hide_none_type is not None else self.model_config.get('cli_hide_none_type')
         )
-        cli_avoid_json = (
-            _cli_avoid_json
-            if _cli_avoid_json is not None
-            else self.model_config.get("cli_avoid_json")
-        )
+        cli_avoid_json = _cli_avoid_json if _cli_avoid_json is not None else self.model_config.get('cli_avoid_json')
         cli_enforce_required = (
             _cli_enforce_required
             if _cli_enforce_required is not None
-            else self.model_config.get("cli_enforce_required")
+            else self.model_config.get('cli_enforce_required')
         )
         cli_use_class_docs_for_groups = (
             _cli_use_class_docs_for_groups
             if _cli_use_class_docs_for_groups is not None
-            else self.model_config.get("cli_use_class_docs_for_groups")
+            else self.model_config.get('cli_use_class_docs_for_groups')
         )
         cli_exit_on_error = (
-            _cli_exit_on_error
-            if _cli_exit_on_error is not None
-            else self.model_config.get("cli_exit_on_error")
+            _cli_exit_on_error if _cli_exit_on_error is not None else self.model_config.get('cli_exit_on_error')
         )
-        cli_prefix = (
-            _cli_prefix
-            if _cli_prefix is not None
-            else self.model_config.get("cli_prefix")
-        )
+        cli_prefix = _cli_prefix if _cli_prefix is not None else self.model_config.get('cli_prefix')
 
-        secrets_dir = (
-            _secrets_dir
-            if _secrets_dir is not None
-            else self.model_config.get("secrets_dir")
-        )
+        secrets_dir = _secrets_dir if _secrets_dir is not None else self.model_config.get('secrets_dir')
 
         # Configure built-in sources
         init_settings = InitSettingsSource(self.__class__, init_kwargs=init_kwargs)
@@ -347,10 +294,7 @@ class BaseSettings(BaseModel):
         )
 
         file_secret_settings = SecretsSettingsSource(
-            self.__class__,
-            secrets_dir=secrets_dir,
-            case_sensitive=case_sensitive,
-            env_prefix=env_prefix,
+            self.__class__, secrets_dir=secrets_dir, case_sensitive=case_sensitive, env_prefix=env_prefix
         )
         # Provide a hook to set built-in sources priority and add / remove sources
         sources = self.settings_customise_sources(
@@ -365,9 +309,7 @@ class BaseSettings(BaseModel):
         if _settings_customize_instance is not None:
             sources = _settings_customize_instance(sources)
 
-        if not any(
-            [source for source in sources if isinstance(source, CliSettingsSource)]
-        ):
+        if not any([source for source in sources if isinstance(source, CliSettingsSource)]):
             if cli_parse_args is not None or cli_settings_source is not None:
                 cli_settings = (
                     CliSettingsSource(
@@ -395,11 +337,7 @@ class BaseSettings(BaseModel):
                     source._set_current_state(state)
                     source._set_settings_sources_data(states)
 
-                source_name = (
-                    source.__name__
-                    if hasattr(source, "__name__")
-                    else type(source).__name__
-                )
+                source_name = source.__name__ if hasattr(source, '__name__') else type(source).__name__
                 source_state = source()
 
                 states[source_name] = source_state
@@ -411,11 +349,11 @@ class BaseSettings(BaseModel):
             return {}
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
-        extra="forbid",
+        extra='forbid',
         arbitrary_types_allowed=True,
         validate_default=True,
         case_sensitive=False,
-        env_prefix="",
+        env_prefix='',
         env_file=None,
         env_file_encoding=None,
         env_ignore_empty=False,
@@ -431,12 +369,12 @@ class BaseSettings(BaseModel):
         cli_enforce_required=False,
         cli_use_class_docs_for_groups=False,
         cli_exit_on_error=True,
-        cli_prefix="",
+        cli_prefix='',
         json_file=None,
         json_file_encoding=None,
         yaml_file=None,
         yaml_file_encoding=None,
         toml_file=None,
         secrets_dir=None,
-        protected_namespaces=("model_", "settings_"),
+        protected_namespaces=('model_', 'settings_'),
     )

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -138,6 +138,13 @@ class BaseSettings(BaseModel):
         _cli_exit_on_error: bool | None = None,
         _cli_prefix: str | None = None,
         _secrets_dir: str | Path | None = None,
+        _settings_customize_instance: (
+            Callable[
+                [tuple[PydanticBaseSettingsSource, ...]],
+                tuple[PydanticBaseSettingsSource, ...],
+            ]
+            | None
+        ) = None,
         **values: Any,
     ) -> None:
         # Uses something other than `self` the first arg to allow "self" as a settable attribute
@@ -163,6 +170,7 @@ class BaseSettings(BaseModel):
                 _cli_exit_on_error=_cli_exit_on_error,
                 _cli_prefix=_cli_prefix,
                 _secrets_dir=_secrets_dir,
+                _settings_customize_instance=_settings_customize_instance,
             )
         )
 

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -1,7 +1,8 @@
 from __future__ import annotations as _annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, Callable, ClassVar
 
 from pydantic import ConfigDict
 from pydantic._internal._config import config_keys
@@ -212,56 +213,115 @@ class BaseSettings(BaseModel):
         _cli_exit_on_error: bool | None = None,
         _cli_prefix: str | None = None,
         _secrets_dir: str | Path | None = None,
+        _settings_customize_instance: (
+            Callable[
+                [tuple[PydanticBaseSettingsSource, ...]],
+                tuple[PydanticBaseSettingsSource, ...],
+            ]
+            | None
+        ) = None,
     ) -> dict[str, Any]:
         # Determine settings config values
-        case_sensitive = _case_sensitive if _case_sensitive is not None else self.model_config.get('case_sensitive')
-        env_prefix = _env_prefix if _env_prefix is not None else self.model_config.get('env_prefix')
-        env_file = _env_file if _env_file != ENV_FILE_SENTINEL else self.model_config.get('env_file')
+        case_sensitive = (
+            _case_sensitive
+            if _case_sensitive is not None
+            else self.model_config.get("case_sensitive")
+        )
+        env_prefix = (
+            _env_prefix
+            if _env_prefix is not None
+            else self.model_config.get("env_prefix")
+        )
+        env_file = (
+            _env_file
+            if _env_file != ENV_FILE_SENTINEL
+            else self.model_config.get("env_file")
+        )
         env_file_encoding = (
-            _env_file_encoding if _env_file_encoding is not None else self.model_config.get('env_file_encoding')
+            _env_file_encoding
+            if _env_file_encoding is not None
+            else self.model_config.get("env_file_encoding")
         )
         env_ignore_empty = (
-            _env_ignore_empty if _env_ignore_empty is not None else self.model_config.get('env_ignore_empty')
+            _env_ignore_empty
+            if _env_ignore_empty is not None
+            else self.model_config.get("env_ignore_empty")
         )
         env_nested_delimiter = (
             _env_nested_delimiter
             if _env_nested_delimiter is not None
-            else self.model_config.get('env_nested_delimiter')
+            else self.model_config.get("env_nested_delimiter")
         )
         env_parse_none_str = (
-            _env_parse_none_str if _env_parse_none_str is not None else self.model_config.get('env_parse_none_str')
+            _env_parse_none_str
+            if _env_parse_none_str is not None
+            else self.model_config.get("env_parse_none_str")
         )
-        env_parse_enums = _env_parse_enums if _env_parse_enums is not None else self.model_config.get('env_parse_enums')
+        env_parse_enums = (
+            _env_parse_enums
+            if _env_parse_enums is not None
+            else self.model_config.get("env_parse_enums")
+        )
 
-        cli_prog_name = _cli_prog_name if _cli_prog_name is not None else self.model_config.get('cli_prog_name')
-        cli_parse_args = _cli_parse_args if _cli_parse_args is not None else self.model_config.get('cli_parse_args')
+        cli_prog_name = (
+            _cli_prog_name
+            if _cli_prog_name is not None
+            else self.model_config.get("cli_prog_name")
+        )
+        cli_parse_args = (
+            _cli_parse_args
+            if _cli_parse_args is not None
+            else self.model_config.get("cli_parse_args")
+        )
         cli_settings_source = (
-            _cli_settings_source if _cli_settings_source is not None else self.model_config.get('cli_settings_source')
+            _cli_settings_source
+            if _cli_settings_source is not None
+            else self.model_config.get("cli_settings_source")
         )
         cli_parse_none_str = (
-            _cli_parse_none_str if _cli_parse_none_str is not None else self.model_config.get('cli_parse_none_str')
+            _cli_parse_none_str
+            if _cli_parse_none_str is not None
+            else self.model_config.get("cli_parse_none_str")
         )
-        cli_parse_none_str = cli_parse_none_str if not env_parse_none_str else env_parse_none_str
+        cli_parse_none_str = (
+            cli_parse_none_str if not env_parse_none_str else env_parse_none_str
+        )
         cli_hide_none_type = (
-            _cli_hide_none_type if _cli_hide_none_type is not None else self.model_config.get('cli_hide_none_type')
+            _cli_hide_none_type
+            if _cli_hide_none_type is not None
+            else self.model_config.get("cli_hide_none_type")
         )
-        cli_avoid_json = _cli_avoid_json if _cli_avoid_json is not None else self.model_config.get('cli_avoid_json')
+        cli_avoid_json = (
+            _cli_avoid_json
+            if _cli_avoid_json is not None
+            else self.model_config.get("cli_avoid_json")
+        )
         cli_enforce_required = (
             _cli_enforce_required
             if _cli_enforce_required is not None
-            else self.model_config.get('cli_enforce_required')
+            else self.model_config.get("cli_enforce_required")
         )
         cli_use_class_docs_for_groups = (
             _cli_use_class_docs_for_groups
             if _cli_use_class_docs_for_groups is not None
-            else self.model_config.get('cli_use_class_docs_for_groups')
+            else self.model_config.get("cli_use_class_docs_for_groups")
         )
         cli_exit_on_error = (
-            _cli_exit_on_error if _cli_exit_on_error is not None else self.model_config.get('cli_exit_on_error')
+            _cli_exit_on_error
+            if _cli_exit_on_error is not None
+            else self.model_config.get("cli_exit_on_error")
         )
-        cli_prefix = _cli_prefix if _cli_prefix is not None else self.model_config.get('cli_prefix')
+        cli_prefix = (
+            _cli_prefix
+            if _cli_prefix is not None
+            else self.model_config.get("cli_prefix")
+        )
 
-        secrets_dir = _secrets_dir if _secrets_dir is not None else self.model_config.get('secrets_dir')
+        secrets_dir = (
+            _secrets_dir
+            if _secrets_dir is not None
+            else self.model_config.get("secrets_dir")
+        )
 
         # Configure built-in sources
         init_settings = InitSettingsSource(self.__class__, init_kwargs=init_kwargs)
@@ -287,7 +347,10 @@ class BaseSettings(BaseModel):
         )
 
         file_secret_settings = SecretsSettingsSource(
-            self.__class__, secrets_dir=secrets_dir, case_sensitive=case_sensitive, env_prefix=env_prefix
+            self.__class__,
+            secrets_dir=secrets_dir,
+            case_sensitive=case_sensitive,
+            env_prefix=env_prefix,
         )
         # Provide a hook to set built-in sources priority and add / remove sources
         sources = self.settings_customise_sources(
@@ -297,7 +360,14 @@ class BaseSettings(BaseModel):
             dotenv_settings=dotenv_settings,
             file_secret_settings=file_secret_settings,
         )
-        if not any([source for source in sources if isinstance(source, CliSettingsSource)]):
+
+        # Instance hook since :meth:`settings_customise_sources` is a classmethod.
+        if _settings_customize_instance is not None:
+            sources = _settings_customize_instance(sources)
+
+        if not any(
+            [source for source in sources if isinstance(source, CliSettingsSource)]
+        ):
             if cli_parse_args is not None or cli_settings_source is not None:
                 cli_settings = (
                     CliSettingsSource(
@@ -325,7 +395,11 @@ class BaseSettings(BaseModel):
                     source._set_current_state(state)
                     source._set_settings_sources_data(states)
 
-                source_name = source.__name__ if hasattr(source, '__name__') else type(source).__name__
+                source_name = (
+                    source.__name__
+                    if hasattr(source, "__name__")
+                    else type(source).__name__
+                )
                 source_state = source()
 
                 states[source_name] = source_state
@@ -337,11 +411,11 @@ class BaseSettings(BaseModel):
             return {}
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
-        extra='forbid',
+        extra="forbid",
         arbitrary_types_allowed=True,
         validate_default=True,
         case_sensitive=False,
-        env_prefix='',
+        env_prefix="",
         env_file=None,
         env_file_encoding=None,
         env_ignore_empty=False,
@@ -357,12 +431,12 @@ class BaseSettings(BaseModel):
         cli_enforce_required=False,
         cli_use_class_docs_for_groups=False,
         cli_exit_on_error=True,
-        cli_prefix='',
+        cli_prefix="",
         json_file=None,
         json_file_encoding=None,
         yaml_file=None,
         yaml_file_encoding=None,
         toml_file=None,
         secrets_dir=None,
-        protected_namespaces=('model_', 'settings_'),
+        protected_namespaces=("model_", "settings_"),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 dynamic = ['version']
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-mock", "pytest-examples"]
+test = ["pytest>=8.3.0", "pytest-mock>=3.14.0", "pytest-examples>=0.0.12"]
 yaml = ["pyyaml>=6.0.1"]
 toml = ["tomli>=2.0.1"]
 azure-key-vault = ["azure-keyvault-secrets>=4.8.0", "azure-identity>=1.16.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
 dynamic = ['version']
 
 [project.optional-dependencies]
+test = ["pytest", "pytest-mock", "pytest-examples"]
 yaml = ["pyyaml>=6.0.1"]
 toml = ["tomli>=2.0.1"]
 azure-key-vault = ["azure-keyvault-secrets>=4.8.0", "azure-identity>=1.16.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
 dynamic = ['version']
 
 [project.optional-dependencies]
-test = ["pytest>=8.3.0", "pytest-mock>=3.14.0", "pytest-examples>=0.0.12"]
 yaml = ["pyyaml>=6.0.1"]
 toml = ["tomli>=2.0.1"]
 azure-key-vault = ["azure-keyvault-secrets>=4.8.0", "azure-identity>=1.16.0"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4158,7 +4158,7 @@ def test_settings_customize_instance_env_only(env):
     class Settings(BaseSettings):
         my_api_key: str
 
-    def settings_use_only_env(sources: tuple[PydanticBaseSettingsSource, ...]):
+    def settings_use_only_env(sources: tuple):
         # Do not use unpacking, look for the ``EnvSettingSource`` since it might
         # not be included if ``settings_customise_sources`` is defined.
         _ = (source for source in sources if isinstance(source, EnvSettingsSource))


### PR DESCRIPTION
I have made this pull request to close [my own issue](https://github.com/pydantic/pydantic-settings/issues/346), #346.

I essentially wanted instance level source customization, therefore I added the callback to ``_settings_customize_instance``. 

This change should also help users when testing since they will not have to add ``settings_customize_sources`` to their class, and will only have to pass ``_settings_customize_instance`` to the constructor.

This also includes a small modification to ``pyproject.toml`` to define test dependencies to improve the developer experience.

Sorry that ``black`` went wild on ``settings.py``, there are only ``3`` lines actually added in there. I am assuming that actions will probably fix this, if not, I will fix it.