### PR TITLE
Fix CliPositionalArg[list[CustomType]] crash for custom types

### DIFF
--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -37,7 +37,7 @@ from typing import (
     overload,
 )
 
-from pydantic import AliasChoices, AliasPath, BaseModel, Field, PrivateAttr, TypeAdapter, ValidationError
+from pydantic import AliasChoices, AliasPath, BaseModel, Field, PrivateAttr, TypeAdapter
 from pydantic._internal._repr import Representation
 from pydantic._internal._utils import is_model_class
 from pydantic.dataclasses import is_pydantic_dataclass
@@ -637,7 +637,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         try:
             list_adapter: Any = TypeAdapter(next(iter(cli_arg_map.values())).field_info.annotation)
             is_num_type_str = type(next(iter(list_adapter.validate_python(['1'])))) is str
-        except (StopIteration, ValidationError):
+        except Exception:
             is_num_type_str = None
         for index, item in enumerate(merged_list):
             cli_arg = cli_arg_map.get(index)

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -19,6 +19,7 @@ from pydantic import (
     DirectoryPath,
     Discriminator,
     Field,
+    GetCoreSchemaHandler,
     RootModel,
     Tag,
     ValidationError,
@@ -29,6 +30,7 @@ from pydantic import (
     dataclasses as pydantic_dataclasses,
 )
 from pydantic._internal._repr import Representation
+from pydantic_core import CoreSchema, core_schema
 
 from pydantic_settings import (
     BaseSettings,
@@ -1563,6 +1565,37 @@ def test_cli_variadic_positional_arg(env):
 
     assert CliApp.run(MainOptional, cli_args=['7', '8', '9']).model_dump() == {'values': [7, 8, 9]}
     assert CliApp.run(MainRequired, cli_args=['7', '8', '9']).model_dump() == {'values': [7, 8, 9]}
+
+
+def test_cli_variadic_positional_arg_custom_type():
+    """Test that CliPositionalArg[list[CustomType]] works with custom types that raise non-ValidationError exceptions.
+
+    Regression test for https://github.com/pydantic/pydantic-settings/issues/823
+    """
+    from string import ascii_letters
+
+    class AsciiLetters(str):
+        def __new__(cls, content: object) -> 'AsciiLetters':
+            if not all(c in ascii_letters for c in str(content)):
+                raise Exception('Non-ascii letter')
+            return super().__new__(cls, content)
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            source_type: Any,
+            handler: GetCoreSchemaHandler,
+        ) -> CoreSchema:
+            return core_schema.no_info_plain_validator_function(
+                cls,
+                serialization=core_schema.to_string_ser_schema(),
+            )
+
+    class App(BaseSettings):
+        args: CliPositionalArg[list[AsciiLetters]]
+
+    assert CliApp.run(App, cli_args=['a', 'b']).model_dump() == {'args': ['a', 'b']}
+    assert CliApp.run(App, cli_args=['hello']).model_dump() == {'args': ['hello']}
 
 
 def test_cli_enums(capsys, monkeypatch):


### PR DESCRIPTION
## Summary
- Fix `CliPositionalArg[list[CustomType]]` crashing when the custom type's validator raises a non-`ValidationError` exception (e.g. plain `Exception`, `ValueError`, `TypeError`)
- The `_merged_list_to_str` method probes the inner type by calling `validate_python(['1'])` — if this fails for any reason, the safe fallback is `is_num_type_str = None`. Widened the `except` clause from `(StopIteration, ValidationError)` to `Exception`
- Added regression test with a custom `str` subclass that raises plain `Exception`

Fixes #823

## Test plan
- [x] New test `test_cli_variadic_positional_arg_custom_type` passes
- [x] All 177 existing CLI tests pass (176 + 1 new)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)