### PR TITLE
Make `InitSettingsSource` resolution deterministic

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -268,8 +268,9 @@ class InitSettingsSource(PydanticBaseSettingsSource):
             init_kwarg_name = init_kwarg_names & set(alias_names)
             if init_kwarg_name:
                 preferred_alias = alias_names[0]
+                preferred_set_alias = next(alias for alias in alias_names if alias in init_kwarg_name)
                 init_kwarg_names -= init_kwarg_name
-                self.init_kwargs[preferred_alias] = init_kwargs[init_kwarg_name.pop()]
+                self.init_kwargs[preferred_alias] = init_kwargs[preferred_set_alias]
         self.init_kwargs.update({key: val for key, val in init_kwargs.items() if key in init_kwarg_names})
 
         super().__init__(settings_cls)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -699,11 +699,6 @@ def test_alias_resolution_init_source(env):
     assert Example(name='john', PREFIX_SURNAME='doe').model_dump() == {'name': 'john', 'last_name': 'doe'}
 
 
-@pytest.mark.xfail(
-    reason='This test is expected to fail in some sessions due to `InitSettingsSource`s non-deterministic behaviour.'
-    "Simply repeating through parameterization won't help as the underlying reason is the non-deterministic "
-    'nature of python sets, which will remain constant within the same session.'
-)
 def test_init_kwargs_alias_resolution_deterministic():
     class Example(BaseSettings):
         name: str

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -699,6 +699,21 @@ def test_alias_resolution_init_source(env):
     assert Example(name='john', PREFIX_SURNAME='doe').model_dump() == {'name': 'john', 'last_name': 'doe'}
 
 
+@pytest.mark.xfail(
+    reason='This test is expected to fail in some sessions due to `InitSettingsSource`s non-deterministic behaviour.'
+    "Simply repeating through parameterization won't help as the underlying reason is the non-deterministic "
+    'nature of python sets, which will remain constant within the same session.'
+)
+def test_init_kwargs_alias_resolution_deterministic():
+    class Example(BaseSettings):
+        name: str
+        last_name: str = Field(validation_alias=AliasChoices('surname', 'last_name'))
+
+    result = Example(name='john', surname='doe', last_name='smith').model_dump()
+
+    assert result == {'name': 'john', 'last_name': 'doe'}
+
+
 def test_alias_nested_model_default_partial_update():
     class SubModel(BaseModel):
         v1: str = 'default'


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/pydantic/pydantic-settings/issues/679, by making the alias resolution in `InitSettingsSource` deterministically follow the configured precedence.