### PR TITLE
Cli prefix validation alias fix

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1608,7 +1608,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                     if arg_prefix and field_info.validation_alias is not None:
                         # Strip prefix if validation alias is set and value is not complex.
                         # Related https://github.com/pydantic/pydantic-settings/pull/25
-                        kwargs['dest'] = kwargs['dest'][self.env_prefix_len:]
+                        kwargs['dest'] = kwargs['dest'][self.env_prefix_len :]
                     if group is not None:
                         if isinstance(group, dict):
                             group = self._add_argument_group(parser, **group)

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1604,16 +1604,19 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                         resolved_names,
                         model_default=model_default,
                     )
-                elif is_alias_path_only:
-                    continue
-                elif group is not None:
-                    if isinstance(group, dict):
-                        group = self._add_argument_group(parser, **group)
-                    added_args += list(arg_names)
-                    self._add_argument(group, *(f'{arg_flag[:len(name)]}{name}' for name in arg_names), **kwargs)
-                else:
-                    added_args += list(arg_names)
-                    self._add_argument(parser, *(f'{arg_flag[:len(name)]}{name}' for name in arg_names), **kwargs)
+                elif not is_alias_path_only:
+                    if arg_prefix and field_info.validation_alias is not None:
+                        # Strip prefix if validation alias is set and value is not complex.
+                        # Related https://github.com/pydantic/pydantic-settings/pull/25
+                        kwargs['dest'] = kwargs['dest'][self.env_prefix_len:]
+                    if group is not None:
+                        if isinstance(group, dict):
+                            group = self._add_argument_group(parser, **group)
+                        added_args += list(arg_names)
+                        self._add_argument(group, *(f'{arg_flag[:len(name)]}{name}' for name in arg_names), **kwargs)
+                    else:
+                        added_args += list(arg_names)
+                        self._add_argument(parser, *(f'{arg_flag[:len(name)]}{name}' for name in arg_names), **kwargs)
 
         self._add_parser_alias_paths(parser, alias_path_args, added_args, arg_prefix, subcommand_prefix, group)
         return parser

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -738,6 +738,18 @@ def test_validation_alias_with_env_prefix(env):
     assert Settings().foobar == 'bar'
 
 
+def test_validation_alias_with_cli_prefix():
+    class Settings(BaseSettings, cli_exit_on_error=False):
+        foobar: str = Field(validation_alias='foo')
+
+        model_config = SettingsConfigDict(cli_prefix='p')
+
+    with pytest.raises(SettingsError, match='error parsing CLI: unrecognized arguments: --foo bar'):
+        Settings(_cli_parse_args=['--foo', 'bar'])
+
+    assert Settings(_cli_parse_args=['--p.foo', 'bar']).foobar == 'bar'
+
+
 def test_case_sensitive(monkeypatch):
     class Settings(BaseSettings):
         foo: str


### PR DESCRIPTION
Fixes CLI issue related to #25.

`cli_prefix` will add prefix to all CLI parser args. These parsed args (with prefixes) then get directly passed down to the env var layer. These were getting missed for non-complex cases as discussed (and expected) in #25. 

However, CLI must make this conversion since the prefix is reserved with the CLI parser. This fix simply maps the CLI prefixed arg to the expected non-prefixed env var.

Test case shows expected case.