### PR TITLE
In sources.py, define T as a covariant type variable.

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -165,7 +165,7 @@ class CliMutuallyExclusiveGroup(BaseModel):
     pass
 
 
-T = TypeVar('T')
+T = TypeVar('T', covariant=True)
 CliSubCommand = Annotated[Union[T, None], _CliSubCommand]
 CliPositionalArg = Annotated[T, _CliPositionalArg]
 _CliBoolFlag = TypeVar('_CliBoolFlag', bound=bool)


### PR DESCRIPTION
Previously, the type parameter was invariant, leading Pyright to report a type incompatibility error:
```
$ pyright test
...
"CliSettingsSource[MyOptions]" is not assignable to "CliSettingsSource[object]"
   Type parameter "T@CliSettingsSource" is invariant, but "MyOptions" is not
     the same as "object" (reportAssignmentType)
...
```

Here's the content of `test.py`:
```
from pydantic_settings import BaseSettings, EnvSettingsSource, CliSettingsSource
class OptionsBase:
    pass
class MyOptions(OptionsBase):
    pass
cli_source: CliSettingsSource[object] = CliSettingsSource[MyOptions](BaseSettings)
```