### PR TITLE
docs: add async usage section for non-blocking settings loading

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3189,13 +3189,17 @@ The recommended pattern is to offload settings instantiation to a worker thread 
 ```py
 import asyncio
 from contextvars import ContextVar
+
 from pydantic_settings import BaseSettings
 
+
 class Settings(BaseSettings):
-    app_name: str = 'myapp'
+    app_name: str = "myapp"
     debug: bool = False
 
-_settings_var: ContextVar[Settings | None] = ContextVar('_settings_var', default=None)
+
+_settings_var: ContextVar[Settings | None] = ContextVar("_settings_var", default=None)
+
 
 async def get_settings(*, force_reload: bool = False) -> Settings:
     """Return cached settings, loading in a worker thread on first call."""
@@ -3215,10 +3219,13 @@ For Python 3.8 or when you need an explicit executor:
 
 ```py
 import asyncio
+
 from pydantic_settings import BaseSettings
 
+
 class Settings(BaseSettings):
-    app_name: str = 'myapp'
+    app_name: str = "myapp"
+
 
 async def load_settings() -> Settings:
     loop = asyncio.get_running_loop()

--- a/docs/index.md
+++ b/docs/index.md
@@ -3180,6 +3180,51 @@ except ValidationError as exc_info:
 ```
 
 
+## Async usage
+
+Pydantic Settings sources perform blocking I/O (reading `.env` files, TOML files, secrets from disk). In an async application this blocks the event loop for the duration of the settings load, which can cause measurable latency under concurrency.
+
+The recommended pattern is to offload settings instantiation to a worker thread using [`asyncio.to_thread`](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread) (Python 3.9+) or `loop.run_in_executor`:
+
+```py
+import asyncio
+from contextvars import ContextVar
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    app_name: str = 'myapp'
+    debug: bool = False
+
+_settings_var: ContextVar[Settings | None] = ContextVar('_settings_var', default=None)
+
+async def get_settings(*, force_reload: bool = False) -> Settings:
+    """Return cached settings, loading in a worker thread on first call."""
+    settings = _settings_var.get()
+    if settings is None or force_reload:
+        settings = await asyncio.to_thread(Settings)
+        _settings_var.set(settings)
+    return settings
+```
+
+`asyncio.to_thread` runs the `Settings()` constructor in a thread-pool worker, keeping the event loop free. The result is cached in a [`ContextVar`](https://docs.python.org/3/library/contextvars.html) so subsequent calls within the same async context return immediately without re-reading from disk.
+
+!!! note
+    `ContextVar` cache is per-context (per-task). If you want a single process-wide cache, use a plain module-level variable instead and guard it with an [`asyncio.Lock`](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Lock) to avoid redundant parallel loads on startup.
+
+For Python 3.8 or when you need an explicit executor:
+
+```py
+import asyncio
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    app_name: str = 'myapp'
+
+async def load_settings() -> Settings:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, Settings)
+```
+
 ## In-place reloading
 
 In case you want to reload in-place an existing setting, you can do it by using its `__init__` method :


### PR DESCRIPTION
Closes #479

## Summary

Adds a new **Async usage** section to the docs, placed immediately before the existing *In-place reloading* section as suggested by @hramezani in the issue.

The section explains:
- Why `BaseSettings` sources block the event loop (disk I/O in `open()` calls)
- The recommended `asyncio.to_thread` pattern with a `ContextVar` cache (Python 3.9+)
- The `loop.run_in_executor` alternative for Python 3.8 / explicit executor control
- A note on per-context vs process-wide caching and `asyncio.Lock` for startup races

## Motivation

The issue was opened with a thorough proof-of-concept showing event loop delay exceeding 1.5s under concurrency when settings are loaded synchronously. The maintainer confirmed the fix is documentation: *'Let's document it at the end of our docs before In-place reloading'*.

I use `BaseSettings` with `toml_file` in my own tooling ([envdoc](https://github.com/Yanflare/envdoc)) and hit this pattern directly — the `asyncio.to_thread` approach is what I use in production.