### PR TITLE
Support loading a specific nested key from YAML in YamlConfigSettingsSource

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -62,6 +62,7 @@ class SettingsConfigDict(ConfigDict, total=False):
     json_file_encoding: str | None
     yaml_file: PathType | None
     yaml_file_encoding: str | None
+    yaml_nested_key: str | None
     pyproject_toml_depth: int
     """
     Number of levels **up** from the current working directory to attempt to find a pyproject.toml
@@ -446,6 +447,7 @@ class BaseSettings(BaseModel):
         json_file_encoding=None,
         yaml_file=None,
         yaml_file_encoding=None,
+        yaml_nested_key=None,
         toml_file=None,
         secrets_dir=None,
         protected_namespaces=('model_validate', 'model_dump', 'settings_customise_sources'),

--- a/pydantic_settings/sources/providers/yaml.py
+++ b/pydantic_settings/sources/providers/yaml.py
@@ -39,6 +39,7 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         settings_cls: type[BaseSettings],
         yaml_file: PathType | None = DEFAULT_PATH,
         yaml_file_encoding: str | None = None,
+        yaml_nested_key: str | None = None,
     ):
         self.yaml_file_path = yaml_file if yaml_file != DEFAULT_PATH else settings_cls.model_config.get('yaml_file')
         self.yaml_file_encoding = (
@@ -46,7 +47,13 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             if yaml_file_encoding is not None
             else settings_cls.model_config.get('yaml_file_encoding')
         )
+        self.yaml_nested_key = (
+            yaml_nested_key if yaml_nested_key is not None else settings_cls.model_config.get('yaml_nested_key')
+        )
         self.yaml_data = self._read_files(self.yaml_file_path)
+
+        if self.yaml_nested_key:
+            self.yaml_data = self.yaml_data[self.yaml_nested_key]
         super().__init__(settings_cls, self.yaml_data)
 
     def _read_file(self, file_path: Path) -> dict[str, Any]:

--- a/tests/test_source_yaml.py
+++ b/tests/test_source_yaml.py
@@ -166,3 +166,34 @@ def test_multiple_file_yaml(tmp_path):
 
     s = Settings()
     assert s.model_dump() == {'yaml3': 3, 'yaml4': 4}
+
+
+@pytest.mark.skipif(yaml is None, reason='pyYAML is not installed')
+def test_yaml_nested_key(tmp_path):
+    p = tmp_path / '.env'
+    p.write_text(
+        """
+    foobar: "Hello"
+    nested:
+        nested_field: "world!"
+    """
+    )
+
+    class Settings(BaseSettings):
+        nested_field: str
+
+        model_config = SettingsConfigDict(yaml_file=p, yaml_nested_key='nested')
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (YamlConfigSettingsSource(settings_cls),)
+
+    s = Settings()
+    assert s.nested_field == 'world!'


### PR DESCRIPTION
# Description

It would be great if YamlConfigSettingsSource could support loading settings from a specific nested key within a YAML file.

## Use Case

Often, YAML files contain configuration for multiple environments or sections, such as:

```yaml
A_service:
  key: "A_key"
 
B_service:
  key: "B_key"
````

In this case, it would be useful to load settings from a specific key, for example, development, rather than requiring separate YAML files for each environment.

Suggested Feature

Allow an optional argument (e.g., nested_key) to be passed to YamlConfigSettingsSource like this:

```python
YamlConfigSettingsSource(settings_cls, yaml_file="config.yaml", yaml_nested_key="A_service")
```

This would tell the source to load settings from config["development"] instead of the root.

Benefits
	•	Reduces the need for multiple YAML files
	•	Simplifies environment-specific configuration management
	•	Aligns with how many existing tools and frameworks organize config