### PR TITLE
Support reading .env files from FIFOs (e.g. 1Password Environments)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -663,6 +663,11 @@ validating them.
     If a filename is specified for `env_file`, Pydantic will only check the current working directory and
     won't check any parent directories for the `.env` file.
 
+!!! tip
+    Named pipes (FIFOs) are also supported as dotenv files. This is useful for tools like
+    [1Password Environments](https://developer.1password.com/docs/environments), which mount `.env` files as
+    named pipes to provide secrets on demand without writing them to disk.
+
 Even when using a dotenv file, *pydantic* will still read environment variables as well as the dotenv file,
 **environment variables will always take priority over values loaded from a dotenv file**.
 

--- a/pydantic_settings/sources/providers/dotenv.py
+++ b/pydantic_settings/sources/providers/dotenv.py
@@ -99,7 +99,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
         dotenv_vars: dict[str, str | None] = {}
         for env_file in env_files:
             env_path = Path(env_file).expanduser()
-            if env_path.is_file():
+            if env_path.is_file() or env_path.is_fifo():
                 dotenv_vars.update(self._read_env_file(env_path))
 
         return dotenv_vars

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1596,6 +1596,34 @@ def test_read_dotenv_vars(tmp_path):
     }
 
 
+@pytest.mark.skipif(not hasattr(os, 'mkfifo'), reason='requires os.mkfifo (Unix)')
+def test_read_dotenv_vars_from_fifo(tmp_path):
+    """Named pipes / FIFOs (e.g. 1Password Environments) should be read as env files."""
+    import threading
+
+    env_content = 'KEY=value\nOTHER=123'
+    fifo_path = tmp_path / '.env'
+    os.mkfifo(fifo_path)
+
+    def write_to_fifo():
+        with fifo_path.open('w') as f:
+            f.write(env_content)
+
+    thread = threading.Thread(target=write_to_fifo)
+    thread.start()
+
+    try:
+        source = DotEnvSettingsSource(
+            BaseSettings(), env_file=fifo_path, env_file_encoding='utf8', case_sensitive=False
+        )
+        assert dict(source.env_vars) == {'key': 'value', 'other': '123'}
+    finally:
+        thread.join(timeout=1)
+        if thread.is_alive():
+            fifo_path.read_text()  # writer may be blocked without a read
+            thread.join(timeout=1)
+
+
 def test_read_dotenv_vars_when_env_file_is_none():
     assert (
         DotEnvSettingsSource(


### PR DESCRIPTION
1Password Environments mounts `.env` files as named pipes (FIFOs). These were previously skipped because the `is_file()` check returns `False` for FIFOs. This adds an `is_fifo()` check so they are read normally.

https://developer.1password.com/docs/environments

Closes #771