### PR TITLE
[feature] Optionally Include settings source in ValidationError

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -421,7 +421,7 @@ class BaseSettings(BaseModel):
                     if not source_state:
                         continue
                     try:
-                        _ = super(BaseSettings, self).__init__(**source_state)
+                        _ = super().__init__(**source_state)
                     except ValidationError as e:
                         line_errors = json.loads(e.json())
                         for line in line_errors:
@@ -436,7 +436,7 @@ class BaseSettings(BaseModel):
 
             if validate_each_source:
                 try:
-                    _ = super(BaseSettings, self).__init__(**state)
+                    _ = super().__init__(**state)
                 except ValidationError as e:
                     line_errors = json.loads(e.json())
                     for line in line_errors:

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -34,6 +34,7 @@ from .sources import (
 
 T = TypeVar('T')
 
+
 class SettingsConfigDict(ConfigDict, total=False):
     case_sensitive: bool
     nested_model_default_partial_update: bool | None
@@ -259,7 +260,7 @@ class BaseSettings(BaseModel):
         _cli_ignore_unknown_args: bool | None = None,
         _cli_kebab_case: bool | None = None,
         _secrets_dir: PathType | None = None,
-        _validate_each_source: bool | None = None
+        _validate_each_source: bool | None = None,
     ) -> dict[str, Any]:
         # Determine settings config values
         case_sensitive = _case_sensitive if _case_sensitive is not None else self.model_config.get('case_sensitive')
@@ -335,7 +336,11 @@ class BaseSettings(BaseModel):
 
         secrets_dir = _secrets_dir if _secrets_dir is not None else self.model_config.get('secrets_dir')
 
