### PR TITLE
Fix `test_protected_namespace_defaults` with -Wdefault

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2175,7 +2175,7 @@ def test_protected_namespace_defaults():
             model_prefixed_field: str
 
     # pydantic-settings default
-    with pytest.raises(
+    with pytest.warns(
         UserWarning, match='Field "settings_prefixed_field" in Model1 has conflict with protected namespace "settings_"'
     ):
 


### PR DESCRIPTION
This test failed with `pytest -Wdefault`, which [distros usually enable][1] for downstream testing to avoid surprise failures.

For example:
```sh
$ pytest tests/test_settings.py::test_protected_namespace_defaults -Wdefault
```

Use proper `pytest.warns()` method instead of incorrect `pytest.raises()`.

[1]: https://mgorny.pl/articles/downstream-testing-python-packages.html#assuming-werror-catching-warnings-as-exceptions