### PR TITLE
Add CLI subcommand union and alias support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -855,13 +855,13 @@ class Beta(BaseModel):
 
 
 class Gamma(BaseModel):
-    """Beta Help"""
+    """Gamma Help"""
 
     opt_gamma: str = Field(alias='opt-gamma')
 
 
 class Root(BaseSettings, cli_parse_args=True, cli_exit_on_error=False):
-    subcommand: CliSubCommand[Union[Alpha, Beta]] = Field(alias='sub-command')
+    alpha_or_beta: CliSubCommand[Union[Alpha, Beta]] = Field(alias='alpha-or-beta-cmd')
     gamma: CliSubCommand[Gamma] = Field(alias='gamma-cmd')
 
 
@@ -922,7 +922,8 @@ when necessary.
     For `python < 3.9` the `--no-flag` option is not generated due to an underlying `argparse` limitation.
 
 !!! note
-    For `python < 3.9` the `CliImplicitFlag` and `CliExplicitFlag` annotations can only be applied to optional bool fields.
+    For `python < 3.9` the `CliImplicitFlag` and `CliExplicitFlag` annotations can only be applied to optional boolean
+    fields.
 
 ```py
 from pydantic_settings import BaseSettings, CliExplicitFlag, CliImplicitFlag

--- a/docs/index.md
+++ b/docs/index.md
@@ -830,6 +830,7 @@ positional arguments, aliasing will change the CLI help text displayed for the f
 
 ```py
 import sys
+from typing import Union
 
 from pydantic import BaseModel, Field
 
@@ -860,7 +861,7 @@ class Gamma(BaseModel):
 
 
 class Root(BaseSettings, cli_parse_args=True, cli_exit_on_error=False):
-    subcommand: CliSubCommand[Alpha | Beta] = Field(alias='sub-command')
+    subcommand: CliSubCommand[Union[Alpha, Beta]] = Field(alias='sub-command')
     gamma: CliSubCommand[Gamma] = Field(alias='gamma-cmd')
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -837,6 +837,7 @@ from pydantic_settings import (
     BaseSettings,
     CliPositionalArg,
     CliSubCommand,
+    get_subcommand,
 )
 
 
@@ -864,16 +865,13 @@ class Root(BaseSettings, cli_parse_args=True, cli_exit_on_error=False):
 
 
 sys.argv = ['example.py', 'Alpha', 'hello']
-print(Root().model_dump())
-#> {'subcommand': {'cmd_alpha': 'hello'}, 'gamma': None}
+assert get_subcommand(Root()).model_dump() == {'cmd_alpha': 'hello'}
 
 sys.argv = ['example.py', 'Beta', '--opt-beta=hey']
-print(Root().model_dump())
-#> {'subcommand': {'opt_beta': 'hey'}, 'gamma': None}
+assert get_subcommand(Root()).model_dump() == {'opt_beta': 'hey'}
 
 sys.argv = ['example.py', 'gamma-cmd', '--opt-gamma=hi']
