### PR TITLE
Handle single-character validation aliases consistently

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -387,7 +387,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                 for alias in v_alias:
                     if isinstance(alias, str):  # AliasPath
                         field_info.append(
-                            (alias, self._apply_case_sensitive(env_prefix + alias), True if len(alias) > 1 else False)
+                            (alias, self._apply_case_sensitive(env_prefix + alias), len(v_alias) > 1)
                         )
                     elif isinstance(alias, list):  # AliasChoices
                         first_arg = cast(str, alias[0])  # first item of an AliasChoices must be a str

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -993,6 +993,22 @@ def test_validation_alias_alias_choices_with_alias_path_first(env):
     assert Settings().my_field == 'env-value'
 
 
+def test_validation_alias_alias_path_short_components(env):
+    """Test that plain AliasPath with single-character components works correctly.
+
+    Regression test: _extract_field_info incorrectly used len(alias) > 1 on the
+    string component itself rather than len(v_alias) > 1 on the AliasPath list,
+    causing short AliasPath components to be treated as non-complex and leading
+    to incorrect key normalization.
+    """
+
+    class Settings(BaseSettings):
+        my_field: str = Field(default='default', validation_alias=AliasPath('a', 'b'))
+
+    env.set('a', '{"b": "found"}')
+    assert Settings().my_field == 'found'
+
+
 def test_validation_alias_with_env_prefix(env):
     class Settings(BaseSettings):
         foobar: str = Field(validation_alias='foo')


### PR DESCRIPTION
When multiple validation aliases are configured, single-character aliases should be treated consistently with longer aliases.

This updates the alias handling branch and adds focused regression coverage for the single-character case.

Verification:
- uv run pytest tests/test_settings.py -q