### PR TITLE
Fix case-insensitive matching in InitSettingsSource

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -280,9 +280,13 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         nested_model_default_partial_update: bool | None = None,
     ):
         self.init_kwargs = {}
-        init_kwarg_names = set(init_kwargs.keys())
+        case_sensitive = settings_cls.model_config.get('case_sensitive', False)
+        _apply_case = (lambda v: v) if case_sensitive else str.lower
+        init_kwarg_names = set(_apply_case(k) for k in init_kwargs.keys())
+        # Build a mapping from lowered key to original key for case-insensitive lookup
+        init_kwargs_lower = {_apply_case(k): v for k, v in init_kwargs.items()}
         for field_name, field_info in settings_cls.model_fields.items():
-            alias_names, *_ = _get_alias_names(field_name, field_info)
+            alias_names, *_ = _get_alias_names(field_name, field_info, case_sensitive=case_sensitive)
             # When populate_by_name is True, allow using the field name as an input key,
             # but normalize to the preferred alias to keep keys consistent across sources.
             matchable_names = set(alias_names)
@@ -290,23 +294,23 @@ class InitSettingsSource(PydanticBaseSettingsSource):
                 'validate_by_name', False
             )
             if include_name:
-                matchable_names.add(field_name)
+                matchable_names.add(_apply_case(field_name))
             init_kwarg_name = init_kwarg_names & matchable_names
             if init_kwarg_name:
                 preferred_alias = alias_names[0] if alias_names else field_name
                 # Choose provided key deterministically: prefer the first alias in alias_names order;
                 # fall back to field_name if allowed and provided.
                 provided_key = next((alias for alias in alias_names if alias in init_kwarg_names), None)
-                if provided_key is None and include_name and field_name in init_kwarg_names:
-                    provided_key = field_name
+                if provided_key is None and include_name and _apply_case(field_name) in init_kwarg_names:
+                    provided_key = _apply_case(field_name)
                 # provided_key should not be None here because init_kwarg_name is non-empty
                 assert provided_key is not None
                 init_kwarg_names -= init_kwarg_name
-                self.init_kwargs[preferred_alias] = init_kwargs[provided_key]
+                self.init_kwargs[preferred_alias] = init_kwargs_lower[provided_key]
         # Include any remaining init kwargs (e.g., extras) unchanged
         # Note: If populate_by_name is True and the provided key is the field name, but
         # no alias exists, we keep it as-is so it can be processed as extra if allowed.
-        self.init_kwargs.update({key: val for key, val in init_kwargs.items() if key in init_kwarg_names})
+        self.init_kwargs.update({key: val for key, val in init_kwargs.items() if _apply_case(key) in init_kwarg_names})
 
         super().__init__(settings_cls)
         self.nested_model_default_partial_update = (

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2547,6 +2547,25 @@ def test_case_sensitive_from_args(monkeypatch):
     ]
 
 
+def test_init_settings_source_case_sensitive():
+    """case_sensitive=False should apply to InitSettingsSource as well as EnvSettingsSource."""
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
+        test: str = 'default'
+
+    settings = Settings(TeSt='override')
+    assert settings.model_dump() == {'test': 'override'}
+
+    # With case_sensitive=True, mismatched keys should not match
+    class StrictSettings(BaseSettings):
+        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
+        test: str = 'default'
+
+    s = StrictSettings(TeSt='override')
+    assert s.model_dump() == {'test': 'default', 'TeSt': 'override'}
+
+
 def test_env_prefix_from_args(env):
     class Settings(BaseSettings):
         apple: str


### PR DESCRIPTION
## Summary

Fixes #562.

 was not respecting the `case_sensitive` model config setting when matching init kwargs to field aliases. This meant that `Settings(TeSt=value)` would not match a `test` field when `case_sensitive=False`.

## Changes

1. **Pass `case_sensitive` to `_get_alias_names()`** in `InitSettingsSource.__init__` so that alias names are properly lowercased when case-insensitive matching is enabled.

2. **Lowercase `init_kwarg_names`** for proper set intersection when `case_sensitive=False`.

3. **Add test case** `test_init_settings_source_case_sensitive` to verify the fix.

## Test

```python
class Settings(BaseSettings):
    model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
    test: str = 'default'

settings = Settings(TeSt='override')
assert settings.model_dump() == {'test': 'override'}
```

Before this fix, `TeSt` would not match `test` and would be treated as an extra field.