### PR TITLE
GoogleSecretManagerSettingsSource: read project_id from previous sources

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2575,7 +2575,7 @@ The `project_id` is resolved lazily when the source is read, in the following or
 
 This lets the project be supplied by another settings source (for example an environment variable or an init argument) instead of being hardcoded. For example, with `GoogleSecretManagerSettingsSource(settings_cls, project_id_field='gcp_project')` the source uses the `gcp_project` value resolved by an earlier source as its project.
 
-`project_id_field` matches a *model field name* (or its preferred alias when a `validation_alias` is set), not an environment variable name. If your settings model has `gcp_project: str = Field(alias='GCP_PROJECT')` and the project is provided via the `GCP_PROJECT` env var, set `project_id_field='GCP_PROJECT'` (the alias the earlier source uses as a key), not `'gcp_project'`.
+`project_id_field` must match the key that the earlier source uses in `current_state` — this is typically the field's preferred alias. For example, if your settings model has `gcp_project: str = Field(alias='GCP_PROJECT')`, use `project_id_field='GCP_PROJECT'` (the alias), not `'gcp_project'` (the Python attribute name).
 
 ### Nested Models
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2565,6 +2565,18 @@ The `GoogleSecretManagerSettingsSource` supports several authentication methods:
 
 2. **Explicit credentials** - You can also provide `credentials` directly. e.g. `sa_credentials = google.oauth2.service_account.Credentials.from_service_account_file('path/to/service-account.json')` and then `GoogleSecretManagerSettingsSource(credentials=sa_credentials)`
 
