### PR TITLE
Fix for case-insensitive alias matching in `InitSettingsSource`

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -306,11 +306,7 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         )
 
     def __repr__(self) -> str:
-        return (
-            f'{self.__class__.__name__}(init_kwargs={self.init_kwargs!r}, '
-            f'case_sensitive={self.case_sensitive!r}, '
-            f'nested_model_default_partial_update={self.nested_model_default_partial_update!r})'
-        )
+        return f'{self.__class__.__name__}(init_kwargs={self.init_kwargs!r})'
 
 
 class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -860,7 +860,7 @@ def test_case_sensitive(monkeypatch):
     class Settings(BaseSettings):
         foo: str
 
-        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
+        model_config = SettingsConfigDict(case_sensitive=True)
 
     # Need to patch os.environ to get build to work on Windows, where os.environ is case insensitive
     monkeypatch.setattr(os, 'environ', value={'Foo': 'foo'})

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -881,44 +881,40 @@ def test_case_sensitive(monkeypatch):
 
 def test_init_settings_source_extra_fields_case_sensitive(monkeypatch):
     class CaseSensitiveSettings(BaseSettings):
-        foo: str = Field(..., alias='FOO')
+        foo: str = Field(..., alias="FOO")
+        model_config = SettingsConfigDict(case_sensitive=True, extra="allow")
 
-        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
-
-    # Test when case sensitivity is enabled (missing correct alias)
-    monkeypatch.setattr(os, 'environ', value={})  # Empty env to isolate init_kwargs
-    init_kwargs_case_sensitive = {
-        'Foo': 'wrong_value',  # Wrong case for alias 'FOO'
-        'extra_field': 'extra_value',
-    }
+    # Test case-sensitive with missing alias
+    monkeypatch.setattr(os, "environ", value={})
+    init_kwargs = {"Foo": "wrong_value", "extra_field": "extra_value"}
     with pytest.raises(ValidationError) as exc_info:
-        CaseSensitiveSettings(**init_kwargs_case_sensitive)
+        CaseSensitiveSettings(**init_kwargs)
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': init_kwargs_case_sensitive}
+        {
+            "type": "missing",
+            "loc": ("FOO",),
+            "msg": "Field required",
+            "input": init_kwargs,
+        }
     ]
 
-    # Test with correct case and extra field
-    monkeypatch.setattr(os, 'environ', value={})  # Ensure no env interference
-    init_kwargs_correct_case = {'FOO': 'foo_value', 'extra_field': 'extra_value'}
-    settings_correct = CaseSensitiveSettings(**init_kwargs_correct_case)
-    assert settings_correct.foo == 'foo_value'
-    assert settings_correct.__pydantic_extra__ == {'extra_field': 'extra_value'}
+    # Test case-sensitive with correct alias and extra field
+    monkeypatch.setattr(os, "environ", value={})
+    init_kwargs = {"FOO": "foo_value", "extra_field": "extra_value"}
+    settings = CaseSensitiveSettings(**init_kwargs)
+    assert settings.foo == "foo_value"
+    assert settings.__pydantic_extra__ == {"extra_field": "extra_value"}
 
     class CaseInsensitiveSettings(BaseSettings):
-        foo: str = Field(..., alias='FOO')
+        foo: str = Field(..., alias="FOO")
+        model_config = SettingsConfigDict(case_sensitive=False, extra="allow")
 
-        model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
-
-    # Test when case sensitivity is disabled
-    monkeypatch.setattr(os, 'environ', value={})  # Empty env to isolate init_kwargs
-    init_kwargs_case_insensitive = {
-        'Foo': 'foo_value',  # Matches alias 'FOO' case-insensitively
-        'extra_field': 'extra_value',
-        'EXTRA_FIELD': 'another_value',
-    }
-    settings = CaseInsensitiveSettings(**init_kwargs_case_insensitive)
-    assert settings.foo == 'foo_value'
-    assert settings.__pydantic_extra__ == {'extra_field': 'extra_value', 'EXTRA_FIELD': 'another_value'}
+    # Test case-insensitive with extra field
+    monkeypatch.setattr(os, "environ", value={})
+    init_kwargs = {"Foo": "foo_value", "extra_field": "extra_value"}
+    settings = CaseInsensitiveSettings(**init_kwargs)
+    assert settings.foo == "foo_value"
+    assert settings.__pydantic_extra__ == {"extra_field": "extra_value"}
 
 
 @pytest.mark.parametrize('env_nested_delimiter', [None, ''])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -879,6 +879,7 @@ def test_case_sensitive(monkeypatch):
     settings = CaseInsensitiveSettings()
     assert settings.foo == 'foo_value'
 
