### PR TITLE
fix: resolve KeyError in run_subcommand for underscore field names

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -787,8 +787,7 @@ class CliApp:
 
         subcommand_cls = cast(type[BaseModel], type(subcommand))
         subcommand_arg = cli_settings_source._parser_map[subcommand_dest][subcommand_cls]
-        subcommand_alias = subcommand_arg.subcommand_alias(subcommand_cls)
-        subcommand_dest = f'{subcommand_dest.split(":")[0]}{subcommand_alias}.:subcommand'
+        subcommand_dest = f'{subcommand_arg.dest}.:subcommand'
         subcommand_parser = subcommand_arg.parser
         CliApp._subcommand_stack[id(subcommand)] = (cli_settings_source, subcommand_parser, subcommand_dest)
         try:

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -3265,3 +3265,31 @@ def test_cli_app_run_env_file_from_model_config(tmp_path):
 
     result = CliApp.run(Settings, cli_args=[])
     assert result.test == 'from dotenv'
+
+
+def test_cli_app_run_subcommand_underscore_field_name():
+    class Leaf(BaseModel):
+        name: str
+
+        def cli_cmd(self) -> None:
+            self.name = f'Hello {self.name}'
+
+    class MiddleCommands(BaseModel):
+        baz: CliSubCommand[Leaf]
+
+        def cli_cmd(self) -> None:
+            CliApp.run_subcommand(self)
+
+    class RootApp(BaseModel):
+        # Underscore in the field name triggers the bug
+        foo_bar: CliSubCommand[MiddleCommands]
+
+        def cli_cmd(self) -> None:
+            CliApp.run_subcommand(self)
+
+    result = CliApp.run(RootApp, cli_args=['foo-bar', 'baz', '--name=world'])
+    assert result.model_dump() == {
+        'foo_bar': {
+            'baz': {'name': 'Hello world'},
+        },
+    }


### PR DESCRIPTION
run_subcommand (added in #759) built the `_parser_map` lookup key using the kebab-cased `subcommand_alias `(e.g. "foo-bar"), but parser construction keys the map using `arg.dest` which preserves the original field name (e.g. "foo_bar"). At the second nesting level this mismatch causes a `KeyError`.

Use `subcommand_arg.dest` to build the next `subcommand_dest`, matching how the map was keyed during construction. This also removes the now unused `subcommand_alias` local variable.

Selected Reviewer: @samuelcolvin