### PR TITLE
Fixes CLI help text for function types 

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1720,9 +1720,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         obj = _strip_annotated(obj)
         if _is_function(obj):
             # If function is locally defined use __name__ instead of __qualname__
-            if hasattr(obj, '__code__') and obj.__code__.co_flags & inspect.CO_NESTED:
-                return obj.__name__
-            return obj.__qualname__
+            return obj.__name__ if '<locals>' in obj.__qualname__ else obj.__qualname__
         elif obj is ...:
             return '...'
         elif isinstance(obj, Representation):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import re
 import sys
+import time
 import typing
 import uuid
 from datetime import datetime, timezone
@@ -2553,9 +2554,7 @@ def test_cli_help_differentiation(capsys, monkeypatch):
   -h, --help  show this help message and exit
   --foo str   (required)
   --bar int   (default: 123)
-  --boo int   (default: <function
-              test_cli_help_differentiation.<locals>.Cfg.<lambda> at
-              0xffffffff>)
+  --boo int   (default factory: <lambda>)
 """
         )
 
@@ -3757,6 +3756,9 @@ def test_cli_user_settings_source_exceptions():
         (Annotated[SimpleSettings, 'annotation'], 'JSON'),
         (DirectoryPath, 'Path'),
         (FruitsEnum, '{pear,kiwi,lime}'),
+        (time.time_ns, 'time_ns'),
+        (foobar, 'foobar'),
+        (CliDummyParser.add_argument, 'CliDummyParser.add_argument'),
     ],
 )
 @pytest.mark.parametrize('hide_none_type', [True, False])


### PR DESCRIPTION
Fixes CLI help text for function types.

Primarily, `isinstance(obj, FunctionType)` does not handle `builtins`, e.g., `time.time_ns`. The added `_is_function` function resolves this.

@hramezani @samuelcolvin this may be something to consider bringing into [pydantic's implementation](https://github.com/pydantic/pydantic/blob/main/pydantic/_internal/_repr.py#L91).