### PR TITLE
Defer GoogleSecretManagerSettingsSource client initialization to __call__

### DIFF
--- a/pydantic_settings/sources/providers/gcp.py
+++ b/pydantic_settings/sources/providers/gcp.py
@@ -130,9 +130,10 @@ class GoogleSecretManagerMapping(Mapping[str, str | None]):
 
 
 class GoogleSecretManagerSettingsSource(EnvSettingsSource):
-    _credentials: Credentials
-    _secret_client: SecretManagerServiceClient
-    _project_id: str
+    _credentials: Credentials | None
+    _secret_client: SecretManagerServiceClient | None
+    _project_id: str | None
+    _provided_secret_client: SecretManagerServiceClient | None
 
     def __init__(
         self,
@@ -145,34 +146,11 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
         secret_client: SecretManagerServiceClient | None = None,
         case_sensitive: bool | None = True,
     ) -> None:
-        # Import Google Packages if they haven't already been imported
-        if SecretManagerServiceClient is None or Credentials is None or google_auth_default is None:
-            import_gcp_secret_manager()
-
-        # If credentials or project_id are not passed, then
-        # try to get them from the default function
-        if not credentials or not project_id:
-            _creds, _project_id = google_auth_default()
-
-        # Set the credentials and/or project id if they weren't specified
-        if credentials is None:
-            credentials = _creds
-
-        if project_id is None:
-            if isinstance(_project_id, str):
-                project_id = _project_id
-            else:
-                raise AttributeError(
-                    'project_id is required to be specified either as an argument or from the google.auth.default. See https://google-auth.readthedocs.io/en/master/reference/google.auth.html#google.auth.default'
-                )
-
-        self._credentials: Credentials = credentials
-        self._project_id: str = project_id
-
-        if secret_client:
-            self._secret_client = secret_client
-        else:
-            self._secret_client = SecretManagerServiceClient(credentials=self._credentials)
+        # Store init-time arguments for deferred initialization in __call__
+        self._credentials = credentials
+        self._project_id = project_id
+        self._provided_secret_client = secret_client
+        self._secret_client = None
 
         super().__init__(
             settings_cls,
@@ -182,6 +160,44 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,
         )