-print(Root().model_dump())
-#> {'subcommand': None, 'gamma': {'opt_gamma': 'hi'}}
+assert get_subcommand(Root()).model_dump() == {'opt_gamma': 'hi'}
 ```
 
 ### Customizing the CLI Experience

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1248,33 +1248,26 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
 
         return self
 
-    def _get_merge_parsed_list_types(
-        self, parsed_list: list[str], field_name: str
-    ) -> tuple[Optional[type], Optional[type]]:
-        merge_type = self._cli_dict_args.get(field_name, list)
-        if (
-            merge_type is list
-            or not origin_is_union(get_origin(merge_type))
-            or not any(
-                type_
-                for type_ in get_args(merge_type)
-                if type_ is not type(None) and get_origin(type_) not in (dict, Mapping)
-            )
-        ):
-            inferred_type = merge_type
-        else:
-            inferred_type = list if parsed_list and (len(parsed_list) > 1 or parsed_list[0].startswith('[')) else str
-
-        return merge_type, inferred_type
-
     def _merge_parsed_list(self, parsed_list: list[str], field_name: str) -> str:
         try:
             merged_list: list[str] = []
             is_last_consumed_a_value = False
-            merge_type, inferred_type = self._get_merge_parsed_list_types(parsed_list, field_name)
+            merge_type = self._cli_dict_args.get(field_name, list)
+            if (
+                merge_type is list
+                or not origin_is_union(get_origin(merge_type))
+                or not any(
+                    type_
+                    for type_ in get_args(merge_type)
+                    if type_ is not type(None) and get_origin(type_) not in (dict, Mapping)
+                )
+            ):
+                inferred_type = merge_type
+            else:
+                inferred_type = (
+                    list if parsed_list and (len(parsed_list) > 1 or parsed_list[0].startswith('[')) else str
+                )
             for val in parsed_list:
-                if not isinstance(val, str):
-                    break
                 val = val.strip()
                 if val.startswith('[') and val.endswith(']'):
                     val = val[1:-1].strip()

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -150,7 +150,7 @@ class _CliInternalArgParser(ArgumentParser):
 
 T = TypeVar('T')
 CliSubCommand = Annotated[Union[T, None], _CliSubCommand]
-CliPositionalArg = Annotated[Union[T, None], _CliPositionalArg]
+CliPositionalArg = Annotated[T, _CliPositionalArg]
 _CliBoolFlag = TypeVar('_CliBoolFlag', bound=bool)
 CliImplicitFlag = Annotated[_CliBoolFlag, _CliImplicitFlag]
 CliExplicitFlag = Annotated[_CliBoolFlag, _CliExplicitFlag]

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1433,7 +1433,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                     for field_type in field_types:
                         if not (is_model_class(field_type) or is_pydantic_dataclass(field_type)):
                             raise SettingsError(
-                                f'subcommand argument {model.__name__}.{field_name} is not derived from BaseModel'
+                                f'subcommand argument {model.__name__}.{field_name} has type not derived from BaseModel'
                             )
                 subcommand_args.append((field_name, field_info))
             elif _CliPositionalArg in field_info.metadata:

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1248,25 +1248,30 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
 
         return self
 
+    def _get_merge_parsed_list_types(
+        self, parsed_list: list[str], field_name: str
+    ) -> tuple[Optional[type], Optional[type]]:
+        merge_type = self._cli_dict_args.get(field_name, list)
+        if (
+            merge_type is list
+            or not origin_is_union(get_origin(merge_type))
+            or not any(
+                type_
+                for type_ in get_args(merge_type)
+                if type_ is not type(None) and get_origin(type_) not in (dict, Mapping)
+            )
+        ):
+            inferred_type = merge_type
+        else:
+            inferred_type = list if parsed_list and (len(parsed_list) > 1 or parsed_list[0].startswith('[')) else str
+
+        return merge_type, inferred_type
+
     def _merge_parsed_list(self, parsed_list: list[str], field_name: str) -> str:
         try:
             merged_list: list[str] = []
             is_last_consumed_a_value = False
-            merge_type = self._cli_dict_args.get(field_name, list)
-            if (
-                merge_type is list
-                or not origin_is_union(get_origin(merge_type))
-                or not any(
-                    type_
-                    for type_ in get_args(merge_type)
-                    if type_ is not type(None) and get_origin(type_) not in (dict, Mapping)
-                )
-            ):
-                inferred_type = merge_type
-            else:
-                inferred_type = (
-                    list if parsed_list and (len(parsed_list) > 1 or parsed_list[0].startswith('[')) else str
-                )
+            merge_type, inferred_type = self._get_merge_parsed_list_types(parsed_list, field_name)
             for val in parsed_list:
                 if not isinstance(val, str):
                     break

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1268,6 +1268,8 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                     list if parsed_list and (len(parsed_list) > 1 or parsed_list[0].startswith('[')) else str
                 )
             for val in parsed_list:
+                if not isinstance(val, str):
+                    break
                 val = val.strip()
                 if val.startswith('[') and val.endswith(']'):
                     val = val[1:-1].strip()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2905,15 +2905,6 @@ def test_cli_annotation_exceptions(monkeypatch):
             SubCommandHasDefault()
 
         with pytest.raises(
-            SettingsError, match='subcommand argument SubCommandMultipleTypes.subcmd has multiple types'
-        ):
-
-            class SubCommandMultipleTypes(BaseSettings, cli_parse_args=True):
-                subcmd: CliSubCommand[Union[SubCmd, SubCmdAlt]]
-
-            SubCommandMultipleTypes()
-
-        with pytest.raises(
             SettingsError, match='subcommand argument SubCommandNotModel.subcmd is not derived from BaseModel'
         ):
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2430,6 +2430,53 @@ def test_cli_source_prioritization(env):
     assert cfg.model_dump() == {'foo': 'FOO FROM ENV'}
 
 
+def test_cli_alias_subcommand_and_positional_args(capsys, monkeypatch):
+    class SubCmd(BaseModel):
+        pos_arg: CliPositionalArg[str] = Field(validation_alias='pos-arg')
+
+    class Cfg(BaseSettings):
+        sub_cmd: CliSubCommand[SubCmd] = Field(validation_alias='sub-cmd')
+
+    cfg = Cfg(**{'sub-cmd': {'pos-arg': 'howdy'}})
+    assert cfg.model_dump() == {'sub_cmd': {'pos_arg': 'howdy'}}
+
+    cfg = Cfg(_cli_parse_args=['sub-cmd', 'howdy'])
+    assert cfg.model_dump() == {'sub_cmd': {'pos_arg': 'howdy'}}
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['example.py', '--help'])
+
+        with pytest.raises(SystemExit):
+            Cfg(_cli_parse_args=True)
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h] {{sub-cmd}} ...
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help  show this help message and exit
+
+subcommands:
+  {{sub-cmd}}
+    sub-cmd
+"""
+        )
+        m.setattr(sys, 'argv', ['example.py', 'sub-cmd', '--help'])
+
+        with pytest.raises(SystemExit):
+            Cfg(_cli_parse_args=True)
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py sub-cmd [-h] POS-ARG
+
+positional arguments:
+  POS-ARG
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help  show this help message and exit
+"""
+        )
+
+
 @pytest.mark.parametrize('avoid_json', [True, False])
 def test_cli_alias_arg(capsys, monkeypatch, avoid_json):
     class Cfg(BaseSettings, cli_avoid_json=avoid_json):
@@ -3088,18 +3135,26 @@ def test_cli_nested_dict_arg():
         cfg = Cfg(_cli_parse_args=args)
 
 
-def test_cli_subcommand_union():
+def test_cli_subcommand_union(capsys, monkeypatch):
     class AlphaCmd(BaseModel):
+        """Alpha Help"""
+
         a: str
 
     class BetaCmd(BaseModel):
+        """Beta Help"""
+
         b: str
 
     class GammaCmd(BaseModel):
+        """Gamma Help"""
+
         g: str
 
-    class Root1(BaseSettings, cli_parse_args=True):
-        subcommand: CliSubCommand[AlphaCmd | BetaCmd | GammaCmd]
+    class Root1(BaseSettings):
+        """Root Help"""
+
+        subcommand: CliSubCommand[AlphaCmd | BetaCmd | GammaCmd] = Field(description='Field Help')
 
     alpha = Root1(_cli_parse_args=['AlphaCmd', '-a=alpha'])
     assert get_subcommand(alpha).model_dump() == {'a': 'alpha'}
@@ -3111,9 +3166,56 @@ def test_cli_subcommand_union():
     assert get_subcommand(gamma).model_dump() == {'g': 'gamma'}
     assert gamma.model_dump() == {'subcommand': {'g': 'gamma'}}
 
-    class Root2(BaseSettings, cli_parse_args=True):
-        subcommand: CliSubCommand[AlphaCmd | GammaCmd]
-        beta: CliSubCommand[BetaCmd]
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['example.py', '--help'])
+
+        with pytest.raises(SystemExit):
+            Root1(_cli_parse_args=True)
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h] {{AlphaCmd,BetaCmd,GammaCmd}} ...
+
+Root Help
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help            show this help message and exit
+
+subcommands:
+  Field Help
+
+  {{AlphaCmd,BetaCmd,GammaCmd}}
+    AlphaCmd
+    BetaCmd
+    GammaCmd
+"""
+        )
+
+        with pytest.raises(SystemExit):
+            Root1(_cli_parse_args=True, _cli_use_class_docs_for_groups=True)
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h] {{AlphaCmd,BetaCmd,GammaCmd}} ...
+
+Root Help
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help            show this help message and exit
+
+subcommands:
+  Field Help
+
+  {{AlphaCmd,BetaCmd,GammaCmd}}
+    AlphaCmd            Alpha Help
+    BetaCmd             Beta Help
+    GammaCmd            Gamma Help
+"""
+        )
+
+    class Root2(BaseSettings):
+        """Root Help"""
+
+        subcommand: CliSubCommand[AlphaCmd | GammaCmd] = Field(description='Field Help')
+        beta: CliSubCommand[BetaCmd] = Field(description='Field Beta Help')
 
     alpha = Root2(_cli_parse_args=['AlphaCmd', '-a=alpha'])
     assert get_subcommand(alpha).model_dump() == {'a': 'alpha'}
@@ -3125,32 +3227,107 @@ def test_cli_subcommand_union():
     assert get_subcommand(gamma).model_dump() == {'g': 'gamma'}
     assert gamma.model_dump() == {'subcommand': {'g': 'gamma'}, 'beta': None}
 
-    class Root3(BaseSettings, cli_parse_args=True):
-        alpha: CliSubCommand[AlphaCmd]
-        beta: CliSubCommand[BetaCmd]
-        gamma: CliSubCommand[GammaCmd]
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['example.py', '--help'])
 
-    alpha = Root3(_cli_parse_args=['alpha', '-a=alpha'])
+        with pytest.raises(SystemExit):
+            Root2(_cli_parse_args=True)
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h] {{AlphaCmd,GammaCmd,beta}} ...
+
+Root Help
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help            show this help message and exit
+
+subcommands:
+  Field Help
+
+  {{AlphaCmd,GammaCmd,beta}}
+    AlphaCmd
+    GammaCmd
+    beta                Field Beta Help
+"""
+        )
+
+        with pytest.raises(SystemExit):
+            Root2(_cli_parse_args=True, _cli_use_class_docs_for_groups=True)
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h] {{AlphaCmd,GammaCmd,beta}} ...
+
+Root Help
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help            show this help message and exit
+
+subcommands:
+  Field Help
+
+  {{AlphaCmd,GammaCmd,beta}}
+    AlphaCmd            Alpha Help
+    GammaCmd            Gamma Help
+    beta                Beta Help
+"""
+        )
+
+    class Root3(BaseSettings):
+        """Root Help"""
+
+        beta: CliSubCommand[BetaCmd] = Field(description='Field Beta Help')
+        subcommand: CliSubCommand[AlphaCmd | GammaCmd] = Field(description='Field Help')
+
+    alpha = Root3(_cli_parse_args=['AlphaCmd', '-a=alpha'])
     assert get_subcommand(alpha).model_dump() == {'a': 'alpha'}
-    assert alpha.model_dump() == {
-        'alpha': {'a': 'alpha'},
-        'beta': None,
-        'gamma': None,
-    }
+    assert alpha.model_dump() == {'subcommand': {'a': 'alpha'}, 'beta': None}
     beta = Root3(_cli_parse_args=['beta', '-b=beta'])
     assert get_subcommand(beta).model_dump() == {'b': 'beta'}
-    assert beta.model_dump() == {
-        'alpha': None,
-        'beta': {'b': 'beta'},
-        'gamma': None,
-    }
-    gamma = Root3(_cli_parse_args=['gamma', '-g=gamma'])
+    assert beta.model_dump() == {'subcommand': None, 'beta': {'b': 'beta'}}
+    gamma = Root3(_cli_parse_args=['GammaCmd', '-g=gamma'])
     assert get_subcommand(gamma).model_dump() == {'g': 'gamma'}
-    assert gamma.model_dump() == {
-        'alpha': None,
-        'beta': None,
-        'gamma': {'g': 'gamma'},
-    }
+    assert gamma.model_dump() == {'subcommand': {'g': 'gamma'}, 'beta': None}
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['example.py', '--help'])
+
+        with pytest.raises(SystemExit):
+            Root3(_cli_parse_args=True)
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h] {{beta,AlphaCmd,GammaCmd}} ...
+
+Root Help
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help            show this help message and exit
+
+subcommands:
+  {{beta,AlphaCmd,GammaCmd}}
+    beta                Field Beta Help
+    AlphaCmd
+    GammaCmd
+"""
+        )
+
+        with pytest.raises(SystemExit):
+            Root3(_cli_parse_args=True, _cli_use_class_docs_for_groups=True)
+        assert (
+            capsys.readouterr().out
+            == f"""usage: example.py [-h] {{beta,AlphaCmd,GammaCmd}} ...
+
+Root Help
+
+{ARGPARSE_OPTIONS_TEXT}:
+  -h, --help            show this help message and exit
+
+subcommands:
+  {{beta,AlphaCmd,GammaCmd}}
+    beta                Beta Help
+    AlphaCmd            Alpha Help
+    GammaCmd            Gamma Help
+"""
+        )
 
 
 def test_cli_subcommand_with_positionals():
@@ -3354,7 +3531,17 @@ def test_cli_annotation_exceptions(monkeypatch):
             SubCommandHasDefault()
 
         with pytest.raises(
-            SettingsError, match='subcommand argument SubCommandNotModel.subcmd is not derived from BaseModel'
+            SettingsError,
+            match='subcommand argument SubCommandMultipleTypes.subcmd has type not derived from BaseModel',
+        ):
+
+            class SubCommandMultipleTypes(BaseSettings, cli_parse_args=True):
+                subcmd: CliSubCommand[Union[SubCmd, str]]
+
+            SubCommandMultipleTypes()
+
+        with pytest.raises(
+            SettingsError, match='subcommand argument SubCommandNotModel.subcmd has type not derived from BaseModel'
         ):
 
             class SubCommandNotModel(BaseSettings, cli_parse_args=True):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2500,20 +2500,20 @@ def test_cli_alias_nested_arg(capsys, monkeypatch, avoid_json):
 
 
 def test_cli_alias_exceptions(capsys, monkeypatch):
-    with pytest.raises(SettingsError, match='subcommand argument BadCliSubCommand.foo has an alias'):
+    with pytest.raises(SettingsError, match='subcommand argument BadCliSubCommand.foo has multiple aliases'):
 
         class SubCmd(BaseModel):
             v0: int
 
         class BadCliSubCommand(BaseSettings):
-            foo: CliSubCommand[SubCmd] = Field(alias='bar')
+            foo: CliSubCommand[SubCmd] = Field(validation_alias=AliasChoices('bar', 'boo'))
 
         BadCliSubCommand(_cli_parse_args=True)
 
-    with pytest.raises(SettingsError, match='positional argument BadCliPositionalArg.foo has an alias'):
+    with pytest.raises(SettingsError, match='positional argument BadCliPositionalArg.foo has multiple alias'):
 
         class BadCliPositionalArg(BaseSettings):
-            foo: CliPositionalArg[int] = Field(alias='bar')
+            foo: CliPositionalArg[int] = Field(validation_alias=AliasChoices('bar', 'boo'))
 
         BadCliPositionalArg(_cli_parse_args=True)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3166,7 +3166,7 @@ def test_cli_subcommand_union(capsys, monkeypatch):
     class Root1(BaseSettings):
         """Root Help"""
 
-        subcommand: CliSubCommand[AlphaCmd | BetaCmd | GammaCmd] = Field(description='Field Help')
+        subcommand: CliSubCommand[Union[AlphaCmd, BetaCmd, GammaCmd]] = Field(description='Field Help')
 
     alpha = Root1(_cli_parse_args=['AlphaCmd', '-a=alpha'])
     assert get_subcommand(alpha).model_dump() == {'a': 'alpha'}
@@ -3226,7 +3226,7 @@ subcommands:
     class Root2(BaseSettings):
         """Root Help"""
 
-        subcommand: CliSubCommand[AlphaCmd | GammaCmd] = Field(description='Field Help')
+        subcommand: CliSubCommand[Union[AlphaCmd, GammaCmd]] = Field(description='Field Help')
         beta: CliSubCommand[BetaCmd] = Field(description='Field Beta Help')
 
     alpha = Root2(_cli_parse_args=['AlphaCmd', '-a=alpha'])
@@ -3288,7 +3288,7 @@ subcommands:
         """Root Help"""
 
         beta: CliSubCommand[BetaCmd] = Field(description='Field Beta Help')
-        subcommand: CliSubCommand[AlphaCmd | GammaCmd] = Field(description='Field Help')
+        subcommand: CliSubCommand[Union[AlphaCmd, GammaCmd]] = Field(description='Field Help')
 
     alpha = Root3(_cli_parse_args=['AlphaCmd', '-a=alpha'])
     assert get_subcommand(alpha).model_dump() == {'a': 'alpha'}


### PR DESCRIPTION
Adds union and alias support for `CliSubCommand` and `CliPositionalArg` annotations.

See [updated subcommand docs](https://github.com/pydantic/pydantic-settings/blob/76fd025a8888119e4de4228fff09976afd4bdf80/docs/index.md#subcommands-and-positional-arguments) for details.