### PR TITLE
CLI Improve Docstring Help Text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1120,7 +1120,7 @@ parser methods that can be customised, along with their argparse counterparts (t
 * `add_argument_group_method` - (`argparse.ArgumentParser.add_argument_group`)
 * `add_parser_method` - (`argparse._SubParsersAction.add_parser`)
 * `add_subparsers_method` - (`argparse.ArgumentParser.add_subparsers`)
-* `formatter_class` - (`argparse.HelpFormatter`)
+* `formatter_class` - (`argparse.RawDescriptionHelpFormatter`)
 
 For a non-argparse parser the parser methods can be set to `None` if not supported. The CLI settings will only raise an
 error when connecting to the root parser if a parser method is necessary but set to `None`.

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -8,11 +8,12 @@ import sys
 import typing
 import warnings
 from abc import ABC, abstractmethod
-from argparse import SUPPRESS, ArgumentParser, HelpFormatter, Namespace, _SubParsersAction
+from argparse import SUPPRESS, ArgumentParser, Namespace, RawDescriptionHelpFormatter, _SubParsersAction
 from collections import deque
 from dataclasses import is_dataclass
 from enum import Enum
 from pathlib import Path
+from textwrap import dedent
 from types import FunctionType
 from typing import (
     TYPE_CHECKING,
@@ -916,7 +917,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             Defaults to `argparse._SubParsersAction.add_parser`.
         add_subparsers_method: The root parser add subparsers (sub-commands) method.
             Defaults to `argparse.ArgumentParser.add_subparsers`.
-        formatter_class: A class for customizing the root parser help text. Defaults to `argparse.HelpFormatter`.
+        formatter_class: A class for customizing the root parser help text. Defaults to `argparse.RawDescriptionHelpFormatter`.
     """
 
     def __init__(
@@ -938,7 +939,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         add_argument_group_method: Callable[..., Any] | None = ArgumentParser.add_argument_group,
         add_parser_method: Callable[..., Any] | None = _SubParsersAction.add_parser,
         add_subparsers_method: Callable[..., Any] | None = ArgumentParser.add_subparsers,
-        formatter_class: Any = HelpFormatter,
+        formatter_class: Any = RawDescriptionHelpFormatter,
     ) -> None:
         self.cli_prog_name = (
             cli_prog_name if cli_prog_name is not None else settings_cls.model_config.get('cli_prog_name', sys.argv[0])
@@ -990,7 +991,10 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
 
         root_parser = (
             _CliInternalArgParser(
-                cli_exit_on_error=self.cli_exit_on_error, prog=self.cli_prog_name, description=settings_cls.__doc__
+                cli_exit_on_error=self.cli_exit_on_error,
+                prog=self.cli_prog_name,
+                description=None if settings_cls.__doc__ is None else dedent(settings_cls.__doc__),
+                formatter_class=formatter_class,
             )
             if root_parser is None
             else root_parser
@@ -1355,7 +1359,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         add_argument_group_method: Callable[..., Any] | None = ArgumentParser.add_argument_group,
         add_parser_method: Callable[..., Any] | None = _SubParsersAction.add_parser,
         add_subparsers_method: Callable[..., Any] | None = ArgumentParser.add_subparsers,
-        formatter_class: Any = HelpFormatter,
+        formatter_class: Any = RawDescriptionHelpFormatter,
     ) -> None:
         self._root_parser = root_parser
         self._parse_args = self._connect_parser_method(parse_args_method, 'parsed_args_method')
@@ -1409,7 +1413,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                         field_name,
                         help=field_info.description,
                         formatter_class=self._formatter_class,
-                        description=model.__doc__,
+                        description=None if model.__doc__ is None else dedent(model.__doc__),
                     ),
                     model=model,
                     added_args=[],
@@ -1501,7 +1505,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         model_group_kwargs: dict[str, Any] = {}
         model_group_kwargs['title'] = f'{arg_names[0]} options'
         model_group_kwargs['description'] = (
-            sub_models[0].__doc__
+            None if sub_models[0].__doc__ is None else dedent(sub_models[0].__doc__)
             if self.cli_use_class_docs_for_groups and len(sub_models) == 1
             else field_info.description
         )

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1509,7 +1509,9 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         model_group_kwargs: dict[str, Any] = {}
         model_group_kwargs['title'] = f'{arg_names[0]} options'
         model_group_kwargs['description'] = (
-            None if sub_models[0].__doc__ is None else dedent(sub_models[0].__doc__)
+            None
+            if sub_models[0].__doc__ is None
+            else dedent(sub_models[0].__doc__)
             if self.cli_use_class_docs_for_groups and len(sub_models) == 1
             else field_info.description
         )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2393,24 +2393,58 @@ def test_cli_help_differentiation(capsys, monkeypatch):
 
 
 def test_cli_help_string_format(capsys, monkeypatch):
-    class Cfg(BaseSettings):
+    class Cfg(BaseSettings, cli_parse_args=True):
         date_str: str = '%Y-%m-%d'
 
-    argparse_options_text = 'options' if sys.version_info >= (3, 10) else 'optional arguments'
+    class MultilineDoc(BaseSettings, cli_parse_args=True):
+        """
+        My
+        Multiline
+        Doc
+        """
 
     with monkeypatch.context() as m:
         m.setattr(sys, 'argv', ['example.py', '--help'])
 
         with pytest.raises(SystemExit):
-            Cfg(_cli_parse_args=True)
+            Cfg()
 
         assert (
             re.sub(r'0x\w+', '0xffffffff', capsys.readouterr().out, flags=re.MULTILINE)
             == f"""usage: example.py [-h] [--date_str str]
 
-{argparse_options_text}:
+{ARGPARSE_OPTIONS_TEXT}:
   -h, --help      show this help message and exit
   --date_str str  (default: %Y-%m-%d)
+"""
+        )
+
+        with pytest.raises(SystemExit):
+            MultilineDoc()
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h]
+
+My
+Multiline
+Doc
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help  show this help message and exit
+"""
+        )
+
+        with pytest.raises(SystemExit):
+            cli_settings_source = CliSettingsSource(MultilineDoc, formatter_class=argparse.HelpFormatter)
+            MultilineDoc(_cli_settings_source=cli_settings_source(args=True))
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h]
+
+My Multiline Doc
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help  show this help message and exit
 """
         )
 


### PR DESCRIPTION
Improve help text generation for docstrings used in CLI help descriptions.

```python
from argparse import HelpFormatter
from pydantic_settings import BaseSettings, CliSettingsSource


class Settings(BaseSettings):
    """
    My
    Multiline
    Doc
    """


# Default now preserves docstring formatting:
s = CliSettingsSource(Settings)
print(s.root_parser.format_help())
"""
usage: example.py [-h]

My
Multiline
Doc

options:
  -h, --help  show this help message and exit
"""


# Also fixed an issue where formatter_class was not getting applied when set.
# Previously, generated docstring help text would default to the below and would not preserve formatting:
s = CliSettingsSource(Settings, formatter_class=HelpFormatter)
print(s.root_parser.format_help())
"""
usage: example.py [-h]

My Multiline Doc

options:
  -h, --help  show this help message and exit
"""
```