### PR TITLE
fix: Expose ConfigFileSourceMixing on top level sources/__init__.py

### DIFF
--- a/pydantic_settings/sources/__init__.py
+++ b/pydantic_settings/sources/__init__.py
@@ -5,6 +5,7 @@ from .base import (
     InitSettingsSource,
     PydanticBaseEnvSettingsSource,
     PydanticBaseSettingsSource,
+    ConfigFileSourceMixin,
     get_subcommand,
 )
 from .providers.aws import AWSSecretsManagerSettingsSource
@@ -55,6 +56,7 @@ __all__ = [
     'PathType',
     'PydanticBaseEnvSettingsSource',
     'PydanticBaseSettingsSource',
+    'ConfigFileSourceMixin',
     'PydanticModel',
     'PyprojectTomlConfigSettingsSource',
     'SecretsSettingsSource',

--- a/pydantic_settings/sources/__init__.py
+++ b/pydantic_settings/sources/__init__.py
@@ -1,11 +1,11 @@
 """Package for handling configuration sources in pydantic-settings."""
 
 from .base import (
+    ConfigFileSourceMixin,
     DefaultSettingsSource,
     InitSettingsSource,
     PydanticBaseEnvSettingsSource,
     PydanticBaseSettingsSource,
-    ConfigFileSourceMixin,
     get_subcommand,
 )
 from .providers.aws import AWSSecretsManagerSettingsSource


### PR DESCRIPTION
Fixes breaking change introduced in `v2.9.0`

More info in https://github.com/pydantic/pydantic-settings/issues/596