### PR TITLE
fix: move SecretsManagerClient type import under TYPE_CHECKING

### DIFF
--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -21,7 +21,6 @@ def import_aws_secrets_manager() -> None:
 
     try:
         from boto3 import client as boto3_client
-        from types_boto3_secretsmanager.client import SecretsManagerClient  # noqa: F401
     except ImportError as e:  # pragma: no cover
         raise ImportError(
             'AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`'

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 
 boto3_client = None
+SecretsManagerClient = None
 
 
 def import_aws_secrets_manager() -> None:
@@ -23,6 +24,7 @@ def import_aws_secrets_manager() -> None:
 
     try:
         from boto3 import client as boto3_client
+        from types_boto3_secretsmanager.client import SecretsManagerClient
     except ImportError as e:  # pragma: no cover
         raise ImportError(
             "AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`"
@@ -31,7 +33,7 @@ def import_aws_secrets_manager() -> None:
 
 class AWSSecretsManagerSettingsSource(EnvSettingsSource):
     _secret_id: str
-    _secretsmanager_client: SecretsManagerClient
+    _secretsmanager_client: SecretsManagerClient  # type: ignore
 
     def __init__(
         self,
@@ -68,7 +70,7 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         if self._version_id:
             request["VersionId"] = self._version_id
 
-        response = self._secretsmanager_client.get_secret_value(**request)
+        response = self._secretsmanager_client.get_secret_value(**request)  # type: ignore
 
         return parse_env_vars(
             json.loads(response["SecretString"]),

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -1,4 +1,6 @@
-from __future__ import annotations as _annotations  # important for BaseSettings import to work
+from __future__ import (
+    annotations as _annotations,
+)  # important for BaseSettings import to work
 
 import json
 from collections.abc import Mapping
@@ -23,7 +25,7 @@ def import_aws_secrets_manager() -> None:
         from boto3 import client as boto3_client
     except ImportError as e:  # pragma: no cover
         raise ImportError(
-            'AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`'
+            "AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`"
         ) from e
 
 
@@ -39,13 +41,15 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         endpoint_url: str | None = None,
         case_sensitive: bool | None = True,
         env_prefix: str | None = None,
-        env_nested_delimiter: str | None = '--',
+        env_nested_delimiter: str | None = "--",
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
         version_id: str | None = None,
     ) -> None:
         import_aws_secrets_manager()
-        self._secretsmanager_client = boto3_client('secretsmanager', region_name=region_name, endpoint_url=endpoint_url)  # type: ignore
+        self._secretsmanager_client = boto3_client(
+            "secretsmanager", region_name=region_name, endpoint_url=endpoint_url
+        )  # type: ignore
         self._secret_id = secret_id
         self._version_id = version_id
         super().__init__(
@@ -59,15 +63,15 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         )
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
-        request = {'SecretId': self._secret_id}
+        request = {"SecretId": self._secret_id}
 
         if self._version_id:
-            request['VersionId'] = self._version_id
+            request["VersionId"] = self._version_id
 
         response = self._secretsmanager_client.get_secret_value(**request)
 
         return parse_env_vars(
-            json.loads(response['SecretString']),
+            json.loads(response["SecretString"]),
             self.case_sensitive,
             self.env_ignore_empty,
             self.env_parse_none_str,
@@ -75,11 +79,11 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
 
     def __repr__(self) -> str:
         return (
-            f'{self.__class__.__name__}(secret_id={self._secret_id!r}, '
-            f'env_nested_delimiter={self.env_nested_delimiter!r})'
+            f"{self.__class__.__name__}(secret_id={self._secret_id!r}, "
+            f"env_nested_delimiter={self.env_nested_delimiter!r})"
         )
 
 
 __all__ = [
-    'AWSSecretsManagerSettingsSource',
+    "AWSSecretsManagerSettingsSource",
 ]

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -1,6 +1,4 @@
-from __future__ import (
-    annotations as _annotations,
-)  # important for BaseSettings import to work
+from __future__ import annotations as _annotations  # important for BaseSettings import to work
 
 import json
 from collections.abc import Mapping
@@ -10,30 +8,29 @@ from ..utils import parse_env_vars
 from .env import EnvSettingsSource
 
 if TYPE_CHECKING:
-    from pydantic_settings.main import BaseSettings
     from types_boto3_secretsmanager.client import SecretsManagerClient
+
+    from pydantic_settings.main import BaseSettings
 
 
 boto3_client = None
-SecretsManagerClient = None
 
 
 def import_aws_secrets_manager() -> None:
     global boto3_client
-    global SecretsManagerClient
 
     try:
         from boto3 import client as boto3_client
-        from types_boto3_secretsmanager.client import SecretsManagerClient
+        from types_boto3_secretsmanager.client import SecretsManagerClient  # noqa: F401
     except ImportError as e:  # pragma: no cover
         raise ImportError(
-            "AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`"
+            'AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`'
         ) from e
 
 
 class AWSSecretsManagerSettingsSource(EnvSettingsSource):
     _secret_id: str
-    _secretsmanager_client: SecretsManagerClient  # type: ignore
+    _secretsmanager_client: SecretsManagerClient  # type: ignore[has-type]
 
     def __init__(
         self,
@@ -43,15 +40,13 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         endpoint_url: str | None = None,
         case_sensitive: bool | None = True,
         env_prefix: str | None = None,
-        env_nested_delimiter: str | None = "--",
+        env_nested_delimiter: str | None = '--',
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
         version_id: str | None = None,
     ) -> None:
         import_aws_secrets_manager()
-        self._secretsmanager_client = boto3_client(
-            "secretsmanager", region_name=region_name, endpoint_url=endpoint_url
-        )  # type: ignore
+        self._secretsmanager_client = boto3_client('secretsmanager', region_name=region_name, endpoint_url=endpoint_url)  # type: ignore
         self._secret_id = secret_id
         self._version_id = version_id
         super().__init__(
@@ -65,15 +60,15 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         )
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
-        request = {"SecretId": self._secret_id}
+        request = {'SecretId': self._secret_id}
 
         if self._version_id:
-            request["VersionId"] = self._version_id
+            request['VersionId'] = self._version_id
 
         response = self._secretsmanager_client.get_secret_value(**request)  # type: ignore
 
         return parse_env_vars(
-            json.loads(response["SecretString"]),
+            json.loads(response['SecretString']),
             self.case_sensitive,
             self.env_ignore_empty,
             self.env_parse_none_str,
@@ -81,11 +76,11 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(secret_id={self._secret_id!r}, "
-            f"env_nested_delimiter={self.env_nested_delimiter!r})"
+            f'{self.__class__.__name__}(secret_id={self._secret_id!r}, '
+            f'env_nested_delimiter={self.env_nested_delimiter!r})'
         )
 
 
 __all__ = [
-    "AWSSecretsManagerSettingsSource",
+    'AWSSecretsManagerSettingsSource',
 ]

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -30,7 +30,7 @@ def import_aws_secrets_manager() -> None:
 
 class AWSSecretsManagerSettingsSource(EnvSettingsSource):
     _secret_id: str
-    _secretsmanager_client: SecretsManagerClient  # type: ignore[has-type]
+    _secretsmanager_client: SecretsManagerClient
 
     def __init__(
         self,
@@ -65,7 +65,7 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         if self._version_id:
             request['VersionId'] = self._version_id
 
-        response = self._secretsmanager_client.get_secret_value(**request)  # type: ignore
+        response = self._secretsmanager_client.get_secret_value(**request)
 
         return parse_env_vars(
             json.loads(response['SecretString']),

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -9,10 +9,10 @@ from .env import EnvSettingsSource
 
 if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
+    from types_boto3_secretsmanager.client import SecretsManagerClient
 
 
 boto3_client = None
-SecretsManagerClient = None
 
 
 def import_aws_secrets_manager() -> None:
@@ -21,7 +21,6 @@ def import_aws_secrets_manager() -> None:
 
     try:
         from boto3 import client as boto3_client
-        from types_boto3_secretsmanager.client import SecretsManagerClient
     except ImportError as e:  # pragma: no cover
         raise ImportError(
             'AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`'

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -29,7 +29,7 @@ def import_aws_secrets_manager() -> None:
 
 class AWSSecretsManagerSettingsSource(EnvSettingsSource):
     _secret_id: str
-    _secretsmanager_client: SecretsManagerClient  # type: ignore
+    _secretsmanager_client: SecretsManagerClient
 
     def __init__(
         self,
@@ -64,7 +64,7 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         if self._version_id:
             request['VersionId'] = self._version_id
 
-        response = self._secretsmanager_client.get_secret_value(**request)  # type: ignore
+        response = self._secretsmanager_client.get_secret_value(**request)
 
         return parse_env_vars(
             json.loads(response['SecretString']),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dynamic = ['version']
 yaml = ["pyyaml>=6.0.1"]
 toml = ["tomli>=2.0.1"]
 azure-key-vault = ["azure-keyvault-secrets>=4.8.0", "azure-identity>=1.16.0"]
-aws-secrets-manager = ["boto3>=1.35.0", "types-boto3[secretsmanager]"]
+aws-secrets-manager = ["boto3>=1.35.0"]
 gcp-secret-manager = [
     "google-cloud-secret-manager>=2.23.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1407,7 +1407,6 @@ dependencies = [
 [package.optional-dependencies]
 aws-secrets-manager = [
     { name = "boto3" },
-    { name = "types-boto3", extra = ["secretsmanager"] },
 ]
 azure-key-vault = [
     { name = "azure-identity" },
@@ -1454,7 +1453,6 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=0.21.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.1" },
     { name = "tomli", marker = "extra == 'toml'", specifier = ">=2.0.1" },
-    { name = "types-boto3", extras = ["secretsmanager"], marker = "extra == 'aws-secrets-manager'" },
     { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
 provides-extras = ["aws-secrets-manager", "azure-key-vault", "gcp-secret-manager", "toml", "yaml"]


### PR DESCRIPTION
## Problem

`SecretsManagerClient` from `types_boto3_secretsmanager` is imported at runtime inside `import_aws_secrets_manager()`, but it's only used for type annotations. This forces users to install `types-boto3[secretsmanager]` even when they don't need type stubs.

Fixes #879

## Fix

1. **`pydantic_settings/sources/providers/aws.py`**:
   - Move `SecretsManagerClient` import under `TYPE_CHECKING` guard
   - Remove it from the runtime import function
   - Since `from __future__ import annotations` is already present, the type annotation is lazy and doesn't require runtime availability

2. **`pyproject.toml`**:
   - Remove `types-boto3[secretsmanager]` from `aws-secrets-manager` extra
   - Keep it in the `linting` dependency group for type checking

## Testing

The type annotation `_secretsmanager_client: SecretsManagerClient` on `AWSSecretsManagerSettingsSource` still works because `from __future__ import annotations` makes it lazy.
