### PR TITLE
Add explicit callout for the case where the unprefixed value is in dotenv

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -728,11 +728,12 @@ class Settings(BaseSettings):
     So if you provide extra values in a dotenv file, whether they start with `env_prefix` or not,
     a `ValidationError` will be raised.
 
-    There is one exception: when an `env_prefix` is set, an unprefixed dotenv entry whose name matches a field name
-    (e.g. `debug` for a `debug` field, while the prefix is `app_`) is silently skipped rather than treated as an
-    extra value. It neither populates the field — only the prefixed name `app_debug` does that — nor raises a
-    `ValidationError`. Note also that the `ValidationError` above is only raised under the default `extra='forbid'`;
-    with `extra='ignore'` the extra values are dropped instead.
+    There is one exception to this. When `env_prefix` is set, an *unprefixed* dotenv entry whose name matches a
+    field name is silently skipped rather than treated as an extra value. For example, with `env_prefix='app_'`
+    and a `debug` field, a `debug=...` line in the dotenv file neither populates `debug` (only `app_debug` does
+    that) nor raises a `ValidationError` — it is simply ignored. This asymmetry can be surprising, because a
+    *non-matching* unprefixed entry such as `foo=...` **would** raise a `ValidationError` under the default
+    `extra='forbid'`.
 
 ## Command Line Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -728,6 +728,12 @@ class Settings(BaseSettings):
     So if you provide extra values in a dotenv file, whether they start with `env_prefix` or not,
     a `ValidationError` will be raised.
 
+    There is one exception: when an `env_prefix` is set, an unprefixed dotenv entry whose name matches a field name
+    (e.g. `debug` for a `debug` field, while the prefix is `app_`) is silently skipped rather than treated as an
+    extra value. It neither populates the field — only the prefixed name `app_debug` does that — nor raises a
+    `ValidationError`. Note also that the `ValidationError` above is only raised under the default `extra='forbid'`;
+    with `extra='ignore'` the extra values are dropped instead.
+
 ## Command Line Support
 
 Pydantic settings provides integrated CLI support, making it easy to quickly define CLI applications using Pydantic


### PR DESCRIPTION
This MR adds an explicit documentation note for an edge case we ran into while using pydantic-settings, where unrecognized settings throw an error (good!), but unrecognized settings (due to lacking prefix) do not throw an error (error prone). If this is actually a bug in the code I am happy to instead open a fix for that.

This example below demonstrates the issue, and hopefully highlights the unintuitive behavior. 

```py3
from pydantic_settings import BaseSettings, SettingsConfigDict


class Settings(BaseSettings):
    model_config = SettingsConfigDict(
        env_prefix="APP_",
        env_file=".env",
    )

    debug: bool = False
    port: int = 8000
    database_url: str


if __name__ == "__main__":
    settings = Settings()
```

with this `.env`

```sh
# APP_DEBUG=true
DEBUG=true
APP_PORT=8080
APP_DATABASE_URL=postgresql://localhost/mydb
# ABC=1
```

Uncomment `ABC` and the script throws a ValidationError, but very unintuitively, `DEBUG` is silently ignored, even though it's not in the model either.

