### PR TITLE
Avoid conflicts with the `NAME` environment variable in WSL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -863,10 +863,10 @@ from pydantic_settings import BaseSettings
 
 class User(BaseSettings, cli_parse_args=True):
     first_name: str = Field(
-        validation_alias=AliasChoices('f', 'fname', AliasPath('name', 0))
+        validation_alias=AliasChoices('f', 'fname', AliasPath('fullname', 0))
     )
     last_name: str = Field(
-        validation_alias=AliasChoices('l', 'lname', AliasPath('name', 1))
+        validation_alias=AliasChoices('l', 'lname', AliasPath('fullname', 1))
     )
 
 
@@ -878,11 +878,11 @@ sys.argv = ['example.py', '-f', 'John', '-l', 'Doe']
 print(User().model_dump())
 #> {'first_name': 'John', 'last_name': 'Doe'}
 
-sys.argv = ['example.py', '--name', 'John,Doe']
+sys.argv = ['example.py', '--fullname', 'John,Doe']
 print(User().model_dump())
 #> {'first_name': 'John', 'last_name': 'Doe'}
 
-sys.argv = ['example.py', '--name', 'John', '--lname', 'Doe']
+sys.argv = ['example.py', '--fullname', 'John', '--lname', 'Doe']
 print(User().model_dump())
 #> {'first_name': 'John', 'last_name': 'Doe'}
 ```


### PR DESCRIPTION
Fix #745

On WSL, the `NAME` environment variable is set automatically, which causes an error when the example is run as-is via copy and paste.
To avoid this, it was renamed to `fullname`.

I also considered using `USERNAME`, but avoided it as well since it appears to be used by zsh.