-        validate_each_source = _validate_each_source if _validate_each_source is not None else self.model_config.get('validate_each_source')
+        validate_each_source = (
+            _validate_each_source
+            if _validate_each_source is not None
+            else self.model_config.get('validate_each_source')
+        )
 
         # Configure built-in sources
         default_settings = DefaultSettingsSource(
@@ -440,8 +445,7 @@ class BaseSettings(BaseModel):
 
                 if all_line_errors:
                     raise ValidationError.from_exception_data(
-                        title=self.__class__.__name__,
-                        line_errors=all_line_errors
+                        title=self.__class__.__name__, line_errors=all_line_errors
                     )
 
             return state

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -425,11 +425,11 @@ class BaseSettings(BaseModel):
                     except ValidationError as e:
                         line_errors = json.loads(e.json())
                         for line in line_errors:
-                            if line.get("type", "") == "missing":
+                            if line.get("type", "") == 'missing':
                                 continue
                             line['loc'] = [source_name] + line['loc']
-                            ctx = line.get("ctx", {})
-                            ctx["source"] = source_name
+                            ctx = line.get('ctx', {})
+                            ctx['source'] = source_name
                             line['ctx'] = ctx
                             all_line_errors.append(line)
 
@@ -439,7 +439,7 @@ class BaseSettings(BaseModel):
                 except ValidationError as e:
                     line_errors = json.loads(e.json())
                     for line in line_errors:
-                        if line.get("type", "") != "missing":
+                        if line.get('type', '') != 'missing':
                             continue
                         all_line_errors.append(line)
 

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -335,7 +335,7 @@ class BaseSettings(BaseModel):
 
         secrets_dir = _secrets_dir if _secrets_dir is not None else self.model_config.get('secrets_dir')
 
-        validate_each_source = _validate_each_source if _validate_each_source is not None else self.model_config.get("validate_each_source")
+        validate_each_source = _validate_each_source if _validate_each_source is not None else self.model_config.get('validate_each_source')
 
         # Configure built-in sources
         default_settings = DefaultSettingsSource(

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -428,6 +428,9 @@ class BaseSettings(BaseModel):
                             if line.get("type", "") == "missing":
                                 continue
                             line['loc'] = [source_name] + line['loc']
+                            ctx = line.get("ctx", {})
+                            ctx["source"] = source_name
+                            line['ctx'] = ctx
                             details = InitErrorDetails(**line)
                             all_line_errors.append(details)
 

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -431,8 +431,7 @@ class BaseSettings(BaseModel):
                             ctx = line.get("ctx", {})
                             ctx["source"] = source_name
                             line['ctx'] = ctx
-                            details = InitErrorDetails(**line)
-                            all_line_errors.append(details)
+                            all_line_errors.append(line)
 
             if validate_each_source:
                 try:
@@ -442,8 +441,7 @@ class BaseSettings(BaseModel):
                     for line in line_errors:
                         if line.get("type", "") != "missing":
                             continue
-                        details = InitErrorDetails(**line)
-                        all_line_errors.append(details)
+                        all_line_errors.append(line)
 
             if all_line_errors and validate_each_source:
                 raise ValidationError.from_exception_data(

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -426,14 +426,14 @@ class BaseSettings(BaseModel):
                         line_errors = json.loads(e.json())
                         for line in line_errors:
                             ctx = line.get("ctx", {})
-                            ctx = {"source": source_name}
+                            ctx["source"] = source_name
                             line['ctx'] = ctx
                         all_line_errors.extend(line_errors)
 
             if all_line_errors and validate_each_source:
                 raise ValidationError.from_exception_data(
                     title=self.__class__.__name__,
-                    line_errors=[InitErrorDetails(**l) for l in  all_line_errors],
+                    line_errors=[InitErrorDetails(**l) for l in all_line_errors],
                     input_type="python"
                 )
             return state

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -427,9 +427,7 @@ class BaseSettings(BaseModel):
                         for line in line_errors:
                             if line.get("type", "") == "missing":
                                 continue
-                            ctx = line.get("ctx", {})
-                            ctx["source"] = source_name
-                            line['ctx'] = ctx
+                            line['loc'] = [source_name] + line['loc']
                             details = InitErrorDetails(**line)
                             all_line_errors.append(details)
 

--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1785,11 +1785,13 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                         if isinstance(group, dict):
                             group = self._add_group(parser, **group)
                         added_args += list(arg_names)
-                        self._add_argument(group, *(f'{flag_prefix[:len(name)]}{name}' for name in arg_names), **kwargs)
+                        self._add_argument(
+                            group, *(f'{flag_prefix[: len(name)]}{name}' for name in arg_names), **kwargs
+                        )
                     else:
                         added_args += list(arg_names)
                         self._add_argument(
-                            parser, *(f'{flag_prefix[:len(name)]}{name}' for name in arg_names), **kwargs
+                            parser, *(f'{flag_prefix[: len(name)]}{name}' for name in arg_names), **kwargs
                         )
 
         self._add_parser_alias_paths(parser, alias_path_args, added_args, arg_prefix, subcommand_prefix, group)
@@ -2246,7 +2248,7 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
         return AzureKeyVaultMapping(secret_client)
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}(url={self._url!r}, ' f'env_nested_delimiter={self.env_nested_delimiter!r})'
+        return f'{self.__class__.__name__}(url={self._url!r}, env_nested_delimiter={self.env_nested_delimiter!r})'
 
 
 def _get_env_var_key(key: str, case_sensitive: bool = False) -> str:

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -58,18 +58,21 @@ def test_line_errors_from_source(monkeypatch, tmp_path):
 
     assert exc_info.value.errors(include_url=False) == [
         {
+            'ctx': {'source': 'JsonConfigSettingsSource'},
             'input': 0,
             'loc': ('JsonConfigSettingsSource', 'foobar',),
             'msg': 'Input should be a valid string',
             'type': 'string_type',
         },
         {
+            'ctx': {'source': 'EnvSettingsSource'},
             'input': 'a',
             'loc': ('EnvSettingsSource', 'nested', 'nested_field'),
             'msg': 'Input should be a valid integer, unable to parse string as an integer',
             'type': 'int_parsing'
         },
         {
+            'ctx': {'source': 'InitSettingsSource'},
             'input': 0,
             'loc': ('InitSettingsSource', 'null_field',),
             'msg': 'Input should be a valid string',

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -29,10 +29,7 @@ def test_line_errors_from_source(monkeypatch, tmp_path):
 
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(
-            json_file=p,
-            env_prefix='SETTINGS_',
-            env_nested_delimiter='__',
-            validate_each_source=True
+            json_file=p, env_prefix='SETTINGS_', env_nested_delimiter='__', validate_each_source=True
         )
         foobar: str
         nested: Nested
@@ -48,11 +45,7 @@ def test_line_errors_from_source(monkeypatch, tmp_path):
             dotenv_settings: PydanticBaseSettingsSource,
             file_secret_settings: PydanticBaseSettingsSource,
         ) -> Tuple[PydanticBaseSettingsSource, ...]:
-            return (
-                JsonConfigSettingsSource(settings_cls),
-                env_settings,
-                init_settings
-            )
+            return (JsonConfigSettingsSource(settings_cls), env_settings, init_settings)
 
     with pytest.raises(ValidationError) as exc_info:
         _ = Settings(null_field=0)
@@ -61,7 +54,10 @@ def test_line_errors_from_source(monkeypatch, tmp_path):
         {
             'ctx': {'source': 'JsonConfigSettingsSource'},
             'input': 0,
-            'loc': ('JsonConfigSettingsSource', 'foobar',),
+            'loc': (
+                'JsonConfigSettingsSource',
+                'foobar',
+            ),
             'msg': 'Input should be a valid string',
             'type': 'string_type',
         },
@@ -70,19 +66,22 @@ def test_line_errors_from_source(monkeypatch, tmp_path):
             'input': 'a',
             'loc': ('EnvSettingsSource', 'nested', 'nested_field'),
             'msg': 'Input should be a valid integer, unable to parse string as an integer',
-            'type': 'int_parsing'
+            'type': 'int_parsing',
         },
         {
             'ctx': {'source': 'InitSettingsSource'},
             'input': 0,
-            'loc': ('InitSettingsSource', 'null_field',),
+            'loc': (
+                'InitSettingsSource',
+                'null_field',
+            ),
             'msg': 'Input should be a valid string',
-            'type': 'string_type'
+            'type': 'string_type',
         },
         {
             'input': {'foobar': 0, 'nested': {'nested_field': 'a'}, 'null_field': None},
             'loc': ('extra',),
             'msg': 'Field required',
-            'type': 'missing'
-        }
+            'type': 'missing',
+        },
     ]

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -58,23 +58,20 @@ def test_line_errors_from_source(monkeypatch, tmp_path):
 
     assert exc_info.value.errors(include_url=False) == [
         {
-            'ctx': {'source': 'JsonConfigSettingsSource'},
             'input': 0,
-            'loc': ('foobar',),
+            'loc': ('JsonConfigSettingsSource', 'foobar',),
             'msg': 'Input should be a valid string',
             'type': 'string_type',
         },
         {
-            'ctx': {'source': 'EnvSettingsSource'},
             'input': 'a',
-            'loc': ('nested', 'nested_field'),
+            'loc': ('EnvSettingsSource', 'nested', 'nested_field'),
             'msg': 'Input should be a valid integer, unable to parse string as an integer',
             'type': 'int_parsing'
         },
         {
-            'ctx': {'source': 'InitSettingsSource'},
             'input': 0,
-            'loc': ('null_field',),
+            'loc': ('InitSettingsSource', 'null_field',),
             'msg': 'Input should be a valid string',
             'type': 'string_type'
         },

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -1,0 +1,87 @@
+"""
+Integration tests with multiple sources
+"""
+
+from typing import Tuple, Type, Union
+
+from pydantic import BaseModel, ValidationError
+import pytest
+
+from pydantic_settings import (
+    BaseSettings,
+    JsonConfigSettingsSource,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+def test_line_errors_from_source(monkeypatch, tmp_path):
+    monkeypatch.setenv("SETTINGS_NESTED__NESTED_FIELD", "a")
+    p = tmp_path / 'settings.json'
+    p.write_text(
+        """
+    {"foobar": 0, "null_field": null}
+    """
+    )
+
+    class Nested(BaseModel):
+        nested_field: int
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(
+            json_file=p,
+            env_prefix="SETTINGS_",
+            env_nested_delimiter="__",
+            validate_each_source=True
+        )
+        foobar: str
+        nested: Nested
+        null_field: Union[str, None]
+        extra: bool
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: Type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> Tuple[PydanticBaseSettingsSource, ...]:
+            return (
+                JsonConfigSettingsSource(settings_cls),
+                env_settings,
+                init_settings
+            )
+
+    with pytest.raises(ValidationError) as exc_info:
+        _ = Settings(null_field=0)
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'source': 'JsonConfigSettingsSource'},
+            'input': 0,
+            'loc': ('foobar',),
+            'msg': 'Input should be a valid string',
+            'type': 'string_type',
+        },
+        {
+            'ctx': {'source': 'EnvSettingsSource'},
+            'input': 'a',
+            'loc': ('nested', 'nested_field'),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'type': 'int_parsing'
+        },
+        {
+            'ctx': {'source': 'InitSettingsSource'},
+            'input': 0,
+            'loc': ('null_field',),
+            'msg': 'Input should be a valid string',
+            'type': 'string_type'
+        },
+        {
+            'input': {'foobar': 0, 'nested': {'nested_field': 'a'}, 'null_field': None},
+            'loc': ('extra',),
+            'msg': 'Field required',
+            'type': 'missing'
+        }
+    ]

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -4,8 +4,8 @@ Integration tests with multiple sources
 
 from typing import Tuple, Type, Union
 
