### PR TITLE
Move preferred alias resolution to private method

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -565,6 +565,21 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
     def _get_resolved_field_value(
         self, field: FieldInfo, field_name: str, use_preferred_alias: bool = False
     ) -> tuple[Any, str, bool]:
+        """
+        Gets the value, the key for model creation, and a flag to determine whether value is complex.
+
+        Note:
+            In V3, this method should either be made public, or, this method should be removed and the
+            abstract method get_field_value should be updated to include a "use_preferred_alias" flag.
+
+        Args:
+            field: The field.
+            field_name: The field name.
+            use_preferred_alias: Use the preferred alias name when resolving key. Defaults to `False`.
+
+        Returns:
+            A tuple that contains the value, key and a flag to determine whether value is complex.
+        """
         field_value, field_key, value_is_complex = self.get_field_value(field, field_name)
         if not (value_is_complex or (self.config.get('populate_by_name', False) and (field_key == field_name))):
             field_infos = self._extract_field_info(field, field_name)

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -562,9 +562,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
         return values
 
-    def _get_resolved_field_value(
-        self, field: FieldInfo, field_name: str, use_preferred_alias: bool = False
-    ) -> tuple[Any, str, bool]:
+    def _get_resolved_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         """
         Gets the value, the key for model creation, and a flag to determine whether value is complex.
 
@@ -575,7 +573,6 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         Args:
             field: The field.
             field_name: The field name.
-            use_preferred_alias: Use the preferred alias name when resolving key. Defaults to `False`.
 
         Returns:
             A tuple that contains the value, key and a flag to determine whether value is complex.
@@ -592,9 +589,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
         for field_name, field in self.settings_cls.model_fields.items():
             try:
-                field_value, field_key, value_is_complex = self._get_resolved_field_value(
-                    field, field_name, use_preferred_alias=True
-                )
+                field_value, field_key, value_is_complex = self._get_resolved_field_value(field, field_name)
             except Exception as e:
                 raise SettingsError(
                     f'error getting value for field "{field_name}" from source "{self.__class__.__name__}"'

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -564,7 +564,8 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
     def _get_resolved_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         """
-        Gets the value, the key for model creation, and a flag to determine whether value is complex.
+        Gets the value, the preferred alias key for model creation, and a flag to determine whether value
+        is complex.
 
         Note:
             In V3, this method should either be made public, or, this method should be removed and the
@@ -575,7 +576,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
             field_name: The field name.
 
         Returns:
-            A tuple that contains the value, key and a flag to determine whether value is complex.
+            A tuple that contains the value, preferred key and a flag to determine whether value is complex.
         """
         field_value, field_key, value_is_complex = self.get_field_value(field, field_name)
         if not (value_is_complex or (self.config.get('populate_by_name', False) and (field_key == field_name))):


### PR DESCRIPTION
Fixes #504 

Reverts #481 and instead moves preferred alias resolution into [private method](https://github.com/pydantic/pydantic-settings/pull/507/files#diff-b4b68ace3cb0cf2820d1d882735748b675a379c39463ccc89700a9618a80a2a2R565).

If desired, the private method could be made public in V3.