### PR TITLE
Support using a table header as root when reading a TOML file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2643,7 +2643,7 @@ Other settings sources are available for common configuration files:
 
 - `JsonConfigSettingsSource` using `json_file` and `json_file_encoding` arguments
 - `PyprojectTomlConfigSettingsSource` using *(optional)* `pyproject_toml_depth` and *(optional)* `pyproject_toml_table_header` arguments
-- `TomlConfigSettingsSource` using `toml_file` argument
+- `TomlConfigSettingsSource` using `toml_file` argument and *(optional)* `toml_table_header` argument
 - `YamlConfigSettingsSource` using `yaml_file` and yaml_file_encoding arguments
 
 To use them, you can use the same mechanism described [here](#customise-settings-sources).
@@ -2816,6 +2816,43 @@ hello = "world"
 [nested]
 foo = 3
 bar = 2
+```
+
+If you want to load from a specific table in the file, you can provide `toml_table_header` as a tuple of header parts. For example, `toml_table_header=('my-table',)` will load variables from the `[my-table]` table.
+
+```python
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
+
+
+class Settings(BaseSettings):
+    field: str
+
+    model_config = SettingsConfigDict(
+        toml_file='config.toml', toml_table_header=('my-table',)
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (TomlConfigSettingsSource(settings_cls),)
+```
+
+This will allow you to read the following TOML file:
+```toml
+# config.toml
+[my-table]
+field = "value from my-table"
 ```
 
 ### pyproject.toml

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -105,6 +105,14 @@ class SettingsConfigDict(ConfigDict, total=False):
     """
 
     toml_file: PathType | None
+
+    toml_table_header: tuple[str, ...]
+    """
+    Header of the TOML table in a TOML file to use when filling variables.
+    Similar to `pyproject_toml_table_header`, but for generic TOML file handling.
+
+    Default is to use the root table, i.e. no table header.
+    """
     enable_decoding: bool
 
 

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -565,7 +565,7 @@ class BaseSettings(BaseModel):
 
         warn_if_not_used(JsonConfigSettingsSource, ('json_file', 'json_file_encoding'))
         warn_if_not_used(PyprojectTomlConfigSettingsSource, ('pyproject_toml_depth', 'pyproject_toml_table_header'))
-        warn_if_not_used(TomlConfigSettingsSource, ('toml_file',))
+        warn_if_not_used(TomlConfigSettingsSource, ('toml_file', 'toml_table_header'))
         warn_if_not_used(YamlConfigSettingsSource, ('yaml_file', 'yaml_file_encoding', 'yaml_config_section'))
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(

--- a/pydantic_settings/sources/providers/toml.py
+++ b/pydantic_settings/sources/providers/toml.py
@@ -59,7 +59,9 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         )
         self.toml_data = self._read_files(self.toml_file_path, deep_merge=deep_merge)
         for key in self.toml_table_header:
-            self.toml_data = self.toml_data.get(key, {})
+            if key not in self.toml_data:
+                raise KeyError(f'toml_table_header key "{key}" not found in {self.toml_file_path}')
+            self.toml_data = self.toml_data[key]
 
         super().__init__(settings_cls, self.toml_data)
 

--- a/pydantic_settings/sources/providers/toml.py
+++ b/pydantic_settings/sources/providers/toml.py
@@ -50,10 +50,17 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         self,
         settings_cls: type[BaseSettings],
         toml_file: PathType | None = DEFAULT_PATH,
+        toml_table_header: tuple[str, ...] = (),
         deep_merge: bool = False,
     ):
         self.toml_file_path = toml_file if toml_file != DEFAULT_PATH else settings_cls.model_config.get('toml_file')
+        self.toml_table_header = (
+            toml_table_header if toml_table_header else settings_cls.model_config.get('toml_table_header', ())
+        )
         self.toml_data = self._read_files(self.toml_file_path, deep_merge=deep_merge)
+        for key in self.toml_table_header:
+            self.toml_data = self.toml_data.get(key, {})
+
         super().__init__(settings_cls, self.toml_data)
 
     def _read_file(self, file_path: Path) -> dict[str, Any]:
@@ -64,4 +71,4 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             return tomllib.load(toml_file)
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}(toml_file={self.toml_file_path})'
+        return f'{self.__class__.__name__}(toml_file={self.toml_file_path}, toml_table_header={self.toml_table_header})'

--- a/tests/test_source_toml.py
+++ b/tests/test_source_toml.py
@@ -23,7 +23,7 @@ except ImportError:
 
 def test_repr() -> None:
     source = TomlConfigSettingsSource(BaseSettings, Path('config.toml'))
-    assert repr(source) == 'TomlConfigSettingsSource(toml_file=config.toml)'
+    assert repr(source) == 'TomlConfigSettingsSource(toml_file=config.toml, toml_table_header=())'
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
@@ -158,3 +158,61 @@ def test_multiple_file_toml_merge(tmp_path, deep_merge):
 
     s = Settings()
     assert s.model_dump() == {'hello': 'world', 'nested': {'foo': 3, 'bar': 2 if deep_merge else 0}}
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_table_header(tmp_path):
+    p = tmp_path / 'test.toml'
+    p.write_text(
+        """
+    [app]
+    hello = "world"
+    """
+    )
+
+    class Settings(BaseSettings):
+        hello: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls, toml_file=p, toml_table_header=('app',)),)
+
+    s = Settings()
+    assert s.model_dump() == {'hello': 'world'}
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_table_header_from_model_config(tmp_path):
+    p = tmp_path / 'test.toml'
+    p.write_text(
+        """
+    [app]
+    hello = "world"
+    """
+    )
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(toml_file=p, toml_table_header=('app',))
+
+        hello: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls),)
+
+    s = Settings()
+    assert s.model_dump() == {'hello': 'world'}

--- a/tests/test_source_toml.py
+++ b/tests/test_source_toml.py
@@ -216,3 +216,33 @@ def test_table_header_from_model_config(tmp_path):
 
     s = Settings()
     assert s.model_dump() == {'hello': 'world'}
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_missing_table_header(tmp_path):
+    p = tmp_path / 'test.toml'
+    p.write_text(
+        """
+    [app]
+    hello = "world"
+    """
+    )
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(toml_file=p, toml_table_header=('missing',))
+
+        hello: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls),)
+
+    with pytest.raises(KeyError, match='toml_table_header key "missing" not found in .*'):
+        Settings()


### PR DESCRIPTION
Support `toml_table_header` for regular TOML files.

It can be set from `model_config` or from `settings_customise_sources`.

Resolves #881 