+### Project ID resolution
+
+The `project_id` is resolved lazily when the source is read, in the following order of precedence:
+
+1. the explicit `project_id` argument if it was passed
+2. the value resolved by a previous (higher priority) settings source - by default the `project_id` field, configurable via the `project_id_field` argument
+3. [`google.auth.default()`](https://google-auth.readthedocs.io/en/master/reference/google.auth.html#google.auth.default)
+
+This lets the project be supplied by another settings source (for example an environment variable or an init argument) instead of being hardcoded. For example, with `GoogleSecretManagerSettingsSource(settings_cls, project_id_field='gcp_project')` the source uses the `gcp_project` value resolved by an earlier source as its project.
+
+`project_id_field` matches a *model field name* (or its preferred alias when a `validation_alias` is set), not an environment variable name. If your settings model has `gcp_project: str = Field(alias='GCP_PROJECT')` and the project is provided via the `GCP_PROJECT` env var, set `project_id_field='GCP_PROJECT'` (the alias the earlier source uses as a key), not `'gcp_project'`.
+
 ### Nested Models
 
 For nested models, Secret Manager supports the `env_nested_delimiter` setting as long as it complies with the [naming rules](https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets#create-a-secret). In the example above, you would create secrets named `database__password` and `database__user` in Secret Manager.

--- a/pydantic_settings/sources/providers/gcp.py
+++ b/pydantic_settings/sources/providers/gcp.py
@@ -153,9 +153,10 @@ class GoogleSecretManagerMapping(Mapping[str, str | None]):
 
 
 class GoogleSecretManagerSettingsSource(EnvSettingsSource):
-    _credentials: Credentials
-    _secret_client: SecretManagerServiceClient
-    _project_id: str
+    _credentials: Credentials | None
+    _secret_client: SecretManagerServiceClient | None
+    _project_id: str | None
+    _explicit_project_id: str | None
 
     def __init__(
         self,
@@ -167,35 +168,43 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
         env_parse_enums: bool | None = None,
         secret_client: SecretManagerServiceClient | None = None,
         case_sensitive: bool | None = True,
+        project_id_field: str = 'project_id',
     ) -> None:
+        """Settings source that reads secrets from Google Cloud Secret Manager.
+
+        Args:
+            project_id: The GCP project to read secrets from. If not provided, it is
+                resolved lazily (see below).
+            project_id_field: The key, populated by a previous (higher priority)
+                settings source, to use as the ``project_id`` when one is not passed
+                explicitly. This is the model field name — or its preferred alias when
+                a ``validation_alias`` is set — under which the project ID is exposed by
+                the previous source, NOT an environment variable name. For example with
+                ``some_field: str = Field(alias='GCP_PROJECT')`` set ``project_id_field``
+                to ``'GCP_PROJECT'``. Defaults to ``'project_id'``.
+
+        The ``project_id`` is resolved lazily in :meth:`__call__` rather than at
+        construction time so that it can be sourced from settings resolved by previous
+        sources (only available via ``current_state`` once the source is called).
+        Resolution order is:
+
+        1. the explicit ``project_id`` argument
+        2. the ``project_id_field`` value from previous settings sources
+        3. ``google.auth.default()``
+        """
         # Import Google Packages if they haven't already been imported
         if SecretManagerServiceClient is None or Credentials is None or google_auth_default is None:
             import_gcp_secret_manager()
 
-        # If credentials or project_id are not passed, then
-        # try to get them from the default function
-        if not credentials or not project_id:
-            _creds, _project_id = google_auth_default()
-
-        # Set the credentials and/or project id if they weren't specified
-        if credentials is None:
-            credentials = _creds
-
-        if project_id is None:
-            if isinstance(_project_id, str):
-                project_id = _project_id
-            else:
-                raise AttributeError(
-                    'project_id is required to be specified either as an argument or from the google.auth.default. See https://google-auth.readthedocs.io/en/master/reference/google.auth.html#google.auth.default'
-                )
-
-        self._credentials: Credentials = credentials
-        self._project_id: str = project_id
-
-        if secret_client:
-            self._secret_client = secret_client
-        else:
-            self._secret_client = SecretManagerServiceClient(credentials=self._credentials)
+        # Resolution is deferred to __call__ (see _resolve_gcp_project / _load_env_vars).
+        # _explicit_project_id is the immutable user input; _project_id is the resolved
+        # value and is written exclusively by _resolve_gcp_project.
+        self._explicit_project_id = project_id
+        self._project_id = None
+        self._credentials = credentials
+        self._secret_client = secret_client
+        self._project_id_field = project_id_field
+        self._env_vars_loaded = False
 
         super().__init__(
             settings_cls,
@@ -205,6 +214,8 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,
         )
+        # __init__ is past; subsequent _load_env_vars() calls may now resolve the project.
+        self._env_vars_loaded = True
 
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         """Override get_field_value to get the secret value from GCP Secret Manager.
@@ -255,13 +266,73 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
             return val, field_name, is_complex
         return val, key, is_complex
 
+    def _resolve_gcp_project(self) -> None:
+        """Resolve the credentials, project_id and Secret Manager client.
+
+        ``project_id`` is resolved, in order of precedence, from: the explicit
+        ``project_id`` argument, the ``project_id_field`` value from previous settings
+        sources (``current_state``), and finally ``google.auth.default()``.
+        """
+        project_id = self._explicit_project_id
+        credentials = self._credentials
+
+        # Fall back to a value resolved by a previous (higher priority) settings source.
+        if project_id is None:
+            state_project_id = self.current_state.get(self._project_id_field)
+            if isinstance(state_project_id, str):
+                project_id = state_project_id
+
+        # Fall back to google.auth.default for whatever is still missing.
+        # Credentials are only needed if we have to build a client ourselves — if the
+        # caller supplied a pre-built secret_client we can skip the auth call entirely
+        # when project_id is also known, avoiding an unnecessary RPC / file read.
+        need_credentials = self._secret_client is None and credentials is None
+        need_project = project_id is None
+        if need_credentials or need_project:
+            _creds, _project_id = google_auth_default()
+            if need_credentials:
+                credentials = _creds
+            if need_project and isinstance(_project_id, str):
+                project_id = _project_id
+
+        if project_id is None:
+            raise AttributeError(
+                'project_id is required to be specified either as an argument, via a previous '
+                'settings source, or from google.auth.default. See '
+                'https://google-auth.readthedocs.io/en/master/reference/google.auth.html#google.auth.default'
+            )
+
+        self._credentials = credentials
+        self._project_id = project_id
+        if self._secret_client is None:
+            self._secret_client = SecretManagerServiceClient(credentials=self._credentials)
+
     def _load_env_vars(self) -> Mapping[str, str | None]:
+        # During __init__ the previous sources have not run yet, so defer building the
+        # mapping until __call__, where current_state (and thus project_id) is available.
+        if not self._env_vars_loaded:
+            return {}
+
+        self._resolve_gcp_project()
+        assert self._project_id is not None and self._secret_client is not None
         return GoogleSecretManagerMapping(
             self._secret_client, project_id=self._project_id, case_sensitive=self.case_sensitive
         )
 
+    def __call__(self) -> dict[str, Any]:
+        # current_state is populated by previous sources right before __call__; (re)build
+        # the mapping now so project_id can be sourced from them.
+        self._env_vars_loaded = True
+        self.env_vars = self._load_env_vars()
+        return super().__call__()
+
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}(project_id={self._project_id!r}, env_nested_delimiter={self.env_nested_delimiter!r})'
+        # Prefer the resolved project_id, falling back to the explicit constructor
+        # arg so the repr is informative before the source has been called.
+        project_id = self._project_id if self._project_id is not None else self._explicit_project_id
+        return (
+            f'{self.__class__.__name__}(project_id={project_id!r}, env_nested_delimiter={self.env_nested_delimiter!r})'
+        )
 
 
 __all__ = ['GoogleSecretManagerSettingsSource', 'GoogleSecretManagerMapping']

--- a/pydantic_settings/sources/providers/gcp.py
+++ b/pydantic_settings/sources/providers/gcp.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic.fields import FieldInfo
 
+from ...exceptions import SettingsError
 from ..types import SecretVersion
 from .env import EnvSettingsSource
 
@@ -273,6 +274,9 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
         ``project_id`` argument, the ``project_id_field`` value from previous settings
         sources (``current_state``), and finally ``google.auth.default()``.
         """
+        if self._project_id is not None:
+            return
+
         project_id = self._explicit_project_id
         credentials = self._credentials
 
@@ -314,7 +318,11 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
             return {}
 
         self._resolve_gcp_project()
-        assert self._project_id is not None and self._secret_client is not None
+        if self._project_id is None or self._secret_client is None:
+            raise SettingsError(
+                'GoogleSecretManagerSettingsSource: could not determine GCP project_id or initialize the Secret Manager client. '
+                'Pass project_id explicitly or ensure it is available via application default credentials or a previous settings source.'
+            )
         return GoogleSecretManagerMapping(
             self._secret_client, project_id=self._project_id, case_sensitive=self.case_sensitive
         )

--- a/pydantic_settings/sources/providers/gcp.py
+++ b/pydantic_settings/sources/providers/gcp.py
@@ -177,11 +177,11 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
                 resolved lazily (see below).
             project_id_field: The key, populated by a previous (higher priority)
                 settings source, to use as the ``project_id`` when one is not passed
-                explicitly. This is the model field name — or its preferred alias when
-                a ``validation_alias`` is set — under which the project ID is exposed by
-                the previous source, NOT an environment variable name. For example with
-                ``some_field: str = Field(alias='GCP_PROJECT')`` set ``project_id_field``
-                to ``'GCP_PROJECT'``. Defaults to ``'project_id'``.
+                explicitly. This must match the key used in ``current_state`` by the
+                previous source (typically the field name or its preferred alias).
+                For example, with ``some_field: str = Field(alias='GCP_PROJECT')``,
+                previous env sources will expose the value under ``'GCP_PROJECT'``.
+                Defaults to ``'project_id'``.
 
         The ``project_id`` is resolved lazily in :meth:`__call__` rather than at
         construction time so that it can be sourced from settings resolved by previous

--- a/tests/test_source_gcp_secret_manager.py
+++ b/tests/test_source_gcp_secret_manager.py
@@ -176,6 +176,8 @@ class TestGoogleSecretManagerSettingsSource:
             credentials = mocker.Mock()
 
         source = GoogleSecretManagerSettingsSource(test_settings, credentials=credentials, project_id=project_id)
+        # project_id (and credentials) are resolved lazily, not at construction time.
+        source._resolve_gcp_project()
         assert source._project_id == expected_project_id
         if credentials:
             assert source._credentials == credentials
@@ -184,8 +186,11 @@ class TestGoogleSecretManagerSettingsSource:
         credentials = mocker.Mock()
         mocker.patch('pydantic_settings.sources.providers.gcp.google_auth_default', return_value=(mocker.Mock(), None))
 
+        # this used to raise an AttributeError if project_id was missing at instantiation time
+        # now project_id is resolved lazily, so the error surfaces when the source resolves it.
+        source = GoogleSecretManagerSettingsSource(test_settings, credentials=credentials)
         with pytest.raises(AttributeError):
-            _ = GoogleSecretManagerSettingsSource(test_settings, credentials=credentials)
+            source._resolve_gcp_project()
 
     def test_settings_source_load_env_vars(self, mock_secret_client, mocker, test_settings):
         credentials = mocker.Mock()
@@ -201,6 +206,79 @@ class TestGoogleSecretManagerSettingsSource:
         source = GoogleSecretManagerSettingsSource(test_settings, project_id='test-project')
         assert 'test-project' in repr(source)
         assert 'GoogleSecretManagerSettingsSource' in repr(source)
+
+    def test_settings_source_project_id_from_previous_source(self, mocker, test_settings):
+        source = GoogleSecretManagerSettingsSource(test_settings)
+        source._set_current_state({'project_id': 'project-from-previous-source'})
+
+        source._resolve_gcp_project()
+
+        # A value resolved by a previous source takes precedence over google.auth.default.
+        assert source._project_id == 'project-from-previous-source'
+
+    def test_settings_source_explicit_project_id_overrides_previous_source(self, mocker, test_settings):
+        source = GoogleSecretManagerSettingsSource(test_settings, project_id='explicit-project')
+        source._set_current_state({'project_id': 'project-from-previous-source'})
+
+        source._resolve_gcp_project()
+
+        # The explicit project_id argument takes precedence over a previous source.
+        assert source._project_id == 'explicit-project'
+
+    def test_settings_source_custom_project_id_field(self, mocker, test_settings):
+        source = GoogleSecretManagerSettingsSource(test_settings, project_id_field='gcp_project')
+        source._set_current_state({'gcp_project': 'project-from-custom-field'})
+
+        source._resolve_gcp_project()
+
+        assert source._project_id == 'project-from-custom-field'
+
+    def test_pydantic_base_settings_project_id_from_env_source(self, mock_secret_client_factory, monkeypatch, mocker):
+        """End-to-end: an earlier env_settings source provides project_id and the GCP source picks it up."""
+        # Register the test secret under the project name we expect the source to resolve to,
+        # so a successful access proves the env-supplied project was used.
+        secret_client = mock_secret_client_factory(
+            [{'project': 'project-from-env', 'name': 'test-secret', 'value': 'test-value'}]
+        )
+        # Patch google_auth_default to a *different* project so we can distinguish
+        # env-resolved from auth-default-resolved. Also assert it isn't called at all
+        # since the user supplied a secret_client and an env-resolved project_id.
+        auth_default = mocker.patch(
+            'pydantic_settings.sources.providers.gcp.google_auth_default',
+            return_value=(mocker.Mock(), 'project-from-auth-default'),
+        )
+        monkeypatch.setenv('GCP_PROJECT', 'project-from-env')
+
+        gcp_sources: list[GoogleSecretManagerSettingsSource] = []
+
+        class Settings(BaseSettings):
+            gcp_project: str = Field(alias='GCP_PROJECT')
+            test_secret: str = Field(..., alias='test-secret')
+
+            @classmethod
+            def settings_customise_sources(
+                cls,
+                settings_cls: type[BaseSettings],
+                init_settings: PydanticBaseSettingsSource,
+                env_settings: PydanticBaseSettingsSource,
+                dotenv_settings: PydanticBaseSettingsSource,
+                file_secret_settings: PydanticBaseSettingsSource,
+            ) -> tuple[PydanticBaseSettingsSource, ...]:
+                gcp = GoogleSecretManagerSettingsSource(
+                    settings_cls, secret_client=secret_client, project_id_field='GCP_PROJECT'
+                )
+                gcp_sources.append(gcp)
+                return (init_settings, env_settings, dotenv_settings, file_secret_settings, gcp)
+
+        settings = Settings()  # type: ignore
+        assert settings.gcp_project == 'project-from-env'
+        assert settings.test_secret == 'test-value'
+        # Prove the GCP source resolved the project from the previous (env) source,
+        # not from google.auth.default.
+        assert gcp_sources[0]._project_id == 'project-from-env'
+        # Also prove the optimisation: when secret_client is supplied and project_id
+        # is resolvable from a previous source, google.auth.default is not called.
+        auth_default.assert_not_called()
 
     def test_pydantic_base_settings(self, mock_secret_client, monkeypatch, mocker):
         monkeypatch.setenv('ANOTHER_SECRET', 'yep_this_one')


### PR DESCRIPTION
The current `GoogleSecretManagerSettingsSource` only allows `project_id` to be set directly at when instantiating it or via the "GOOGLE_CLOUD_PROJECT` environment variable (which is what the gcloud sdk uses ). 


This PR defer the `project_id` resolution so that the google project id can be set via a previous pydantic-settings source. 


For example like this 

```
class Settings(BaseSettings):
    # Resolved by an earlier source (env/init) before the GCP source runs;
    # GoogleSecretManagerSettingsSource reads it via project_id_field below.
    gcp_project: str = Field(default=...)
    api_key: str

    @classmethod
    def settings_customise_sources(
        cls,
        settings_cls: type[BaseSettings],
        init_settings: PydanticBaseSettingsSource,
        env_settings: PydanticBaseSettingsSource,
        dotenv_settings: PydanticBaseSettingsSource,
        file_secret_settings: PydanticBaseSettingsSource,
    ) -> tuple[PydanticBaseSettingsSource, ...]:
        return (
            init_settings,
            env_settings,
            dotenv_settings,
            file_secret_settings,
            GoogleSecretManagerSettingsSource(
                settings_cls, project_id_field="gcp_project"
            ),
        )
```

where the project_id can be set from any previous source by the field `gcp_project` 