### PR TITLE
Skip partial update merging for discriminated union fields

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -228,6 +228,15 @@ class ConfigFileSourceMixin(ABC):
         pass
 
 
+def _has_discriminator(field_info: FieldInfo) -> bool:
+    """Check if a field uses a discriminated union (via Annotated or Field(discriminator=...))."""
+    if field_info.discriminator is not None:
+        return True
+    from pydantic import Discriminator
+
+    return any(isinstance(m, Discriminator) for m in field_info.metadata)
+
+
 class DefaultSettingsSource(PydanticBaseSettingsSource):
     """
     Source class for loading default object values.
@@ -248,6 +257,8 @@ class DefaultSettingsSource(PydanticBaseSettingsSource):
         )
         if self.nested_model_default_partial_update:
             for field_name, field_info in settings_cls.model_fields.items():
+                if _has_discriminator(field_info):
+                    continue
                 alias_names, *_ = _get_alias_names(field_name, field_info)
                 preferred_alias = alias_names[0]
                 if is_dataclass(type(field_info.default)):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,6 +18,7 @@ from pydantic import (
     AliasGenerator,
     AliasPath,
     BaseModel,
+    ConfigDict,
     Discriminator,
     Field,
     HttpUrl,
@@ -828,6 +829,49 @@ def test_alias_nested_model_default_partial_update():
         'v0': 'ok',
         'sub_model': {'v1': 'cli', 'v2': b'hello', 'v3': 33},
     }
+
+
+def test_nested_model_default_partial_update_with_discriminated_union():
+    """Test that nested_model_default_partial_update skips discriminated union fields.
+
+    When a field uses a discriminated union, the default model's fields should not bleed
+    into the incoming value when the discriminator selects a different type.
+    See: https://github.com/pydantic/pydantic-settings/issues/871
+    """
+
+    class SubModel1(BaseModel):
+        discriminator: Literal['submodel1'] = 'submodel1'
+        submodel1_field: str = 'foo'
+
+    class SubModel2(BaseModel):
+        model_config = ConfigDict(extra='forbid')
+        discriminator: Literal['submodel2'] = 'submodel2'
+
+    # Test with Annotated[..., Discriminator(...)]
+    class SettingsAnnotated(BaseSettings):
+        model_config = SettingsConfigDict(nested_model_default_partial_update=True)
+        root_field: Annotated[SubModel1 | SubModel2, Discriminator('discriminator')] = SubModel1()
+
+    result = SettingsAnnotated.model_validate_json('{"root_field": {"discriminator": "submodel2"}}')
+    assert result.root_field == SubModel2()
+
+    # Test with Field(discriminator=...)
+    class SettingsField(BaseSettings):
+        model_config = SettingsConfigDict(nested_model_default_partial_update=True)
+        root_field: SubModel1 | SubModel2 = Field(default=SubModel1(), discriminator='discriminator')
+
+    result = SettingsField.model_validate_json('{"root_field": {"discriminator": "submodel2"}}')
+    assert result.root_field == SubModel2()
+
+    # Test that selecting the same type as the default still works
+    result = SettingsAnnotated.model_validate_json(
+        '{"root_field": {"discriminator": "submodel1", "submodel1_field": "bar"}}'
+    )
+    assert result.root_field == SubModel1(submodel1_field='bar')
+
+    # Test that the default is used when no value is provided
+    result = SettingsAnnotated.model_validate_json('{}')
+    assert result.root_field == SubModel1()
 
 
 def test_env_str(env):


### PR DESCRIPTION
## Summary
- Fix `nested_model_default_partial_update=True` breaking discriminated unions by merging default model fields into a different discriminated type
- Skip dumping defaults for fields that use a discriminator (both `Annotated[..., Discriminator(...)]` and `Field(discriminator=...)`)
- Add tests covering the discriminated union case

Fixes #871

## Test plan
- [x] New test `test_nested_model_default_partial_update_with_discriminated_union` covers:
  - `Annotated[..., Discriminator(...)]` style
  - `Field(discriminator=...)` style
  - Same-type selection still works
  - Default used when no value provided
- [x] Existing `partial_update` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)