### PR TITLE
Fix loading env vars on Windows with case_sensitive=True

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -297,8 +297,13 @@ except ValidationError as e:
 1. Note that the `host` field is not found because the environment variable name is `HOST` (all upper-case).
 
 !!! note
-    On Windows, Python's `os` module always treats environment variables as case-insensitive, so the
-    `case_sensitive` config setting will have no effect - settings will always be updated ignoring case.
+    On Windows, environment variable names exposed through Python's `os` module are case-insensitive
+    and normalized to upper-case (e.g. setting `redis` results in `REDIS`). Because the original case
+    cannot be recovered, the `case_sensitive` setting has **no effect for environment variables** on
+    Windows — they are always matched ignoring case.
+
+    This only applies to environment variables. Values loaded from dotenv (`.env`) files preserve
+    case, so `case_sensitive=True` is still respected for those, including on Windows.
 
 ## Parsing environment variable values
 

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -34,6 +34,15 @@ if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
 
 
+def _environ_is_case_insensitive() -> bool:
+    """Whether ``os.environ`` is the OS-backed, case-insensitive mapping (i.e. on Windows).
+
+    When ``os.environ`` has been replaced (e.g. patched to a plain ``dict`` in tests), the
+    requested case sensitivity is honored as-is.
+    """
+    return os.name == 'nt' and isinstance(os.environ, os._Environ)
+
+
 class EnvSettingsSource(PydanticBaseEnvSettingsSource):
     """
     Source class for loading settings values from environment variables.
@@ -72,6 +81,13 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         self.env_vars = self._load_env_vars()
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
+        # On Windows, ``os.environ`` is case-insensitive: variable names are normalized to
+        # upper-case and looked up regardless of case. Matching environment variables
+        # case-sensitively is therefore impossible, so we fall back to case-insensitive
+        # matching to avoid spurious "field required" errors (see #295). ``.env`` files do
+        # preserve case and are handled by ``DotEnvSettingsSource``, which overrides this method.
+        if self.case_sensitive and _environ_is_case_insensitive():
+            self.case_sensitive = False
         return parse_env_vars(os.environ, self.case_sensitive, self.env_ignore_empty, self.env_parse_none_str)
 
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1106,6 +1106,23 @@ def test_case_sensitive_no_nested_delimiter(monkeypatch, env_nested_delimiter):
     ]
 
 
+@pytest.mark.skipif(os.name != 'nt', reason='os.environ is only case-insensitive on Windows')
+def test_case_sensitive_windows_env_fallback(env):
+    # On Windows, os.environ is case-insensitive (variable names are normalized to
+    # upper-case), so case_sensitive=True must not break matching of environment
+    # variables (see https://github.com/pydantic/pydantic-settings/issues/295).
+    class RedisSettings(BaseModel):
+        host: str
+        port: int
+
+    class Settings(BaseSettings, case_sensitive=True):
+        redis: RedisSettings
+
+    env.set('redis', '{"host": "localhost", "port": 6379}')
+    assert 'REDIS' in os.environ  # Windows upper-cases env var names
+    assert Settings().model_dump() == {'redis': {'host': 'localhost', 'port': 6379}}
+
+
 def test_nested_dataclass(env):
     @pydantic_dataclasses.dataclass
     class DeepNestedDataclass:
@@ -2802,7 +2819,9 @@ def test_custom_env_source_default_values_from_config():
 
     c = CustomEnvSettingsSource(Settings)
     assert c.env_prefix == 'prefix_'
-    assert c.case_sensitive is True
+    # os.environ is case-insensitive on Windows, so EnvSettingsSource falls back to
+    # case-insensitive matching there regardless of the configured value (see #295).
+    assert c.case_sensitive is (os.name != 'nt')
 
 
 def test_model_config_through_class_kwargs(env):

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import os
 import re
 import sys
 import time
@@ -837,7 +838,10 @@ def test_cli_show_env_vars_case_sensitive_display():
         foo_bar: str
 
     assert '[env: MYAPP_FOO_BAR]' in CliApp.format_help(CaseInsensitive, strip_ansi_color=True)
-    assert '[env: myapp_foo_bar]' in CliApp.format_help(CaseSensitive, strip_ansi_color=True)
+    # On Windows, os.environ is case-insensitive, so case_sensitive has no effect for
+    # environment variables and the canonical (upper-cased) name is displayed (see #295).
+    expected_case_sensitive_env = 'MYAPP_FOO_BAR' if os.name == 'nt' else 'myapp_foo_bar'
+    assert f'[env: {expected_case_sensitive_env}]' in CliApp.format_help(CaseSensitive, strip_ansi_color=True)
 
 
 def test_cli_show_env_vars_subcommand(capsys):


### PR DESCRIPTION
## Change Summary

On Windows, `os.environ` normalizes variable names to upper-case and looks them up case-insensitively. With `case_sensitive=True`, `EnvSettingsSource` preserved the upper-cased keys (e.g. `REDIS`) but matched them against the original-cased field names (e.g. `redis`), so values coming from `os.environ` were never found and settings raised `Field required`.

This is the long-standing bug behind the docs note that already claims `case_sensitive` "will have no effect" on Windows — previously that was aspirational; the code actually errored instead.

### Fix

`EnvSettingsSource._load_env_vars` now falls back to case-insensitive matching when the **real** Windows `os.environ` is in use:

```python
if self.case_sensitive and _environ_is_case_insensitive():
    self.case_sensitive = False
```

where `_environ_is_case_insensitive()` is `os.name == 'nt' and isinstance(os.environ, os._Environ)`.

Why it's scoped correctly:

- **`.env` files are unaffected** — `DotEnvSettingsSource` overrides `_load_env_vars` to read files, which preserve case. (The reporter confirmed `case_sensitive=True` already works for `.env` on Windows.)
- **The `isinstance(os.environ, os._Environ)` guard** means a monkeypatched plain `dict` — used by existing tests to exercise case-sensitivity deterministically across platforms — is honored as-is. Only the genuine OS-backed, case-insensitive mapping triggers the fallback, which is also the honest semantics: the source really can't match case-sensitively there.

### Tests

- Added `test_case_sensitive_windows_env_fallback` (skipped off-Windows) reproducing the exact example from #295. Verified it fails without the fix (`Field required`) and passes with it.
- Updated `test_custom_env_source_default_values_from_config` to assert `c.case_sensitive is (os.name != 'nt')`.

Local run on Windows: lint, format, and mypy clean; `tests/test_settings.py` passes (202 passed / 7 skipped). The only failures in the full suite were pre-existing symlink tests needing Developer Mode/admin (`WinError 1314`), unrelated to this change.

Fixes #295
Fixes #819