+
+    def _initialize_client(self) -> None:
+        """Initialize the GCP client, resolving project_id from current_state if not provided."""
+        # Import Google Packages if they haven't already been imported
+        if SecretManagerServiceClient is None or Credentials is None or google_auth_default is None:
+            import_gcp_secret_manager()
+
+        project_id = self._project_id
+
+        # Try to get project_id from a previous source if not explicitly provided
+        if project_id is None:
+            project_id = self.current_state.get('project_id')
+
+        credentials = self._credentials
+
+        # If credentials or project_id are still missing, fall back to google.auth.default
+        if not credentials or not project_id:
+            _creds, _project_id = google_auth_default()
+
+            if credentials is None:
+                credentials = _creds
+
+            if project_id is None:
+                if _project_id is not None:
+                    project_id = _project_id
+                else:
+                    raise AttributeError(
+                        'project_id is required to be specified either as an argument, from a previous settings source, '
+                        'or from google.auth.default. See https://google-auth.readthedocs.io/en/master/reference/google.auth.html#google.auth.default'
+                    )
+
+        self._credentials = credentials
+        self._project_id = project_id
+
+        if self._provided_secret_client is not None:
+            self._secret_client = self._provided_secret_client
+        else:
+            self._secret_client = SecretManagerServiceClient(credentials=self._credentials)
 
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         """Override get_field_value to get the secret value from GCP Secret Manager.
@@ -230,9 +246,17 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
         return val, key, is_complex
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
+        if self._secret_client is None or self._project_id is None:
+            # Return empty mapping during __init__; real mapping is set in __call__
+            return {}
         return GoogleSecretManagerMapping(
             self._secret_client, project_id=self._project_id, case_sensitive=self.case_sensitive
         )
+
+    def __call__(self) -> dict[str, Any]:
+        self._initialize_client()
+        self.env_vars = self._load_env_vars()
+        return super().__call__()
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(project_id={self._project_id!r}, env_nested_delimiter={self.env_nested_delimiter!r})'

--- a/tests/test_source_gcp_secret_manager.py
+++ b/tests/test_source_gcp_secret_manager.py
@@ -152,6 +152,8 @@ class TestGoogleSecretManagerSettingsSource:
             credentials = mocker.Mock()
 
         source = GoogleSecretManagerSettingsSource(test_settings, credentials=credentials, project_id=project_id)
+        # Client initialization is deferred to __call__, so resolve it now to check project_id
+        source._initialize_client()
         assert source._project_id == expected_project_id
         if credentials:
             assert source._credentials == credentials
@@ -160,8 +162,37 @@ class TestGoogleSecretManagerSettingsSource:
         credentials = mocker.Mock()
         mocker.patch('pydantic_settings.sources.providers.gcp.google_auth_default', return_value=(mocker.Mock(), None))
 
+        source = GoogleSecretManagerSettingsSource(test_settings, credentials=credentials)
+        # Error is now raised at __call__ time (deferred initialization), not __init__
         with pytest.raises(AttributeError):
-            _ = GoogleSecretManagerSettingsSource(test_settings, credentials=credentials)
+            source._initialize_client()
+
+    def test_project_id_from_current_state(self, mock_secret_client_factory, mocker):
+        """project_id can be omitted and fetched from a previous source via current_state."""
+        mocker.patch('pydantic_settings.sources.providers.gcp.google_auth_default', return_value=(mocker.Mock(), None))
+        client = mock_secret_client_factory([{'name': 'api_key', 'project': 'state-project', 'value': 'secret-val'}])
+
+        class Settings(BaseSettings):
+            project_id: str
+            api_key: str = 'default'
+
+            @classmethod
+            def settings_customise_sources(
+                cls,
+                settings_cls: type[BaseSettings],
+                init_settings: PydanticBaseSettingsSource,
+                env_settings: PydanticBaseSettingsSource,
+                dotenv_settings: PydanticBaseSettingsSource,
+                file_secret_settings: PydanticBaseSettingsSource,
+            ) -> tuple[PydanticBaseSettingsSource, ...]:
+                return (
+                    init_settings,
+                    GoogleSecretManagerSettingsSource(settings_cls, secret_client=client),
+                )
+
+        settings = Settings(project_id='state-project')
+        assert settings.project_id == 'state-project'
+        assert settings.api_key == 'secret-val'
 
     def test_settings_source_load_env_vars(self, mock_secret_client, mocker, test_settings):
         credentials = mocker.Mock()


### PR DESCRIPTION
## Summary

- **Lazy GCP client init**: All GCP setup (`google_auth_default`, `SecretManagerServiceClient`) is moved out of `__init__` into a new `_initialize_client()` method, called from `__call__`. This avoids side-effects (network calls, credential resolution) at import/construction time.
- **`project_id` from previous sources**: If `project_id` is not explicitly passed, `_initialize_client()` checks `self.current_state.get('project_id')` — which is populated by previously-run settings sources — before falling back to `google_auth_default()`. This enables patterns like placing the GCP project ID in environment variables or init kwargs and having the GCP source pick it up automatically.
- **`_load_env_vars()` guard**: Returns an empty dict during `__init__` (before the client exists); `__call__` repopulates `self.env_vars` with the real `GoogleSecretManagerMapping` before delegating to the parent.
- **Idiomatic None check**: Replaced `isinstance(_project_id, str)` with `_project_id is not None`.
- **Test updates**: Two existing tests updated to call `_initialize_client()` explicitly (since resolution is now deferred); new `test_project_id_from_current_state` verifies the end-to-end flow.