### PR TITLE
Fix bug in dotenv source when there is env with and without prefix

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -982,7 +982,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
         # As `extra` config is allowed in dotenv settings source, We have to
         # update data with extra env variables from dotenv file.
         for env_name, env_value in self.env_vars.items():
-            if not env_value:
+            if not env_value or env_name in data:
                 continue
             env_used = False
             for field_name, field in self.settings_cls.model_fields.items():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2715,3 +2715,20 @@ def test_dotenv_optional_nested(tmp_path):
 
     s = Settings()
     assert s.model_dump() == {'not_nested': 'works', 'NESTED': {'A': 'fails', 'b': 2}}
+
+
+def test_dotenv_env_prefix_env_without_prefix(tmp_path):
+    p = tmp_path / '.env'
+    p.write_text('test_foo=test-foo\nfoo=foo')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(
+            env_file=p,
+            env_prefix='TEST_',
+            extra='ignore',
+        )
+
+        foo: str
+
+    s = Settings()
+    assert s.model_dump() == {'foo': 'test-foo'}


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic-settings/issues/437