### PR TITLE
Fix alias resolution to use preferred key.

### DIFF
--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -10,6 +10,7 @@ import pytest
 import typing_extensions
 from pydantic import (
     AliasChoices,
+    AliasGenerator,
     AliasPath,
     BaseModel,
     ConfigDict,
@@ -107,7 +108,7 @@ class CliDummyParser(BaseModel, arbitrary_types_allowed=True):
         return self.parser.parse_args(*args, **kwargs)
 
 
-def test_validation_alias_with_cli_prefix():
+def test_cli_validation_alias_with_cli_prefix():
     class Settings(BaseSettings, cli_exit_on_error=False):
         foobar: str = Field(validation_alias='foo')
 
@@ -117,6 +118,36 @@ def test_validation_alias_with_cli_prefix():
         CliApp.run(Settings, cli_args=['--foo', 'bar'])
 
     assert CliApp.run(Settings, cli_args=['--p.foo', 'bar']).foobar == 'bar'
+
+
+@pytest.mark.parametrize(
+    'alias_generator',
+    [
+        AliasGenerator(validation_alias=lambda s: AliasChoices(s, s.replace('_', '-'))),
+        AliasGenerator(validation_alias=lambda s: AliasChoices(s.replace('_', '-'), s)),
+    ],
+)
+def test_cli_alias_resolution_consistency_with_env(env, alias_generator):
+    class SubModel(BaseModel):
+        v1: str = 'model default'
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(
+            env_nested_delimiter='__',
+            nested_model_default_partial_update=True,
+            alias_generator=alias_generator,
+        )
+
+        sub_model: SubModel = SubModel(v1='top default')
+
+    assert CliApp.run(Settings, cli_args=[]).model_dump() == {'sub_model': {'v1': 'top default'}}
+
+    env.set('SUB_MODEL__V1', 'env default')
+    assert CliApp.run(Settings, cli_args=[]).model_dump() == {'sub_model': {'v1': 'env default'}}
+
+    assert CliApp.run(Settings, cli_args=['--sub-model.v1=cli default']).model_dump() == {
+        'sub_model': {'v1': 'cli default'}
+    }
 
 
 def test_cli_nested_arg():


### PR DESCRIPTION
Fixes alias resolution order for `EnvSettingsSource` and `SecretsSettingsSource`.

Issue was first observed in #469. See [comment](https://github.com/pydantic/pydantic-settings/issues/469#issuecomment-2491494347) for details.