### PR TITLE
Fix field named `cls` conflicting with classmethod parameter

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -240,7 +240,7 @@ class BaseSettings(BaseModel):
                 _cli_kebab_case=_cli_kebab_case,
                 _cli_shortcuts=_cli_shortcuts,
                 _secrets_dir=_secrets_dir,
-                **values,
+                _init_kwargs=values,
             )
         )
 
@@ -300,7 +300,7 @@ class BaseSettings(BaseModel):
         _cli_kebab_case: bool | Literal['all', 'no_enums'] | None = None,
         _cli_shortcuts: Mapping[str, str | list[str]] | None = None,
         _secrets_dir: PathType | None = None,
-        **init_kwargs: dict[str, Any],
+        _init_kwargs: dict[str, Any] | None = None,
     ) -> tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any]]:
         # Determine settings config values
         case_sensitive = _case_sensitive if _case_sensitive is not None else cls.model_config.get('case_sensitive')
@@ -378,7 +378,7 @@ class BaseSettings(BaseModel):
         )
         init_settings = InitSettingsSource(
             cls,
-            init_kwargs=init_kwargs,
+            init_kwargs=_init_kwargs if _init_kwargs is not None else {},
             nested_model_default_partial_update=nested_model_default_partial_update,
         )
         env_settings = EnvSettingsSource(
@@ -451,7 +451,7 @@ class BaseSettings(BaseModel):
 
         cls._settings_warn_unused_config_keys(sources, cls.model_config)
 
-        return sources, init_kwargs
+        return sources, _init_kwargs if _init_kwargs is not None else {}
 
     @classmethod
     def _settings_build_values(
@@ -723,19 +723,25 @@ class CliApp:
         elif isinstance(cli_parse_args, (Namespace, SimpleNamespace, dict)):
             raise SettingsError('Error: `cli_args` must be list[str] or None when `cli_settings_source` is not used')
 
-        model_init_data['_cli_parse_args'] = cli_parse_args
-        model_init_data['_cli_exit_on_error'] = cli_exit_on_error
-        model_init_data['_cli_settings_source'] = cli_settings
+        _settings_kwargs = {
+            '_cli_parse_args': cli_parse_args,
+            '_cli_exit_on_error': cli_exit_on_error,
+            '_cli_settings_source': cli_settings,
+        }
         if not issubclass(model_cls, BaseSettings):
             base_settings_cls = CliApp._get_base_settings_cls(model_cls)
-            sources, init_kwargs = base_settings_cls._settings_init_sources(**model_init_data)
+            sources, init_kwargs = base_settings_cls._settings_init_sources(
+                _init_kwargs=model_init_data, **_settings_kwargs
+            )
             model = base_settings_cls(**base_settings_cls._settings_build_values(sources, init_kwargs))
             model_init_data = {}
             for field_name, field_info in base_settings_cls.model_fields.items():
                 model_init_data[_field_name_for_signature(field_name, field_info)] = getattr(model, field_name)
             command = model_cls(**model_init_data)
         else:
-            sources, init_kwargs = model_cls._settings_init_sources(**model_init_data)
+            sources, init_kwargs = model_cls._settings_init_sources(
+                _init_kwargs=model_init_data, **_settings_kwargs
+            )
             command = model_cls(_build_sources=(sources, init_kwargs))
 
         subcommand_dest = ':subcommand'

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -723,15 +723,13 @@ class CliApp:
         elif isinstance(cli_parse_args, (Namespace, SimpleNamespace, dict)):
             raise SettingsError('Error: `cli_args` must be list[str] or None when `cli_settings_source` is not used')
 
-        _settings_kwargs = {
-            '_cli_parse_args': cli_parse_args,
-            '_cli_exit_on_error': cli_exit_on_error,
-            '_cli_settings_source': cli_settings,
-        }
         if not issubclass(model_cls, BaseSettings):
             base_settings_cls = CliApp._get_base_settings_cls(model_cls)
             sources, init_kwargs = base_settings_cls._settings_init_sources(
-                _init_kwargs=model_init_data, **_settings_kwargs
+                _cli_parse_args=cli_parse_args,  # type: ignore[arg-type]
+                _cli_exit_on_error=cli_exit_on_error,
+                _cli_settings_source=cli_settings,
+                _init_kwargs=model_init_data,
             )
             model = base_settings_cls(**base_settings_cls._settings_build_values(sources, init_kwargs))
             model_init_data = {}
@@ -740,7 +738,10 @@ class CliApp:
             command = model_cls(**model_init_data)
         else:
             sources, init_kwargs = model_cls._settings_init_sources(
-                _init_kwargs=model_init_data, **_settings_kwargs
+                _cli_parse_args=cli_parse_args,  # type: ignore[arg-type]
+                _cli_exit_on_error=cli_exit_on_error,
+                _cli_settings_source=cli_settings,
+                _init_kwargs=model_init_data,
             )
             command = model_cls(_build_sources=(sources, init_kwargs))
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3689,3 +3689,13 @@ def test_env_literal_numeric_enum(field_type, env_val, expected, env):
     env.set('VAL', env_val)
     cfg = Cfg()
     assert cfg.val is expected
+
+
+def test_field_named_cls():
+    """Test that a model with a field named `cls` works correctly (GH-857)."""
+
+    class Settings(BaseSettings):
+        cls: str = 'Foo'
+
+    s = Settings.model_validate({'cls': 'Foo'})
+    assert s.cls == 'Foo'


### PR DESCRIPTION
## Summary
- Fixes #857 — having a model field named `cls` caused `TypeError: BaseSettings._settings_init_sources() got multiple values for argument 'cls'`
- Root cause: `_settings_init_sources` is a `@classmethod` receiving `cls` implicitly. User field values were spread via `**values`, so a field named `cls` collided with that parameter.
- Fix: pass user field values as a single `_init_kwargs` dict parameter instead of unpacking them with `**values`. Also applied the same fix to `CliApp.run` which had the same pattern.

## Test plan
- [x] Verified the reproducer from the issue works:
  ```python
  from pydantic_settings import BaseSettings

  class Settings(BaseSettings):
      cls: str = "Foo"

  Settings.model_validate({"cls": "Foo"})  # no longer raises TypeError
  ```
- [x] All 611 existing tests pass
- [x] Tested edge cases with other potentially conflicting field names (`values`, `sources`, `self_field`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)