### PR TITLE
Don't complain about missing table headers in a TOML file that isn't there

### DIFF
--- a/pydantic_settings/sources/providers/toml.py
+++ b/pydantic_settings/sources/providers/toml.py
@@ -58,10 +58,11 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             toml_table_header if toml_table_header else settings_cls.model_config.get('toml_table_header', ())
         )
         self.toml_data = self._read_files(self.toml_file_path, deep_merge=deep_merge)
-        for key in self.toml_table_header:
-            if key not in self.toml_data:
-                raise KeyError(f'toml_table_header key "{key}" not found in {self.toml_file_path}')
-            self.toml_data = self.toml_data[key]
+        if self.toml_file_path is not None:
+            for key in self.toml_table_header:
+                if key not in self.toml_data:
+                    raise KeyError(f'toml_table_header key "{key}" not found in {self.toml_file_path}')
+                self.toml_data = self.toml_data[key]
 
         super().__init__(settings_cls, self.toml_data)
 

--- a/tests/test_source_toml.py
+++ b/tests/test_source_toml.py
@@ -246,3 +246,27 @@ def test_missing_table_header(tmp_path):
 
     with pytest.raises(KeyError, match='toml_table_header key "missing" not found in .*'):
         Settings()
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_table_header_missing_toml_file(tmp_path):
+    """If a table header is configured, and the toml file is missing, no error should be raised."""
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(toml_file=None, toml_table_header=('app',))
+
+        hello: str = 'world'
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls),)
+
+    s = Settings()
+    assert s.model_dump() == {'hello': 'world'}


### PR DESCRIPTION
In PR #882 I added support for TOML table headers.

I noticed that I broke one thing: If you set up a `TomlConfigSettingsSource` and then pass `toml_file=None`, no error is raised: it's okay to not have a config file after all. Configuring a  `toml_table_header` broke this: the code expects that a file is read and that the header should be in there, otherwise an error is raised. The possibility of having no config file was lost.

With this PR, it works like this:
- no toml file: no error
- toml file exists and table header found: no error
- toml file exists but table header is missing: error