### PR TITLE
Snake case conversion in Azure Key Vault

### DIFF
--- a/pydantic_settings/sources/providers/azure.py
+++ b/pydantic_settings/sources/providers/azure.py
@@ -5,6 +5,7 @@ from __future__ import annotations as _annotations
 from collections.abc import Iterator, Mapping
 from typing import TYPE_CHECKING, Optional
 
+from pydantic.alias_generators import to_snake
 from pydantic.fields import FieldInfo
 
 from .env import EnvSettingsSource
@@ -44,27 +45,27 @@ class AzureKeyVaultMapping(Mapping[str, Optional[str]]):
     def __init__(
         self,
         secret_client: SecretClient,
-        case_sensitive: bool,
     ) -> None:
         self._loaded_secrets = {}
         self._secret_client = secret_client
-        self._case_sensitive = case_sensitive
         self._secret_map: dict[str, str] = self._load_remote()
 
     def _load_remote(self) -> dict[str, str]:
         secret_names: Iterator[str] = (
             secret.name for secret in self._secret_client.list_properties_of_secrets() if secret.name and secret.enabled
         )
-        if self._case_sensitive:
-            return {name: name for name in secret_names}
-        return {name.lower(): name for name in secret_names}
+        return {to_snake(name): name for name in secret_names}
 
     def __getitem__(self, key: str) -> str | None:
-        if not self._case_sensitive:
-            key = key.lower()
-        if key not in self._loaded_secrets and key in self._secret_map:
-            self._loaded_secrets[key] = self._secret_client.get_secret(self._secret_map[key]).value
-        return self._loaded_secrets[key]
+        key_snake = to_snake(key)
+
+        if key_snake not in self._loaded_secrets and key_snake in self._secret_map:
+            self._loaded_secrets[key_snake] = self._secret_client.get_secret(self._secret_map[key_snake]).value
+
+        try:
+            return self._loaded_secrets[key_snake]
+        except Exception:
+            raise KeyError(key)
 
     def __len__(self) -> int:
         return len(self._secret_map)
@@ -82,8 +83,6 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
         settings_cls: type[BaseSettings],
         url: str,
         credential: TokenCredential,
-        dash_to_underscore: bool = False,
-        case_sensitive: bool | None = None,
         env_prefix: str | None = None,
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
@@ -91,12 +90,11 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
         import_azure_key_vault()
         self._url = url
         self._credential = credential
-        self._dash_to_underscore = dash_to_underscore
         super().__init__(
             settings_cls,
-            case_sensitive=case_sensitive,
+            case_sensitive=False,
             env_prefix=env_prefix,
-            env_nested_delimiter='--',
+            env_nested_delimiter='__',
             env_ignore_empty=False,
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,
@@ -104,12 +102,10 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
 
     def _load_env_vars(self) -> Mapping[str, Optional[str]]:
         secret_client = SecretClient(vault_url=self._url, credential=self._credential)
-        return AzureKeyVaultMapping(secret_client, self.case_sensitive)
+        return AzureKeyVaultMapping(secret_client)
 
     def _extract_field_info(self, field: FieldInfo, field_name: str) -> list[tuple[str, str, bool]]:
-        if self._dash_to_underscore:
-            return list((x[0], x[1].replace('_', '-'), x[2]) for x in super()._extract_field_info(field, field_name))
-        return super()._extract_field_info(field, field_name)
+        return list((x[0], x[0], x[2]) for x in super()._extract_field_info(field, field_name))
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(url={self._url!r}, env_nested_delimiter={self.env_nested_delimiter!r})'


### PR DESCRIPTION
Until now, we had workarounds to read secrets from Azure Key Vault:
- Alias in each field.
- Alias generator in all settings.
- dash_to_underscore to convert from "my-secret" to "my_secret".

And Key Vault uses the dash for different semantics:
- Prefixes (5-StorageAccountAccessKey).
- Hierarchical values (StorageAccount--AccessKey).
- Arrays (StorageAccounts--0---AccessKey).

Now, the package implements a mature conversion, from Key Vault's semantics to the Python convention. For example, it converts the following secrets in Key Vault to Python:
- SqlServer -> sql_server
- sqlServer -> sql_server
- sql-server -> sql_server
- SqlServer--Password -> sql_server__password  (nested model).