### PR TITLE
Address issues in toml table header implementation

### DIFF
--- a/pydantic_settings/sources/providers/toml.py
+++ b/pydantic_settings/sources/providers/toml.py
@@ -3,6 +3,7 @@
 from __future__ import annotations as _annotations
 
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -58,7 +59,8 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             toml_table_header if toml_table_header else settings_cls.model_config.get('toml_table_header', ())
         )
         self.toml_data = self._read_files(self.toml_file_path, deep_merge=deep_merge)
-        if self.toml_file_path is not None:
+
+        if self._any_file_exists(self.toml_file_path):
             for key in self.toml_table_header:
                 if key not in self.toml_data:
                     raise KeyError(f'toml_table_header key "{key}" not found in {self.toml_file_path}')
@@ -72,6 +74,15 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             if sys.version_info < (3, 11):
                 return tomli.load(toml_file)
             return tomllib.load(toml_file)
+
+    @staticmethod
+    def _any_file_exists(paths: PathType | None) -> bool:
+        """Check if any of the given file paths exist."""
+        if paths is None:
+            return False
+        if not isinstance(paths, Sequence):
+            paths = [paths]
+        return any(Path(path).exists() for path in paths)
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(toml_file={self.toml_file_path}, toml_table_header={self.toml_table_header})'

--- a/tests/test_source_toml.py
+++ b/tests/test_source_toml.py
@@ -83,6 +83,28 @@ def test_toml_no_file():
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_toml_file_missing(tmp_path):
+    p = tmp_path / 'does-not-exist.toml'
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(toml_file=p)
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls),)
+
+    s = Settings()
+    assert s.model_dump() == {}
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
 def test_multiple_file_toml(tmp_path):
     p1 = tmp_path / '.env.toml1'
     p2 = tmp_path / '.env.toml2'
@@ -161,7 +183,7 @@ def test_multiple_file_toml_merge(tmp_path, deep_merge):
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
-def test_table_header(tmp_path):
+def test_toml_table_header(tmp_path):
     p = tmp_path / 'test.toml'
     p.write_text(
         """
@@ -189,7 +211,7 @@ def test_table_header(tmp_path):
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
-def test_table_header_from_model_config(tmp_path):
+def test_toml_table_header_from_model_config(tmp_path):
     p = tmp_path / 'test.toml'
     p.write_text(
         """
@@ -219,17 +241,18 @@ def test_table_header_from_model_config(tmp_path):
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
-def test_missing_table_header(tmp_path):
+def test_toml_table_header_no_header(tmp_path):
+    """If a toml file is read, but the configured table header is missing from the result, raise an error"""
     p = tmp_path / 'test.toml'
     p.write_text(
         """
-    [app]
+    [other]
     hello = "world"
     """
     )
 
     class Settings(BaseSettings):
-        model_config = SettingsConfigDict(toml_file=p, toml_table_header=('missing',))
+        model_config = SettingsConfigDict(toml_file=p, toml_table_header=('app',))
 
         hello: str
 
@@ -244,16 +267,131 @@ def test_missing_table_header(tmp_path):
         ) -> tuple[PydanticBaseSettingsSource, ...]:
             return (TomlConfigSettingsSource(settings_cls),)
 
-    with pytest.raises(KeyError, match='toml_table_header key "missing" not found in .*'):
+    with pytest.raises(KeyError, match='toml_table_header key "app" not found in .*'):
         Settings()
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
-def test_table_header_missing_toml_file():
-    """If a table header is configured, and the toml file is missing, no error should be raised."""
+def test_toml_table_header_no_file():
+    """If a table header is configured, but the toml file is unset, no error should be raised."""
 
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(toml_file=None, toml_table_header=('app',))
+
+        hello: str = 'world'
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls),)
+
+    s = Settings()
+    assert s.model_dump() == {'hello': 'world'}
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_toml_table_header_file_missing(tmp_path):
+    """If a table header is configured, but the configured toml file is missing, no error should be raised."""
+    p = tmp_path / 'does-not-exist.toml'
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(toml_file=p, toml_table_header=('app',))
+
+        hello: str = 'world'
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls),)
+
+    s = Settings()
+    assert s.model_dump() == {'hello': 'world'}
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_toml_table_header_file_multiple(tmp_path):
+    """If multiple files are configured and at least one is available, the table header extraction should work"""
+    p1 = tmp_path / 'test.toml'
+    p1.write_text(
+        """
+    [app]
+    hello = "world"
+    """
+    )
+    p2 = tmp_path / 'does-not-exist.toml'
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(toml_file=[p1, p2], toml_table_header=('app',))
+
+        hello: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls),)
+
+    s = Settings()
+    assert s.model_dump() == {'hello': 'world'}
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_toml_table_header_file_multiple_no_header(tmp_path):
+    """When multiple files are configured and at least one is available, if the configured table header is missing from the result, an error should be raised"""
+    p1 = tmp_path / 'test.toml'
+    p1.write_text(
+        """
+    [other]
+    hello = "world"
+    """
+    )
+    p2 = tmp_path / 'does-not-exist.toml'
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(toml_file=[p1, p2], toml_table_header=('app',))
+
+        hello: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls),)
+
+    with pytest.raises(KeyError, match='toml_table_header key "app" not found in .*'):
+        Settings()
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_toml_table_header_file_multiple_no_files(tmp_path):
+    """When multiple files are configured but none are available, if the configured table header is missing from the result, no error should be raised"""
+    p1 = tmp_path / 'does-not-exist.toml'
+    p2 = tmp_path / 'also-does-not-exist.toml'
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(toml_file=[p1, p2], toml_table_header=('app',))
 
         hello: str = 'world'
 

--- a/tests/test_source_toml.py
+++ b/tests/test_source_toml.py
@@ -249,7 +249,7 @@ def test_missing_table_header(tmp_path):
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
-def test_table_header_missing_toml_file(tmp_path):
+def test_table_header_missing_toml_file():
     """If a table header is configured, and the toml file is missing, no error should be raised."""
 
     class Settings(BaseSettings):


### PR DESCRIPTION
This PR addresses the issues noted by CoPilot in #886 .

The table below summarizes the different states of the `toml_file` and `toml_table_header` parameters,with expected outcomes.

| Value of `toml_file` set *| Value of `toml_table_header` set | File exists | Table header exists in file | Expected outcome | Unit test |
|---|---|---|---|---|---|
| ✅ | 🚫 | ✅ | - | No error | `test_toml_file` |
| 🚫 | 🚫 | - | - | No error | `test_toml_no_file` |
| ✅ | 🚫 | 🚫 | - | No error | `test_toml_file_missing` (new) |
| ✅ | ✅ | ✅ |✅ | No error | `test_toml_table_header` (name updated) |
| ✅ | ✅ | ✅ | 🚫 | Error❗️ | `test_toml_table_header_no_header` (name updated) |
| ✅ | ✅ | 🚫 | - | No error | `test_toml_table_header_file_missing` (name updated) |
| 🚫 | ✅ | - | - | No error | `test_toml_table_header_no_file` (new) |
| ✅ + ✅ ** | ✅ | ✅ + 🚫 | ✅ | No error | `test_toml_table_header_file_multiple` (new)|
| ✅ + ✅ ** | ✅ | ✅ + 🚫 | 🚫 | Error❗️ | `test_toml_table_header_file_multiple_no_header` (new) |
| ✅ + ✅ *** | ✅ | 🚫 + 🚫 | - | No error | `test_toml_table_header_file_multiple_no_files` (new) |

`*` = No set means undefined, or set to `None`
`**` = Two file paths passed, only one exists 
`***` = Two files passed, none exists