### PR TITLE
Fix AliasChoices ignored when changing provider priority

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -520,8 +520,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
             A tuple that contains the value, preferred key and a flag to determine whether value is complex.
         """
         field_value, field_key, value_is_complex = self.get_field_value(field, field_name)
-        # Only use preferred_key when no value was found; otherwise preserve the key that matched
-        if field_value is None and not (
+        if not (
             value_is_complex
             or (
                 (self.config.get('populate_by_name', False) or self.config.get('validate_by_name', False))
@@ -529,8 +528,12 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
             )
         ):
             field_infos = self._extract_field_info(field, field_name)
-            preferred_key, *_ = field_infos[0]
-            return field_value, preferred_key, value_is_complex
+            preferred_key, _, preferred_is_complex = field_infos[0]
+            # Only normalize to preferred_key when it's a simple string alias.
+            # When the preferred key comes from an AliasPath (complex entry), skip normalization
+            # to avoid using the AliasPath's first element as the key (see #766).
+            if not preferred_is_complex:
+                return field_value, preferred_key, value_is_complex
         return field_value, field_key, value_is_complex
 
     def __call__(self) -> dict[str, Any]:

--- a/tests/test_precedence_and_merging.py
+++ b/tests/test_precedence_and_merging.py
@@ -3,7 +3,8 @@ from __future__ import annotations as _annotations
 from pathlib import Path
 from typing import Literal
 
-from pydantic import AnyHttpUrl, Field
+from pydantic import AliasChoices, AliasGenerator, AnyHttpUrl, Field
+from pydantic.alias_generators import to_camel
 
 from pydantic_settings import (
     BaseSettings,
@@ -117,6 +118,51 @@ def test_merging_preserves_earlier_values(tmp_path: Path, env):
     assert s.b == 20  # init wins
     # nested: dotenv provides x=1; env provides y=3; deep merged => {x:1, y:3}
     assert s.nested == {'x': 1, 'y': 3}
+
+
+def test_env_overrides_init_with_alias_choices_and_custom_source_order(env):
+    """Regression test for https://github.com/pydantic/pydantic-settings/issues/812
+
+    When using AliasChoices with an AliasGenerator and custom source ordering
+    (env > init), env variables should take precedence over init kwargs even when
+    different alias choices match in each source.
+    """
+    to_snake_or_camel = AliasGenerator(
+        validation_alias=lambda field_name: AliasChoices(f'PREF_{field_name}', to_camel(field_name), field_name)
+    )
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(alias_generator=to_snake_or_camel, extra='ignore')
+
+        interval: int = Field(60, ge=60)
+        data_store_path: str = '/data'
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return env_settings, init_settings, dotenv_settings, file_secret_settings
+
+    # Env var using the PREF_ prefix (first alias choice) should override init
+    env.set('PREF_INTERVAL', '120')
+    s = Settings(interval=73)
+    assert s.interval == 120
+
+    # Env var using camelCase (second alias choice) should override init
+    env.set('dataStorePath', '/env-data')
+    s = Settings(data_store_path='/init-data')
+    assert s.data_store_path == '/env-data'
+
+    # Env var using field name (third alias choice) should override init
+    env.pop('dataStorePath')
+    env.set('data_store_path', '/env-data-2')
+    s = Settings(data_store_path='/init-data')
+    assert s.data_store_path == '/env-data-2'
 
 
 def test_init_kwargs_override_env_with_alias_and_extra_forbid(env):


### PR DESCRIPTION
## Summary
- Fixes #812: `AliasChoices` with `AliasGenerator` were ignored when customizing source priority (e.g. env > init)
- The fix in #767 (`a04b034`) stopped normalizing env source keys to the preferred alias when a value was found, causing different sources to emit different keys for the same field. `deep_update` couldn't deduplicate them, and `_settings_restore_init_kwarg_names` picked the wrong (lower-priority) value.
- Now we normalize to `preferred_key` unless it comes from an `AliasPath` (complex entry), which preserves the fix for #766 while restoring correct key normalization for string-only `AliasChoices`.

## Test plan
- [x] Added regression test `test_env_overrides_init_with_alias_choices_and_custom_source_order` covering all three alias variants (prefixed, camelCase, field_name) with env > init ordering
- [x] Existing test for #766 (`test_validation_alias_alias_choices_with_alias_path_first`) still passes
- [x] Full test suite passes (190/190)

🤖 Generated with [Claude Code](https://claude.com/claude-code)