### PR TITLE
Fixes #452 - Adding support for populate_by_name

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -445,10 +445,12 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                         )
             else:  # string validation alias
                 field_info.append((v_alias, self._apply_case_sensitive(v_alias), False))
-        elif origin_is_union(get_origin(field.annotation)) and _union_is_complex(field.annotation, field.metadata):
-            field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), True))
-        else:
-            field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), False))
+
+        if not v_alias or self.config.get('populate_by_name', False):
+            if origin_is_union(get_origin(field.annotation)) and _union_is_complex(field.annotation, field.metadata):
+                field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), True))
+            else:
+                field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), False))
 
         return field_info
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -188,7 +188,7 @@ def test_populate_by_name_with_alias_path_when_using_name(env):
         pytest.param({'pomme': 'pomme-chosen', 'manzano': 'manzano-chosen'}, 'pomme-chosen', id='pomme-priority'),
     ],
 )
-def test_populate_by_name_with_alias_choices_when_using_alias(env, env_vars: dict[str, str], expected_value: str):
+def test_populate_by_name_with_alias_choices_when_using_alias(env, env_vars: Dict[str, str], expected_value: str):
     for k, v in env_vars.items():
         env.set(k, v)
 


### PR DESCRIPTION
Adds support for `populate_by_name` model config and a handful of tests to validate this functionality.

- I wasn't 100% sure on whether the preference was to modify existing tests (which, for example, ensure that populate-by-name is _not_ happening), but I opted to create new tests for this code path specifically.
- I only added tests for env and dotenv.  Let me know if more coverage is needed on some of the alternative options.