### PR TITLE
Don't explode env vars if env_nested_delimiter is empty

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -908,6 +908,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         Returns:
             A dictionary contains extracted values from nested env values.
         """
+        if not self.env_nested_delimiter:
+            return {}
+
         is_dict = lenient_issubclass(get_origin(field.annotation), dict)
 
         prefixes = [


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic-settings/issues/535 