+
 def test_init_settings_source_extra_fields_case_sensitive(monkeypatch):
     class CaseSensitiveSettings(BaseSettings):
         foo: str = Field(..., alias='FOO')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -627,45 +627,6 @@ def test_class_nested_model_default_partial_update(env):
     }
 
 
-def test_env_source_case_sensitive(monkeypatch):
-    """Tests EnvSettingsSource with case_sensitive=True."""
-
-    class Settings(BaseSettings):
-        foo: str
-        model_config = SettingsConfigDict(case_sensitive=True)
-
-    monkeypatch.setenv('Foo', 'foo_env_value')
-    with pytest.raises(ValidationError) as exc_info:
-        Settings()
-    assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
-    ]
-    monkeypatch.delenv('Foo', raising=False)
-
-    monkeypatch.setenv('foo', 'foo_env_value')
-    s = Settings()
-    assert s.foo == 'foo_env_value'
-    monkeypatch.delenv('foo', raising=False)
-
-
-def test_env_source_case_insensitive(monkeypatch):
-    """Tests EnvSettingsSource with case_sensitive=False."""
-
-    class Settings(BaseSettings):
-        foo: str
-        model_config = SettingsConfigDict(case_sensitive=False)
-
-    monkeypatch.setenv('Foo', 'foo_env_value')
-    s_upper = Settings()
-    assert s_upper.foo == 'foo_env_value'
-    monkeypatch.delenv('Foo', raising=False)
-
-    monkeypatch.setenv('foo', 'foo_env_value_lower')
-    s_lower = Settings()
-    assert s_lower.foo == 'foo_env_value_lower'
-    monkeypatch.delenv('foo', raising=False)
-
-
 def test_init_kwargs_nested_model_default_partial_update(env):
     class DeepSubModel(BaseModel):
         v4: str
@@ -896,18 +857,27 @@ def test_validation_alias_with_env_prefix(env):
 
 
 def test_case_sensitive(monkeypatch):
-    class Settings(BaseSettings):
-        foo: str
+    class CaseSensitiveSettings(BaseSettings):
+            foo: str
 
-        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
+            model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
 
