### PR TITLE
Fix minor typo: conotations => connotations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -721,7 +721,7 @@ print(Settings().model_dump())
 """
 ```
 
-To enable CLI parsing, we simply set the `cli_parse_args` flag to a valid value, which retains similar conotations as
+To enable CLI parsing, we simply set the `cli_parse_args` flag to a valid value, which retains similar connotations as
 defined in `argparse`.
 
 Note that a CLI settings source is [**the topmost source**](#field-value-priority) by default unless its [priority value


### PR DESCRIPTION
Found a minor typo while reading the (_very thorough_, thank you!) documentation.