### PR TITLE
Inspect type aliases to determine if an annotation is complex

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -356,10 +356,8 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
         if not v_alias or self.config.get('populate_by_name', False):
             annotation = field.annotation
-            if annotation and (
-                typing_objects.is_typealiastype(annotation) or typing_objects.is_typealiastype(get_origin(annotation))
-            ):
-                annotation = _strip_annotated(annotation.__value__)
+            if typing_objects.is_typealiastype(annotation) or typing_objects.is_typealiastype(get_origin(annotation)):
+                annotation = _strip_annotated(annotation.__value__)  # type: ignore[union-attr]
             if is_union_origin(get_origin(annotation)) and _union_is_complex(annotation, field.metadata):
                 field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), True))
             else:

--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -16,6 +16,7 @@ from pydantic._internal._typing_extra import (  # type: ignore[attr-defined]
 from pydantic._internal._utils import is_model_class
 from pydantic.fields import FieldInfo
 from typing_extensions import get_args
+from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
 from ..exceptions import SettingsError
@@ -25,6 +26,7 @@ from .utils import (
     _annotation_is_complex,
     _get_alias_names,
     _get_model_fields,
+    _strip_annotated,
     _union_is_complex,
 )
 
@@ -353,7 +355,10 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                 field_info.append((v_alias, self._apply_case_sensitive(v_alias), False))
 
         if not v_alias or self.config.get('populate_by_name', False):
-            if is_union_origin(get_origin(field.annotation)) and _union_is_complex(field.annotation, field.metadata):
+            annotation = field.annotation
+            if typing_objects.is_typealiastype(annotation):
+                annotation = _strip_annotated(annotation.__value__)
+            if is_union_origin(get_origin(annotation)) and _union_is_complex(annotation, field.metadata):
                 field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), True))
             else:
                 field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), False))

--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -356,7 +356,9 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
         if not v_alias or self.config.get('populate_by_name', False):
             annotation = field.annotation
-            if typing_objects.is_typealiastype(annotation):
+            if annotation and (
+                typing_objects.is_typealiastype(annotation) or typing_objects.is_typealiastype(get_origin(annotation))
+            ):
                 annotation = _strip_annotated(annotation.__value__)
             if is_union_origin(get_origin(annotation)) and _union_is_complex(annotation, field.metadata):
                 field_info.append((field_name, self._apply_case_sensitive(self.env_prefix + field_name), True))

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -40,12 +40,10 @@ def parse_env_vars(
     }
 
 
-def _annotation_is_complex(annotation: type[Any] | None, metadata: list[Any]) -> bool:
+def _annotation_is_complex(annotation: Any, metadata: list[Any]) -> bool:
     # If the model is a root model, the root annotation should be used to
     # evaluate the complexity.
-    if annotation and (
-        typing_objects.is_typealiastype(annotation) or typing_objects.is_typealiastype(get_origin(annotation))
-    ):
+    if typing_objects.is_typealiastype(annotation) or typing_objects.is_typealiastype(get_origin(annotation)):
         annotation = annotation.__value__
     if annotation is not None and _lenient_issubclass(annotation, RootModel) and annotation is not RootModel:
         annotation = cast('type[RootModel[Any]]', annotation)

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -43,6 +43,8 @@ def parse_env_vars(
 def _annotation_is_complex(annotation: type[Any] | None, metadata: list[Any]) -> bool:
     # If the model is a root model, the root annotation should be used to
     # evaluate the complexity.
+    if typing_objects.is_typealiastype(annotation):
+        annotation = annotation.__value__
     if annotation is not None and _lenient_issubclass(annotation, RootModel) and annotation is not RootModel:
         annotation = cast('type[RootModel[Any]]', annotation)
         root_annotation = annotation.model_fields['root'].annotation

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -43,7 +43,9 @@ def parse_env_vars(
 def _annotation_is_complex(annotation: type[Any] | None, metadata: list[Any]) -> bool:
     # If the model is a root model, the root annotation should be used to
     # evaluate the complexity.
-    if typing_objects.is_typealiastype(annotation):
+    if annotation and (
+        typing_objects.is_typealiastype(annotation) or typing_objects.is_typealiastype(get_origin(annotation))
+    ):
         annotation = annotation.__value__
     if annotation is not None and _lenient_issubclass(annotation, RootModel) and annotation is not RootModel:
         annotation = cast('type[RootModel[Any]]', annotation)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -34,7 +34,7 @@ from pydantic import (
     dataclasses as pydantic_dataclasses,
 )
 from pydantic.fields import FieldInfo
-from typing_extensions import override
+from typing_extensions import TypeAliasType, override
 
 from pydantic_settings import (
     BaseSettings,
@@ -472,6 +472,21 @@ def test_annotated_list(env):
             'type': 'too_short',
         }
     ]
+
+
+def test_annotated_with_type(env):
+    """https://github.com/pydantic/pydantic-settings/issues/536.
+
+    PEP 695 type aliases need to be analyzed when determining if an annotation is complex.
+    """
+    MinLenList = TypeAliasType('MinLenList', Annotated[Union[list[str], list[int]], MinLen(2)])
+
+    class AnnotatedComplexSettings(BaseSettings):
+        apples: MinLenList
+
+    env.set('apples', '["russet", "granny smith"]')
+    s = AnnotatedComplexSettings()
+    assert s.apples == ['russet', 'granny smith']
 
 
 def test_set_dict_model(env):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -488,6 +488,15 @@ def test_annotated_with_type(env):
     s = AnnotatedComplexSettings()
     assert s.apples == ['russet', 'granny smith']
 
+    T = TypeVar('T')
+    MinLenList = TypeAliasType('MinLenList', Annotated[Union[list[T], tuple[T]], MinLen(2)], type_params=(T,))
+
+    class AnnotatedComplexSettings(BaseSettings):
+        apples: MinLenList[str]
+
+    s = AnnotatedComplexSettings()
+    assert s.apples == ['russet', 'granny smith']
+
 
 def test_set_dict_model(env):
     env.set('bananas', '[1, 2, 3, 3]')


### PR DESCRIPTION
This PR ensures that type aliases declared using type (PEP 695) are correctly resolved and handled during environment value parsing and model field introspection.

I aimed to keep the changes minimal, but addressing compatibility issues required introducing a couple of new patterns, specifically to work around syntax errors triggered by pytest when using Python versions <3.12, as well as ruff linter errors. If there are better or more idiomatic approaches, I'm happy to discuss them. I'm not certain the current solutions are the best long-term fit for the project.

Fixes #536