### PR TITLE
Fix RecursionError with mutually recursive models in CLI

### DIFF
--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -912,6 +912,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             group=None,
             alias_prefixes=[],
             model_default=PydanticUndefined,
+            model_path=set(),
         )
 
     def _add_default_help(self) -> None:
@@ -944,7 +945,11 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         is_model_suppressed: bool = False,
         discriminator_vals: dict[str, set[Any]] = {},
         is_last_discriminator: bool = True,
+        model_path: set[type[BaseModel]] | None = None,
     ) -> ArgumentParser:
+        if model_path is None:
+            model_path = set()
+        model_path = model_path | {model}
         subparsers: Any = None
         alias_path_args: dict[str, int | None] = {}
         # Ignore model default if the default is a model and not a subclass of the current model.
@@ -1014,6 +1019,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                         group=None,
                         alias_prefixes=[],
                         model_default=PydanticUndefined,
+                        model_path=model_path,
                     )
             else:
                 flag_prefix: str = self._cli_flag_prefix
@@ -1045,7 +1051,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
 
                 self._convert_bool_flag(arg.kwargs, field_info, model_default)
 
-                non_recursive_sub_models = [m for m in arg.sub_models if m is not model]
+                non_recursive_sub_models = [m for m in arg.sub_models if m not in model_path]
                 if (
                     arg.is_parser_submodel
                     and not getattr(field_info.annotation, '__pydantic_root_model__', False)
@@ -1066,6 +1072,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                         arg.alias_names,
                         model_default=model_default,
                         is_model_suppressed=is_model_suppressed,
+                        model_path=model_path,
                     )
                 elif _CliUnknownArgs in field_info.metadata:
                     self._cli_unknown_args[arg.kwargs['dest']] = []
@@ -1192,6 +1199,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         alias_names: tuple[str, ...],
         model_default: Any,
         is_model_suppressed: bool,
+        model_path: set[type[BaseModel]] | None = None,
     ) -> None:
         if issubclass(model, CliMutuallyExclusiveGroup):
             # Argparse has deprecated "calling add_argument_group() or add_mutually_exclusive_group() on a
@@ -1258,6 +1266,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                 is_model_suppressed=is_model_suppressed,
                 discriminator_vals=discriminator_vals,
                 is_last_discriminator=model is sub_models[-1],
+                model_path=model_path,
             )
 
     def _add_parser_alias_paths(


### PR DESCRIPTION
## Summary

- Fixes the remaining case from #781 reported in [this comment](https://github.com/pydantic/pydantic-settings/issues/781#issuecomment-3940538757)
- The previous fix (4a98429) only prevented **direct** self-recursion (`Foo -> Foo`) by checking `m is not model`
- This did not handle **indirect/mutual** recursion where models reference each other through discriminated unions (e.g., `B` has field `Union[A, B, C]` and `C` has field `Union[A, B, C]`, creating a cycle `B -> C -> B -> ...`)
- Now tracks the full ancestor `model_path` set through recursion and filters sub-models against all visited ancestors

## Test plan

- [x] Added `test_cli_mutually_recursive_models` covering the exact scenario from the issue comment (discriminated unions with mutually recursive models)
- [x] Existing `test_cli_self_referential_model` still passes (direct self-recursion)
- [x] Full CLI test suite passes (167 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)