### PR TITLE
Included endpoint_url kwarg in AWSSecretsManagerSettingsSource class

### DIFF
--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -37,19 +37,21 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         settings_cls: type[BaseSettings],
         secret_id: str,
         region_name: str | None = None,
+        endpoint_url: str | None = None,
         case_sensitive: bool | None = True,
         env_prefix: str | None = None,
+        env_nested_delimiter: str | None = '--',
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
     ) -> None:
         import_aws_secrets_manager()
-        self._secretsmanager_client = boto3_client('secretsmanager', region_name=region_name)  # type: ignore
+        self._secretsmanager_client = boto3_client('secretsmanager', region_name=region_name, endpoint_url=endpoint_url)  # type: ignore
         self._secret_id = secret_id
         super().__init__(
             settings_cls,
             case_sensitive=case_sensitive,
             env_prefix=env_prefix,
-            env_nested_delimiter='--',
+            env_nested_delimiter=env_nested_delimiter,
             env_ignore_empty=False,
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,


### PR DESCRIPTION
During testing and development phases, I use a `motoserver` docker container to interact with my AWS resources of my application locally. 

I was able to connect with `motoserver` by using the following code:

```python
    @classmethod
    def settings_customise_sources(
        cls,
        settings_cls: type[BaseSettings],
        init_settings: PydanticBaseSettingsSource,
        env_settings: PydanticBaseSettingsSource,
        dotenv_settings: PydanticBaseSettingsSource,
        file_secret_settings: PydanticBaseSettingsSource,
    ) -> tuple[PydanticBaseSettingsSource, ...]:
        aws_secrets_manager_settings = AWSSecretsManagerSettingsSource(
            settings_cls,
            secret_id=os.getenv('APP_SECRETS_MANAGER_SECRET'),
            region_name=os.getenv('AWS_DEFAULT_REGION'),
            endpoint_url=os.getenv('AWS_SECRETS_MANAGER_ENDPOINT'),
            env_prefix='',
            env_nested_delimiter='__',
            case_sensitive=True,
        )
        return (
            init_settings,
            env_settings,
            dotenv_settings,
            file_secret_settings,
            aws_secrets_manager_settings,
        )
```

My proposal keeps the original behavior in the `AWSSecretsManagerSettingsSource` class and add a more complete configuration to interact with the AWS Secrets Manager provider.