### PR TITLE
Patch default help for user provided _CliInternalArgParser

### DIFF
--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -14,8 +14,8 @@ from argparse import (
     BooleanOptionalAction,
     Namespace,
     RawDescriptionHelpFormatter,
-    _SubParsersAction,
     _HelpAction,
+    _SubParsersAction,
 )
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
@@ -995,7 +995,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                     if 'help' in alias_names:
                         return
 
-            if not any([_HelpAction == type(_) for _ in self._root_parser._actions]):
+            if not any([_HelpAction is type(_) for _ in self._root_parser._actions]):
                 self._add_argument(
                     self.root_parser,
                     f'{self._cli_flag_prefix[:1]}h',

--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -15,6 +15,7 @@ from argparse import (
     Namespace,
     RawDescriptionHelpFormatter,
     _SubParsersAction,
+    _HelpAction,
 )
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
@@ -994,14 +995,15 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                     if 'help' in alias_names:
                         return
 
-            self._add_argument(
-                self.root_parser,
-                f'{self._cli_flag_prefix[:1]}h',
-                f'{self._cli_flag_prefix[:2]}help',
-                action='help',
-                default=SUPPRESS,
-                help='show this help message and exit',
-            )
+            if not any([_HelpAction == type(_) for _ in self._root_parser._actions]):
+                self._add_argument(
+                    self.root_parser,
+                    f'{self._cli_flag_prefix[:1]}h',
+                    f'{self._cli_flag_prefix[:2]}help',
+                    action='help',
+                    default=SUPPRESS,
+                    help='show this help message and exit',
+                )
 
     def _add_parser_args(
         self,


### PR DESCRIPTION
In my project we use ``_CliInternalArgParser`` directly with ``add_help=True``, which causes an argparse error:
```bash
argparse.ArgumentError: argument -h/--help: conflicting option strings: -h, --help
```

This patch checks the registered actions for the ``argparse._HelpAction`` type, to prevent the issue.

To reproduce this error:
```python
from pydantic_settings.sources.providers.cli import _CliInternalArgParser
from pydantic_settings import CliSettingsSource
from pydantic import BaseModel

CliSettingsSource(root_parser=_CliInternalArgParser(add_help=True), settings_cls=type("Model", (BaseModel,), {}))
```

Selected Reviewer: @samuelcolvin