### PR TITLE
Unpack type alisases when looking for `NoDecode`

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -24,6 +24,7 @@ from .types import EnvNoneType, ForceDecode, NoDecode, PathType, PydanticModel, 
 from .utils import (
     _annotation_is_complex,
     _get_alias_names,
+    _get_field_metadata,
     _get_model_fields,
     _strip_annotated,
     _union_is_complex,
@@ -179,7 +180,7 @@ class PydanticBaseSettingsSource(ABC):
             The decoded value for further preparation
         """
         if field and (
-            NoDecode in field.metadata
+            NoDecode in _get_field_metadata(field)
             or (self.config.get('enable_decoding') is False and ForceDecode not in field.metadata)
         ):
             return value

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -11,6 +11,7 @@ from typing import Any, cast, get_args, get_origin
 from pydantic import BaseModel, Json, RootModel, Secret
 from pydantic._internal._utils import is_model_class
 from pydantic.dataclasses import is_pydantic_dataclass
+from pydantic.fields import FieldInfo
 from typing_inspection import typing_objects
 
 from ..exceptions import SettingsError
@@ -70,6 +71,18 @@ def _annotation_is_complex(annotation: Any, metadata: list[Any]) -> bool:
         or hasattr(origin, '__pydantic_core_schema__')
         or hasattr(origin, '__get_pydantic_core_schema__')
     )
+
+
+def _get_field_metadata(field: FieldInfo) -> list[Any]:
+    annotation = field.annotation
+    metadata = field.metadata
+    if typing_objects.is_typealiastype(annotation) or typing_objects.is_typealiastype(get_origin(annotation)):
+        annotation = annotation.__value__  # type: ignore[union-attr]
+    origin = get_origin(annotation)
+    if typing_objects.is_annotated(origin):
+        _, *meta = get_args(annotation)
+        metadata += meta
+    return metadata
 
 
 def _annotation_is_complex_inner(annotation: type[Any] | None) -> bool:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -499,6 +499,24 @@ def test_annotated_with_type(env):
     assert s.apples == ['russet', 'granny smith']
 
 
+def test_annotated_with_type_no_decode(env):
+    A = TypeAliasType('A', Annotated[list[str], NoDecode])
+
+    class Settings(BaseSettings):
+        a: A
+
+        # decode the value here. the field value won't be decoded because of NoDecode
+        @field_validator('a', mode='before')
+        @classmethod
+        def decode_a(cls, v: str) -> list[str]:
+            return json.loads(v)
+
+    env.set('a', '["one", "two"]')
+
+    s = Settings()
+    assert s.model_dump() == {'a': ['one', 'two']}
+
+
 def test_set_dict_model(env):
     env.set('bananas', '[1, 2, 3, 3]')
     env.set('CARROTS', '{"a": null, "b": 4}')


### PR DESCRIPTION
Provide field metadata utility function to properly handle Annotated types.

The issue was mentioned [here](https://github.com/pydantic/pydantic-settings/pull/644#issuecomment-3345774638).

Fixes https://github.com/pydantic/pydantic-settings/issues/715.