### PR TITLE
Remove parsing of command line arguments from `CliSettingsSource.__init__`.

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -391,7 +391,8 @@ class BaseSettings(BaseModel):
             dotenv_settings=dotenv_settings,
             file_secret_settings=file_secret_settings,
         ) + (default_settings,)
-        if not any([source for source in sources if isinstance(source, CliSettingsSource)]):
+        custom_cli_sources = [source for source in sources if isinstance(source, CliSettingsSource)]
+        if not any(custom_cli_sources):
             if isinstance(cli_settings_source, CliSettingsSource):
                 sources = (cli_settings_source,) + sources
             elif cli_parse_args is not None:
@@ -414,6 +415,10 @@ class BaseSettings(BaseModel):
                     case_sensitive=case_sensitive,
                 )
                 sources = (cli_settings,) + sources
+        # We ensure that if command line arguments haven't been parsed yet, we do so.
+        elif cli_parse_args and not custom_cli_sources[0].env_vars:
+            custom_cli_sources[0](args=cli_parse_args)
+
         if sources:
             state: dict[str, Any] = {}
             states: dict[str, dict[str, Any]] = {}

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -2612,3 +2612,25 @@ def test_cli_serialize_positional_args(env):
     serialized_cli_args = CliApp.serialize(cfg)
     assert serialized_cli_args == ['0', '1', '2', '3', '4', '5']
     assert CliApp.run(Cfg, cli_args=serialized_cli_args).model_dump() == cfg.model_dump()
+
+
+def test_cli_app_with_separate_parser(monkeypatch):
+    class Cfg(BaseSettings):
+        model_config = SettingsConfigDict(cli_parse_args=True)
+        pet: Literal['dog', 'cat', 'bird']
+
+    parser = argparse.ArgumentParser()
+
+    # The actual parsing of command line argument should not happen here.
+    cli_settings = CliSettingsSource(Cfg, root_parser=parser)
+
+    parser.add_argument('-e', '--extra', dest='extra', default=0, action='count')
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['example.py', '--pet', 'dog', '-eeee'])
+
+        parsed_args = parser.parse_args()
+
+    assert parsed_args.extra == 4
+    # With parsed arguments passed to CliApp.run, the parser should not need to be called again.
+    assert CliApp.run(Cfg, cli_args=parsed_args, cli_settings_source=cli_settings).model_dump() == {'pet': 'dog'}

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -2531,6 +2531,33 @@ def test_cli_json_optional_default():
     assert CliApp.run(Options, cli_args=['--nested.foo=5']).model_dump() == {'nested': {'foo': 5, 'bar': 2}}
 
 
+def test_cli_parse_args_from_model_config_is_respected_with_settings_customise_sources(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class MySettings(BaseSettings):
+        model_config = SettingsConfigDict(cli_parse_args=True)
+
+        foo: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (CliSettingsSource(settings_cls),)
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['example.py', '--foo', 'bar'])
+
+        cfg = CliApp.run(MySettings)
+
+        assert cfg.model_dump() == {'foo': 'bar'}
+
+
 def test_cli_shortcuts_on_flat_object():
     class Settings(BaseSettings):
         option: str = Field(default='foo')


### PR DESCRIPTION
As part of the discussions in #610 and #654 , PR #611 needs to be reverted due to breaking backwards compatability. In particular, it stems from `CliSettingsSource.__init__` eagerly parsing command line arguments when passed with `cli_parse_args`.

This PR is meant as an alternative solution to the problem:

1. The call to `_load_env_vars` in `CliSettingsSource.__init__` is removed.
2. Checks for `CliSettingsSource.env_vars` put in places where the caller needs the arguments to have been parsed. As far as I found, this turned out to be during serialization (in `CliSettingsSource._serialized_args`), and during `CliSettingsSource.__call__`.
3. I've also added a test that's almost identical to the example found in #654 .

> NOTE: This PR is primarily meant as part of a discussion (and as a learning experience for me), so feel free to reject it on account of code quality or any other reason. Any feedback, though, is greatly appreciated.