-    # Need to patch os.environ to get build to work on Windows, where os.environ is case insensitive
-    monkeypatch.setattr(os, 'environ', value={'Foo': 'foo'})
-    with pytest.raises(ValidationError) as exc_info:
-        Settings()
-    assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
-    ]
+        # Test when case sensitivity is enabled
+        monkeypatch.setattr(os, 'environ', value={'Foo': 'foo_value'})
+        with pytest.raises(ValidationError) as exc_info:
+            CaseSensitiveSettings()
+        assert exc_info.value.errors(include_url=False) == [
+            {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
+        ]
+
+    class CaseInsensitiveSettings(BaseSettings):
+            foo: str
+
+            model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
+
+        monkeypatch.setattr(os, 'environ', value={'Foo': 'foo_value'})
+        settings = CaseInsensitiveSettings()
+        assert settings.foo == 'foo_value'
 
 
 @pytest.mark.parametrize('env_nested_delimiter', [None, ''])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -858,26 +858,26 @@ def test_validation_alias_with_env_prefix(env):
 
 def test_case_sensitive(monkeypatch):
     class CaseSensitiveSettings(BaseSettings):
-            foo: str
+        foo: str
 
-            model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
+        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
 
-        # Test when case sensitivity is enabled
-        monkeypatch.setattr(os, 'environ', value={'Foo': 'foo_value'})
-        with pytest.raises(ValidationError) as exc_info:
-            CaseSensitiveSettings()
-        assert exc_info.value.errors(include_url=False) == [
-            {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
-        ]
+    # Test when case sensitivity is enabled
+    monkeypatch.setattr(os, 'environ', value={'Foo': 'foo_value'})
+    with pytest.raises(ValidationError) as exc_info:
+        CaseSensitiveSettings()
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
+    ]
 
     class CaseInsensitiveSettings(BaseSettings):
-            foo: str
+        foo: str
 
-            model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
+        model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
 
-        monkeypatch.setattr(os, 'environ', value={'Foo': 'foo_value'})
-        settings = CaseInsensitiveSettings()
-        assert settings.foo == 'foo_value'
+    monkeypatch.setattr(os, 'environ', value={'Foo': 'foo_value'})
+    settings = CaseInsensitiveSettings()
+    assert settings.foo == 'foo_value'
 
 
 @pytest.mark.parametrize('env_nested_delimiter', [None, ''])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -881,40 +881,40 @@ def test_case_sensitive(monkeypatch):
 
 def test_init_settings_source_extra_fields_case_sensitive(monkeypatch):
     class CaseSensitiveSettings(BaseSettings):
-        foo: str = Field(..., alias="FOO")
-        model_config = SettingsConfigDict(case_sensitive=True, extra="allow")
+        foo: str = Field(..., alias='FOO')
+        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
 
     # Test case-sensitive with missing alias
-    monkeypatch.setattr(os, "environ", value={})
-    init_kwargs = {"Foo": "wrong_value", "extra_field": "extra_value"}
+    monkeypatch.setattr(os, 'environ', value={})
+    init_kwargs = {'Foo': 'wrong_value', 'extra_field': 'extra_value'}
     with pytest.raises(ValidationError) as exc_info:
         CaseSensitiveSettings(**init_kwargs)
     assert exc_info.value.errors(include_url=False) == [
         {
-            "type": "missing",
-            "loc": ("FOO",),
-            "msg": "Field required",
-            "input": init_kwargs,
+            'type': 'missing',
+            'loc': ('FOO',),
+            'msg': 'Field required',
+            'input': init_kwargs,
         }
     ]
 
     # Test case-sensitive with correct alias and extra field
-    monkeypatch.setattr(os, "environ", value={})
-    init_kwargs = {"FOO": "foo_value", "extra_field": "extra_value"}
+    monkeypatch.setattr(os, 'environ', value={})
+    init_kwargs = {'FOO': 'foo_value', 'extra_field': 'extra_value'}
     settings = CaseSensitiveSettings(**init_kwargs)
-    assert settings.foo == "foo_value"
-    assert settings.__pydantic_extra__ == {"extra_field": "extra_value"}
+    assert settings.foo == 'foo_value'
+    assert settings.__pydantic_extra__ == {'extra_field': 'extra_value'}
 
     class CaseInsensitiveSettings(BaseSettings):
-        foo: str = Field(..., alias="FOO")
-        model_config = SettingsConfigDict(case_sensitive=False, extra="allow")
+        foo: str = Field(..., alias='FOO')
+        model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
 
     # Test case-insensitive with extra field
-    monkeypatch.setattr(os, "environ", value={})
-    init_kwargs = {"Foo": "foo_value", "extra_field": "extra_value"}
+    monkeypatch.setattr(os, 'environ', value={})
+    init_kwargs = {'Foo': 'foo_value', 'extra_field': 'extra_value'}
     settings = CaseInsensitiveSettings(**init_kwargs)
-    assert settings.foo == "foo_value"
-    assert settings.__pydantic_extra__ == {"extra_field": "extra_value"}
+    assert settings.foo == 'foo_value'
+    assert settings.__pydantic_extra__ == {'extra_field': 'extra_value'}
 
 
 @pytest.mark.parametrize('env_nested_delimiter', [None, ''])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -860,7 +860,7 @@ def test_case_sensitive(monkeypatch):
     class Settings(BaseSettings):
         foo: str
 
-        model_config = SettingsConfigDict(case_sensitive=True)
+        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
 
     # Need to patch os.environ to get build to work on Windows, where os.environ is case insensitive
     monkeypatch.setattr(os, 'environ', value={'Foo': 'foo'})

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -857,27 +857,18 @@ def test_validation_alias_with_env_prefix(env):
 
 
 def test_case_sensitive(monkeypatch):
-    class CaseSensitiveSettings(BaseSettings):
+    class Settings(BaseSettings):
         foo: str
 
-        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
+        model_config = SettingsConfigDict(case_sensitive=True)
 
-    # Test when case sensitivity is enabled
-    monkeypatch.setattr(os, 'environ', value={'Foo': 'foo_value'})
+    # Need to patch os.environ to get build to work on Windows, where os.environ is case insensitive
+    monkeypatch.setattr(os, 'environ', value={'Foo': 'foo'})
     with pytest.raises(ValidationError) as exc_info:
-        CaseSensitiveSettings()
+        Settings()
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'missing', 'loc': ('foo',), 'msg': 'Field required', 'input': {}}
     ]
-
-    class CaseInsensitiveSettings(BaseSettings):
-        foo: str
-
-        model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
-
-    monkeypatch.setattr(os, 'environ', value={'Foo': 'foo_value'})
-    settings = CaseInsensitiveSettings()
-    assert settings.foo == 'foo_value'
 
 
 def test_init_settings_source_extra_fields_case_sensitive(monkeypatch):


### PR DESCRIPTION
# Issue
When using case-insensitive settings with aliases, the InitSettingsSource wasn't correctly matching field aliases in a case-insensitive manner due to not considering case sensitivity when obtaining alias names.

# Changes
Modified the `__init__` method of `InitSettingsSource` to pass the **case_sensitive** parameter to get_alias_names() when generating match aliases
Now properly creates two sets of aliases:
- Canonical aliases (always case-sensitive) for the output key
- Match aliases that respect the configured case sensitivity for matching input values

Add unittest `test_init_settings_source_extra_fields_case_sensitive`