-from pydantic import BaseModel, ValidationError
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from pydantic_settings import (
     BaseSettings,
@@ -13,6 +13,7 @@ from pydantic_settings import (
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
+
 
 def test_line_errors_from_source(monkeypatch, tmp_path):
     monkeypatch.setenv('SETTINGS_NESTED__NESTED_FIELD', 'a')

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -15,7 +15,7 @@ from pydantic_settings import (
 )
 
 def test_line_errors_from_source(monkeypatch, tmp_path):
-    monkeypatch.setenv("SETTINGS_NESTED__NESTED_FIELD", "a")
+    monkeypatch.setenv('SETTINGS_NESTED__NESTED_FIELD', 'a')
     p = tmp_path / 'settings.json'
     p.write_text(
         """
@@ -29,8 +29,8 @@ def test_line_errors_from_source(monkeypatch, tmp_path):
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(
             json_file=p,
-            env_prefix="SETTINGS_",
-            env_nested_delimiter="__",
+            env_prefix='SETTINGS_',
+            env_nested_delimiter='__',
             validate_each_source=True
         )
         foobar: str

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -487,7 +487,10 @@ def test_annotated_list_with_error_source(env):
         {
             'ctx': {'actual_length': 1, 'field_type': 'List', 'min_length': 2, 'source': 'EnvSettingsSource'},
             'input': ['russet'],
-            'loc': ('EnvSettingsSource', 'apples',),
+            'loc': (
+                'EnvSettingsSource',
+                'apples',
+            ),
             'msg': 'List should have at least 2 items after validation, not 1',
             'type': 'too_short',
         }
@@ -1141,10 +1144,13 @@ def test_env_file_with_env_prefix_invalid_with_sources(tmp_path):
     assert exc_info.value.errors(include_url=False) == [
         {
             'type': 'extra_forbidden',
-            'loc': ('DotEnvSettingsSource', 'f',),
+            'loc': (
+                'DotEnvSettingsSource',
+                'f',
+            ),
             'msg': 'Extra inputs are not permitted',
             'input': 'random value',
-            'ctx': {'source': 'DotEnvSettingsSource'}
+            'ctx': {'source': 'DotEnvSettingsSource'},
         }
     ]
 
@@ -1925,8 +1931,7 @@ def test_builtins_settings_source_repr():
         == "EnvSettingsSource(env_nested_delimiter='__', env_prefix_len=0)"
     )
     assert repr(DotEnvSettingsSource(BaseSettings, env_file='.env', env_file_encoding='utf-8')) == (
-        "DotEnvSettingsSource(env_file='.env', env_file_encoding='utf-8', "
-        'env_nested_delimiter=None, env_prefix_len=0)'
+        "DotEnvSettingsSource(env_file='.env', env_file_encoding='utf-8', env_nested_delimiter=None, env_prefix_len=0)"
     )
     assert (
         repr(SecretsSettingsSource(BaseSettings, secrets_dir='/secrets'))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -44,7 +44,7 @@ from pydantic_settings import (
     NoDecode,
     PydanticBaseSettingsSource,
     SecretsSettingsSource,
-    SettingsConfigDict,
+    SettingsConfigDict
 )
 from pydantic_settings.sources import DefaultSettingsSource, SettingsError
 
@@ -1100,6 +1100,30 @@ def test_env_file_with_env_prefix_invalid(tmp_path):
         Settings()
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'extra_forbidden', 'loc': ('f',), 'msg': 'Extra inputs are not permitted', 'input': 'random value'}
+    ]
+
+
+def test_env_file_with_env_prefix_invalid_with_sources(tmp_path):
+    p = tmp_path / '.env'
+    p.write_text(prefix_test_env_invalid_file)
+
+    class Settings(BaseSettings):
+        a: str
+        b: str
+        c: str
+
+        model_config = SettingsConfigDict(env_file=p, env_prefix='prefix_', validate_each_source=True)
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'extra_forbidden',
+            'loc': ('f',),
+            'msg': 'Extra inputs are not permitted',
+            'input': 'random value',
+            'ctx': {'source': 'DotEnvSettingsSource'}
+        }
     ]
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -485,7 +485,7 @@ def test_annotated_list_with_error_source(env):
         AnnotatedComplexSettings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'ctx': {'actual_length': 1, 'field_type': 'List', 'min_length': 2},
+            'ctx': {'actual_length': 1, 'field_type': 'List', 'min_length': 2, 'source': 'EnvSettingsSource'},
             'input': ['russet'],
             'loc': ('EnvSettingsSource', 'apples',),
             'msg': 'List should have at least 2 items after validation, not 1',
@@ -1143,7 +1143,8 @@ def test_env_file_with_env_prefix_invalid_with_sources(tmp_path):
             'type': 'extra_forbidden',
             'loc': ('DotEnvSettingsSource', 'f',),
             'msg': 'Extra inputs are not permitted',
-            'input': 'random value'
+            'input': 'random value',
+            'ctx': {'source': 'DotEnvSettingsSource'}
         }
     ]
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -44,7 +44,7 @@ from pydantic_settings import (
     NoDecode,
     PydanticBaseSettingsSource,
     SecretsSettingsSource,
-    SettingsConfigDict
+    SettingsConfigDict,
 )
 from pydantic_settings.sources import DefaultSettingsSource, SettingsError
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -485,9 +485,9 @@ def test_annotated_list_with_error_source(env):
         AnnotatedComplexSettings()
     assert exc_info.value.errors(include_url=False) == [
         {
-            'ctx': {'actual_length': 1, 'field_type': 'List', 'min_length': 2, 'source': 'EnvSettingsSource'},
+            'ctx': {'actual_length': 1, 'field_type': 'List', 'min_length': 2},
             'input': ['russet'],
-            'loc': ('apples',),
+            'loc': ('EnvSettingsSource', 'apples',),
             'msg': 'List should have at least 2 items after validation, not 1',
             'type': 'too_short',
         }
@@ -1141,10 +1141,9 @@ def test_env_file_with_env_prefix_invalid_with_sources(tmp_path):
     assert exc_info.value.errors(include_url=False) == [
         {
             'type': 'extra_forbidden',
-            'loc': ('f',),
+            'loc': ('DotEnvSettingsSource', 'f',),
             'msg': 'Extra inputs are not permitted',
-            'input': 'random value',
-            'ctx': {'source': 'DotEnvSettingsSource'}
+            'input': 'random value'
         }
     ]
 


### PR DESCRIPTION
When working with settings configured for multiple sources it can be hard to pin down the exact source of a validation error. See #538 

In this PR I've added a configuration parameter `validate_each_source=True` that performs the validation while constructing the merged state of all configured sources. All validation errors are collected and raised after all sources have been parsed. The settings source is prepended to the `loc` field. Further, `type=missing` line errors are checked using the fully merged state and added to the raised ValidationError exception.

Here is an example using the Init and Env sources.

```python
import os
from pydantic_settings import BaseSettings

class MySettings(BaseSettings, validate_each_source=True, env_prefix='settings_'):
    foo: str
    default: int = 0
    extra: str | None = None

os.environ['settings_default'] = 'a'
settings = MySettings(extra=0)
```

The following error message is reported

```
Traceback (most recent call last):
  File "/Users/adefusco/Development/pydantic/pydantic-settings/testy.py", line 10, in <module>
    settings = MySettings(extra=0)
               ^^^^^^^^^^^^^^^^^^^
  File "/Users/adefusco/Development/pydantic/pydantic-settings/pydantic_settings/main.py", line 182, in __init__
    **self._settings_build_values(
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adefusco/Development/pydantic/pydantic-settings/pydantic_settings/main.py", line 451, in _settings_build_values
    raise ValidationError.from_exception_data(
pydantic_core._pydantic_core.ValidationError: 3 validation errors for MySettings
InitSettingsSource.extra
  Input should be a valid string [type=string_type, input_value=0, input_type=int]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
EnvSettingsSource.default
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='a', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/int_parsing
foo
  Field required [type=missing, input_value={'default': 'a', 'extra': 0}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
```
