### PR TITLE
Add AwsSystemsManagerParameterStoreSettingsSource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ refresh-lockfiles:
 	find requirements/ -name '*.txt' ! -name 'all.txt' -type f -delete
 	pip-compile -q --no-emit-index-url --resolver backtracking -o requirements/linting.txt requirements/linting.in
 	pip-compile -q --no-emit-index-url --resolver backtracking -o requirements/testing.txt requirements/testing.in
-	pip-compile -q --no-emit-index-url --resolver backtracking --extra toml --extra yaml --extra azure-key-vault -o requirements/pyproject.txt pyproject.toml
+	pip-compile -q --no-emit-index-url --resolver backtracking --extra toml --extra yaml --extra azure-key-vault --extra aws -o requirements/pyproject.txt pyproject.toml
 	pip install --dry-run -r requirements/all.txt
 
 .PHONY: format

--- a/docs/index.md
+++ b/docs/index.md
@@ -1334,7 +1334,7 @@ class SubModel(BaseModel):
     a: str
 
 
-class AzureKeyVaultSettings(BaseSettings):
+class AwsParamStoreSettings(BaseSettings):
     foo: str
     bar: int
     sub: SubModel

--- a/docs/index.md
+++ b/docs/index.md
@@ -1306,6 +1306,63 @@ class AzureKeyVaultSettings(BaseSettings):
         )
 ```
 
+## AWS Systems Manager Parameter Store
+
+You must set the following parameters:
+
+- `ssm_client`: An initialized [`boto3` SSM Client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html#client).
+
+Optionally, you may specify the following parameters:
+
+- `ssm_path`: The hierarchy for the parameter. Hierarchies start with a forward slash (/). The hierarchy is the parameter name except the last part of the parameter. Under the hood, we make use of the [`get_parameters_by_path` method](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm/client/get_parameters_by_path.html) to recursively retrieve all parameters within the a specified path hierarchy.
+
+```py
+import os
+from typing import Tuple, Type
+
+import boto3
+from pydantic import BaseModel
+
+from pydantic_settings import (
+    AwsSystemsManagerParameterStoreSettingsSource,
+    BaseSettings,
+    PydanticBaseSettingsSource,
+)
+
+
+class SubModel(BaseModel):
+    a: str
+
+
+class AzureKeyVaultSettings(BaseSettings):
+    foo: str
+    bar: int
+    sub: SubModel
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        client = boto3.client('ssm')
+        ssm_param_store_settings = AwsSystemsManagerParameterStoreSettingsSource(
+            settings_cls,
+            ssm_client=client,
+            ssm_path=os.environ.get('SSM_PREFIX', '/api/dev/'),
+        )
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            file_secret_settings,
+            ssm_param_store_settings,
+        )
+``` -->
+
 ## Other settings source
 
 Other settings sources are available for common configuration files:

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -59,6 +59,11 @@ if TYPE_CHECKING:
     import tomli
     import yaml
 
+    try:
+        from mypy_boto3_ssm import SSMClient
+    except ImportError:
+        pass
+
     from pydantic_settings.main import BaseSettings
 else:
     yaml = None
@@ -2015,13 +2020,13 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
 
 
 class AwsSystemsManagerParameterStoreSettingsSource(EnvSettingsSource):
-    _ssm_client: 'SSMClient'  # type: ignore
+    _ssm_client: 'SSMClient'
     _ssm_path: str
 
     def __init__(
         self,
         settings_cls: type[BaseSettings],
-        ssm_client: 'SSMClient',  # type: ignore
+        ssm_client: 'SSMClient',
         ssm_path: str = '/',
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     try:
         from mypy_boto3_ssm import SSMClient
     except ImportError:
-        pass
+        SSMClient = None
 
     from pydantic_settings.main import BaseSettings
 else:
@@ -2020,13 +2020,13 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
 
 
 class AwsSystemsManagerParameterStoreSettingsSource(EnvSettingsSource):
-    _ssm_client: 'SSMClient'
+    _ssm_client: SSMClient
     _ssm_path: str
 
     def __init__(
         self,
         settings_cls: type[BaseSettings],
-        ssm_client: 'SSMClient',
+        ssm_client: SSMClient,
         ssm_path: str = '/',
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dynamic = ['version']
 yaml = ["pyyaml>=6.0.1"]
 toml = ["tomli>=2.0.1"]
 azure-key-vault = ["azure-keyvault-secrets>=4.8.0", "azure-identity>=1.16.0"]
+aws = ["boto3>=1.35.0", "boto3-stubs[ssm]>=1.35.0"]
 
 [project.urls]
 Homepage = 'https://github.com/pydantic/pydantic-settings'

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -32,12 +32,6 @@ try:
 except ImportError:
     azure_key_vault = False
 
-try:
-    aws = True
-    import boto3
-except ImportError:
-    aws = False
-
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -219,7 +213,6 @@ class TestAzureKeyVaultSettingsSource:
         return key_vault_secret
 
 
-@pytest.mark.skipif(not aws, reason="boto3 is not installed")
 class TestAwsSystemsManagerParameterStoreSettingsSource:
     """Test AwsSystemsManagerParameterStoreSettingsSource."""
 


### PR DESCRIPTION
## What I'm adding

In a spirit similar to #175, this PR adds support for [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).  The name is a bit of a mouthful, but I errored on the side of verbosity and named the source `AwsSystemsManagerParameterStoreSettingsSource`.  Something like `AwsSsmParameterStoreSettingsSource` might be better.

For Pydantic v1, we have been using https://github.com/developmentseed/pydantic-ssm-settings/ on a number of projects, however having the functionality included in Pydantic Settings core seems preferred.

## How I did it

I more or less copied the pattern of `AzureKeyVaultSettingsSource`.

### Uncertainties

The testing mocks out the AWS SSM Client, however typically I use something like [moto](https://github.com/getmoto/moto) to mock out the AWS services when testing.  I wasn't sure about this project's appetite for the added test dependency.

Additionally, I was a bit uncertain about typing the `SSMClient`.  Projects like [boto3-stubs](https://github.com/youtype/mypy_boto3_builder) provide such types, however I wasn't sure about the project's appetite for adding this dependency.