### PR TITLE
Fix env_file from model_config ignored in CliApp.run() (#795)

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -272,7 +272,7 @@ class BaseSettings(BaseModel):
         _nested_model_default_partial_update: bool | None = None,
         _env_prefix: str | None = None,
         _env_prefix_target: EnvPrefixTarget | None = None,
-        _env_file: DotenvType | None = None,
+        _env_file: DotenvType | None = ENV_FILE_SENTINEL,
         _env_file_encoding: str | None = None,
         _env_ignore_empty: bool | None = None,
         _env_nested_delimiter: str | None = None,

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -3244,3 +3244,24 @@ contents options:
                         (default: null)
 """
     )
+
+
+def test_cli_app_run_env_file_from_model_config(tmp_path):
+    """Regression test for https://github.com/pydantic/pydantic-settings/issues/795
+
+    CliApp.run() should respect env_file set in model_config even when _env_file
+    is not explicitly passed.
+    """
+    env_file = tmp_path / '.env'
+    env_file.write_text('TEST=from dotenv\n')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file=str(env_file), env_file_encoding='utf-8')
+
+        test: str = 'default'
+
+        def cli_cmd(self) -> None:
+            pass
+
+    result = CliApp.run(Settings, cli_args=[])
+    assert result.test == 'from dotenv'


### PR DESCRIPTION
The _env_file default in _settings_init_sources was None instead of ENV_FILE_SENTINEL, causing the model_config env_file to be skipped when CliApp.run() calls _settings_init_sources without _env_file.