### PR TITLE
Migrate `boto3-stubs` to `types-boto3`

### DIFF
--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -21,7 +21,7 @@ def import_aws_secrets_manager() -> None:
 
     try:
         from boto3 import client as boto3_client
-        from mypy_boto3_secretsmanager.client import SecretsManagerClient
+        from types_boto3_secretsmanager.client import SecretsManagerClient
     except ImportError as e:  # pragma: no cover
         raise ImportError(
             'AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dynamic = ['version']
 yaml = ["pyyaml>=6.0.1"]
 toml = ["tomli>=2.0.1"]
 azure-key-vault = ["azure-keyvault-secrets>=4.8.0", "azure-identity>=1.16.0"]
-aws-secrets-manager = ["boto3>=1.35.0", "boto3-stubs[secretsmanager]"]
+aws-secrets-manager = ["boto3>=1.35.0", "types-boto3[secretsmanager]"]
 gcp-secret-manager = [
     "google-cloud-secret-manager>=2.23.1",
 ]
@@ -70,7 +70,7 @@ linting = [
     "pyyaml",
     "ruff",
     "types-pyyaml",
-    "boto3-stubs[secretsmanager]",
+    "types-boto3[secretsmanager]",
 ]
 testing = [
     "coverage[toml]",

--- a/uv.lock
+++ b/uv.lock
@@ -119,25 +119,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3-stubs"
-version = "1.42.60"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore-stubs" },
-    { name = "types-s3transfer" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/0d/2db11a9c84744ce963d625e73d1e0f4f5fdd50e028edc9ec702f3713abfb/boto3_stubs-1.42.60.tar.gz", hash = "sha256:6b6d2614f44d042275d5070bb0d59001bb665ade353aa49aadb349f78077f088", size = 101014, upload-time = "2026-03-03T21:38:38.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/6b/4f13c623b08a2160b3b6b69a70e37db01f9d6238611a875be8b2c7ed3b4f/boto3_stubs-1.42.60-py3-none-any.whl", hash = "sha256:5f1a55c8bfcaca3c02c0e70d485373c7663f5eca3aeeebd8f36a112e47e2d1dd", size = 69827, upload-time = "2026-03-03T21:38:33.429Z" },
-]
-
-[package.optional-dependencies]
-secretsmanager = [
-    { name = "mypy-boto3-secretsmanager" },
-]
-
-[[package]]
 name = "botocore"
 version = "1.42.77"
 source = { registry = "https://pypi.org/simple" }
@@ -1105,18 +1086,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-boto3-secretsmanager"
-version = "1.42.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/58/ccae71b7b7f550eab01d600e956d57e6e6bb9148dbf5d116696d0dc43369/mypy_boto3_secretsmanager-1.42.8.tar.gz", hash = "sha256:5ab42f35ce932765ebb1684146f478a87cc4b83bef950fd1aa0e268b88d59c81", size = 19863, upload-time = "2025-12-11T22:12:51.045Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/42/90cef7241c98f6e504cabc9a99d89dd38b84e4d40ff0774c89bc871ffb18/mypy_boto3_secretsmanager-1.42.8-py3-none-any.whl", hash = "sha256:50c891a88e725a8dba7444018e47590ea63d8e938abe2b1c0b25e5413f39d51d", size = 27243, upload-time = "2025-12-11T22:12:44.389Z" },
-]
-
-[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1388,7 +1357,7 @@ dependencies = [
 [package.optional-dependencies]
 aws-secrets-manager = [
     { name = "boto3" },
-    { name = "boto3-stubs", extra = ["secretsmanager"] },
+    { name = "types-boto3", extra = ["secretsmanager"] },
 ]
 azure-key-vault = [
     { name = "azure-identity" },
@@ -1407,11 +1376,11 @@ yaml = [
 [package.dev-dependencies]
 linting = [
     { name = "black" },
-    { name = "boto3-stubs", extra = ["secretsmanager"] },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-boto3", extra = ["secretsmanager"] },
     { name = "types-pyyaml" },
 ]
 testing = [
@@ -1430,12 +1399,12 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'azure-key-vault'", specifier = ">=1.16.0" },
     { name = "azure-keyvault-secrets", marker = "extra == 'azure-key-vault'", specifier = ">=4.8.0" },
     { name = "boto3", marker = "extra == 'aws-secrets-manager'", specifier = ">=1.35.0" },
-    { name = "boto3-stubs", extras = ["secretsmanager"], marker = "extra == 'aws-secrets-manager'" },
     { name = "google-cloud-secret-manager", marker = "extra == 'gcp-secret-manager'", specifier = ">=2.23.1" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "python-dotenv", specifier = ">=0.21.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.1" },
     { name = "tomli", marker = "extra == 'toml'", specifier = ">=2.0.1" },
+    { name = "types-boto3", extras = ["secretsmanager"], marker = "extra == 'aws-secrets-manager'" },
     { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
 provides-extras = ["aws-secrets-manager", "azure-key-vault", "gcp-secret-manager", "toml", "yaml"]
@@ -1443,11 +1412,11 @@ provides-extras = ["aws-secrets-manager", "azure-key-vault", "gcp-secret-manager
 [package.metadata.requires-dev]
 linting = [
     { name = "black" },
-    { name = "boto3-stubs", extras = ["secretsmanager"] },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-boto3", extras = ["secretsmanager"] },
     { name = "types-pyyaml" },
 ]
 testing = [
@@ -1839,6 +1808,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/24/5497a611f32cbaf4b9e1af35f56463e8f02e198ec513b68cb59a63f5a446/types_awscrt-0.31.2.tar.gz", hash = "sha256:dc79705acd24094656b8105b8d799d7e273c8eac37c69137df580cd84beb54f6", size = 18190, upload-time = "2026-02-16T02:33:53.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/3d/21a2212b5fcef9e8e9f368403885dc567b7d31e50b2ce393efad3cd83572/types_awscrt-0.31.2-py3-none-any.whl", hash = "sha256:3d6a29c1cca894b191be408f4d985a8e3a14d919785652dd3fa4ee558143e4bf", size = 43340, upload-time = "2026-02-16T02:33:52.109Z" },
+]
+
+[[package]]
+name = "types-boto3"
+version = "1.42.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/ca/d6bf0c7816f7d9d38196c60579172ffcf68b07123e3968f7468c218ae316/types_boto3-1.42.78.tar.gz", hash = "sha256:132e0dc52a718f858f8a79436422848c4efe1c89e87d748784aecef3d1f69965", size = 102016, upload-time = "2026-03-27T19:35:45.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/68/52ff5bab810f89ed873abad375c3aa98161f79042ef5007bde7cc7bee3f3/types_boto3-1.42.78-py3-none-any.whl", hash = "sha256:fe1576d3a518422534ff8372cf0fcaf9856eec3fa096d31a72d2d6ca62e0b956", size = 70062, upload-time = "2026-03-27T19:35:37.828Z" },
+]
+
+[package.optional-dependencies]
+secretsmanager = [
+    { name = "types-boto3-secretsmanager" },
+]
+
+[[package]]
+name = "types-boto3-secretsmanager"
+version = "1.42.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/06/2b13da1dea04e74ff941150d2fc5fa59a9a180f8e580425d21157895ed32/types_boto3_secretsmanager-1.42.8.tar.gz", hash = "sha256:9134df496a352acff861c3d046ae83740881d7aead1bc656d1ca32abcb921ae3", size = 19889, upload-time = "2025-12-11T22:12:47.67Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/63/15a5649fbf769e92d0a55c1091696d50ebb922ba77735c263c27267011df/types_boto3_secretsmanager-1.42.8-py3-none-any.whl", hash = "sha256:af75257c3c26da97a8ee470bb1a2e199a25bf70859740cdcdfb74f53853f24da", size = 27194, upload-time = "2025-12-11T22:12:39.498Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace `boto3-stubs[secretsmanager]` with `types-boto3[secretsmanager]` in optional and dev dependencies
- Update import from `mypy_boto3_secretsmanager` to `types_boto3_secretsmanager`

The `boto3-stubs` GitHub repository has been moved with a **301 - MOVED PERMANENTLY** notice pointing to [`youtype/types-boto3`](https://github.com/youtype/types-boto3). While the maintainer still publishes to both PyPI package names, the canonical home is now `types-boto3`.

Fixes #828

## Test plan

- [ ] CI passes (existing AWS Secrets Manager tests cover the import path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)