### PR TITLE
Hide default None value in cli_hide_none_type is set

### DIFF
--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -1258,7 +1258,9 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                 ifdef = 'ifdef: ' if model_default is None else ''
                 _help += f' ({ifdef}required)' if _help else f'({ifdef}required)'
         else:
-            default = f'(default: {self.cli_parse_none_str})'
+            default = ''
+            if not self.cli_hide_none_type:
+                default = f'(default: {self.cli_parse_none_str})'
             if is_model_class(type(model_default)) or is_pydantic_dataclass(type(model_default)):
                 default = f'(default: {getattr(model_default, field_name)})'
             elif model_default not in (PydanticUndefined, None) and _is_function(model_default):


### PR DESCRIPTION
When a field defaults to None, displaying `(default: null)` provides no additional information to users. The absence of a default value already implies None/null for optional fields, and this matches the behavior of most CLI tools (argparse, click) where optional arguments don't display `default: None`.  Users expect optional CLI arguments to default to None implicitly.

This change aligns pydantic-settings with standard CLI tool conventions (argparse, click) where None defaults are hidden. Also, this reduces visual noise in help messages:

```python
class Settings(BaseSettings):
    model_config = SettingsConfigDict(
        cli_hide_none_type=True,
    )

    foo: Path | None
    bar: str | None
    baz: str | None = None
    timeout: int = 50
    config: Path | None = None
```

**before**

```
usage: main.py [-h] [--foo Path] [--bar str] [--baz str] [--timeout int] [--config Path]

options:
  -h, --help     show this help message and exit
  --foo Path     (required)
  --bar str      (required)
  --baz str      (default: null)
  --timeout int  (default: 50)
  --config Path  (default: null)
```

**after**

```
usage: main.py [-h] [--foo Path] [--bar str] [--baz str] [--timeout int] [--config Path]

options:
  -h, --help     show this help message and exit
  --foo Path     (required)
  --bar str      (required)
  --baz str
  --timeout int  (default: 50)
  --config Path
```

As this MR alters the behavior of `cli_hide_none_type`, you might prefer adding another flag to support this, e.g. `cli_hide_none_type_defaults`?  