### PR TITLE
docs: clarify environment variable helper descriptions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -92,15 +92,15 @@ print(Settings().model_dump())
 
     Check the [`Field` documentation](fields.md#field-aliases) for more information.
 
-3. The [`AliasChoices`][pydantic.AliasChoices] class allows to have multiple environment variable names for a single field.
+3. The [`AliasChoices`][pydantic.AliasChoices] class allows you to have multiple environment variable names for a single field.
    The first environment variable that is found will be used.
 
     Check the [documentation on alias choices](alias.md#aliaspath-and-aliaschoices) for more information.
 
-4. The [`ImportString`][pydantic.types.ImportString] class allows to import an object from a string.
+4. The [`ImportString`][pydantic.types.ImportString] class allows you to import an object from a string.
    In this case, the environment variable `special_function` will be read and the function [`math.cos`][] will be imported.
 
-5. The `env_prefix` config setting allows to set a prefix for all environment variables.
+5. The `env_prefix` config setting allows you to set a prefix for all environment variables.
 
     Check the [Environment variable names documentation](#environment-variable-names) for more information.
 
@@ -2271,7 +2271,7 @@ Same as `case_sensitive`, but works for secrets only. If not specified, defaults
 #### secrets_nested_delimiter
 
 Same as `env_nested_delimiter`, but works for secrets only. If not specified, defaults to `env_nested_delimiter`.
-This option is used to implement _nested secrets directory_ layout and allows to do even nasty things
+This option is used to implement _nested secrets directory_ layout and allows you to do even nasty things
 like `/run/secrets/model/delim/nested1/delim/nested2`.
 
 #### secrets_nested_subdir


### PR DESCRIPTION
Polishes three descriptions in the settings documentation so they read more naturally.

- Clarifies the AliasChoices, ImportString, and env_prefix descriptions
- Documentation-only change; no runtime behavior change
- Verified with git diff --check

Tooling: Kimi-assisted edit, reviewed before submission.