### PR TITLE
Fix CLI parsing error for set field types since 2.13.0 (#787)

### DIFF
--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -621,7 +621,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         cli_arg_map = self._parser_map.get(field_name, {})
         try:
             list_adapter: Any = TypeAdapter(next(iter(cli_arg_map.values())).field_info.annotation)
-            is_num_type_str = type(list_adapter.validate_python(['1'])[0]) is str
+            is_num_type_str = type(next(iter(list_adapter.validate_python(['1'])))) is str
         except (StopIteration, ValidationError):
             is_num_type_str = None
         for index, item in enumerate(merged_list):

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -812,6 +812,18 @@ def test_cli_list_arg(prefix, arg_spaces):
     check_answer(cfg, prefix, expected)
 
 
+def test_cli_set_arg():
+    class Cfg(BaseSettings):
+        str_set: set[str] | None = None
+        num_set: set[int] | None = None
+
+    cfg = CliApp.run(Cfg, cli_args=['--str_set', 'a,b', '--str_set', 'c'])
+    assert cfg.model_dump() == {'str_set': {'a', 'b', 'c'}, 'num_set': None}
+
+    cfg = CliApp.run(Cfg, cli_args=['--num_set', '1,2', '--num_set', '3'])
+    assert cfg.model_dump() == {'str_set': None, 'num_set': {1, 2, 3}}
+
+
 @pytest.mark.parametrize('arg_spaces', [no_add_cli_arg_spaces, add_cli_arg_spaces])
 def test_cli_list_json_value_parsing(arg_spaces):
     class Cfg(BaseSettings):


### PR DESCRIPTION
Fixes #787

## Summary
- Fix `SettingsError: 'set' object is not subscriptable` when using `set[str]` or `set[int]` fields with `cli_parse_args=True`
- The numeric type coercion added in #769 used `[0]` to index the result of `validate_python`, which fails for `set` types since sets are not subscriptable
- Use `next(iter(...))` instead which works for any iterable (lists, sets, frozensets, etc.)

## Test plan
- [x] Added `test_cli_set_arg` covering `set[str]` and `set[int]` CLI argument parsing
- [x] All 166 CLI tests pass
- [x] `make format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)