### PR TITLE
Use the class name in the `__repr__` implementations

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -349,7 +349,9 @@ class DefaultSettingsSource(PydanticBaseSettingsSource):
         return self.defaults
 
     def __repr__(self) -> str:
-        return f'DefaultSettingsSource(nested_model_default_partial_update={self.nested_model_default_partial_update})'
+        return (
+            f'{self.__class__.__name__}(nested_model_default_partial_update={self.nested_model_default_partial_update})'
+        )
 
 
 class InitSettingsSource(PydanticBaseSettingsSource):
@@ -383,7 +385,7 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         )
 
     def __repr__(self) -> str:
-        return f'InitSettingsSource(init_kwargs={self.init_kwargs!r})'
+        return f'{self.__class__.__name__}(init_kwargs={self.init_kwargs!r})'
 
 
 class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
@@ -673,7 +675,7 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
         return None, field_key, value_is_complex
 
     def __repr__(self) -> str:
-        return f'SecretsSettingsSource(secrets_dir={self.secrets_dir!r})'
+        return f'{self.__class__.__name__}(secrets_dir={self.secrets_dir!r})'
 
 
 class EnvSettingsSource(PydanticBaseEnvSettingsSource):
@@ -898,7 +900,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
 
     def __repr__(self) -> str:
         return (
-            f'EnvSettingsSource(env_nested_delimiter={self.env_nested_delimiter!r}, '
+            f'{self.__class__.__name__}(env_nested_delimiter={self.env_nested_delimiter!r}, '
             f'env_prefix_len={self.env_prefix_len!r})'
         )
 
@@ -1014,7 +1016,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
 
     def __repr__(self) -> str:
         return (
-            f'DotEnvSettingsSource(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
+            f'{self.__class__.__name__}(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
             f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r})'
         )
 
@@ -1952,7 +1954,7 @@ class JsonConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             return json.load(json_file)
 
     def __repr__(self) -> str:
-        return f'JsonConfigSettingsSource(json_file={self.json_file_path})'
+        return f'{self.__class__.__name__}(json_file={self.json_file_path})'
 
 
 class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
@@ -1977,7 +1979,7 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             return tomllib.load(toml_file)
 
     def __repr__(self) -> str:
-        return f'TomlConfigSettingsSource(toml_file={self.toml_file_path})'
+        return f'{self.__class__.__name__}(toml_file={self.toml_file_path})'
 
 
 class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSource):
@@ -2052,7 +2054,7 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             return yaml.safe_load(yaml_file) or {}
 
     def __repr__(self) -> str:
-        return f'YamlConfigSettingsSource(yaml_file={self.yaml_file_path})'
+        return f'{self.__class__.__name__}(yaml_file={self.yaml_file_path})'
 
 
 class AzureKeyVaultMapping(Mapping[str, Optional[str]]):
@@ -2116,7 +2118,7 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
         return AzureKeyVaultMapping(secret_client)
 
     def __repr__(self) -> str:
-        return f'AzureKeyVaultSettingsSource(url={self._url!r}, ' f'env_nested_delimiter={self.env_nested_delimiter!r})'
+        return f'{self.__class__.__name__}(url={self._url!r}, ' f'env_nested_delimiter={self.env_nested_delimiter!r})'
 
 
 def _get_env_var_key(key: str, case_sensitive: bool = False) -> str:

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1951,6 +1951,9 @@ class JsonConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         with open(file_path, encoding=self.json_file_encoding) as json_file:
             return json.load(json_file)
 
+    def __repr__(self) -> str:
+        return f'JsonConfigSettingsSource(json_file={self.json_file_path})'
+
 
 class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
     """
@@ -1972,6 +1975,9 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             if sys.version_info < (3, 11):
                 return tomli.load(toml_file)
             return tomllib.load(toml_file)
+
+    def __repr__(self) -> str:
+        return f'TomlConfigSettingsSource(toml_file={self.toml_file_path})'
 
 
 class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSource):
@@ -2044,6 +2050,9 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         import_yaml()
         with open(file_path, encoding=self.yaml_file_encoding) as yaml_file:
             return yaml.safe_load(yaml_file) or {}
+
+    def __repr__(self) -> str:
+        return f'YamlConfigSettingsSource(yaml_file={self.yaml_file_path})'
 
 
 class AzureKeyVaultMapping(Mapping[str, Optional[str]]):

--- a/tests/test_source_json.py
+++ b/tests/test_source_json.py
@@ -3,6 +3,7 @@ Test pydantic_settings.JsonConfigSettingsSource.
 """
 
 import json
+from pathlib import Path
 from typing import Tuple, Type, Union
 
 from pydantic import BaseModel
@@ -13,6 +14,11 @@ from pydantic_settings import (
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
+
+
+def test_repr() -> None:
+    source = JsonConfigSettingsSource(BaseSettings(), Path('config.json'))
+    assert repr(source) == 'JsonConfigSettingsSource(json_file=config.json)'
 
 
 def test_json_file(tmp_path):

--- a/tests/test_source_toml.py
+++ b/tests/test_source_toml.py
@@ -3,6 +3,7 @@ Test pydantic_settings.TomlConfigSettingsSource.
 """
 
 import sys
+from pathlib import Path
 from typing import Tuple, Type
 
 import pytest
@@ -19,6 +20,11 @@ try:
     import tomli
 except ImportError:
     tomli = None
+
+
+def test_repr() -> None:
+    source = TomlConfigSettingsSource(BaseSettings(), Path('config.toml'))
+    assert repr(source) == 'TomlConfigSettingsSource(toml_file=config.toml)'
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')

--- a/tests/test_source_yaml.py
+++ b/tests/test_source_yaml.py
@@ -2,6 +2,7 @@
 Test pydantic_settings.YamlConfigSettingsSource.
 """
 
+from pathlib import Path
 from typing import Tuple, Type, Union
 
 import pytest
@@ -18,6 +19,11 @@ try:
     import yaml
 except ImportError:
     yaml = None
+
+
+def test_repr() -> None:
+    source = YamlConfigSettingsSource(BaseSettings(), Path('config.yaml'))
+    assert repr(source) == 'YamlConfigSettingsSource(yaml_file=config.yaml)'
 
 
 @pytest.mark.skipif(yaml, reason='PyYAML is installed')


### PR DESCRIPTION
Previously, the `__repr__()` method of those settings source classes was inherited from InitSettingsSource's thus returning a misleading 'InitSettingsSource(init_kwargs={})'. We here define a specific `__repr__()` method implementation for classes using a config file (json, toml, yaml).