### PR TITLE
Fix AliasPath on nested model fields not decoding env values (#670)

### DIFF
--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -10,7 +10,7 @@ from typing import (
     get_origin,
 )
 
-from pydantic import Json, TypeAdapter, ValidationError
+from pydantic import AliasChoices, AliasPath, Json, TypeAdapter, ValidationError
 from pydantic._internal._utils import deep_update, is_model_class
 from pydantic.dataclasses import is_pydantic_dataclass
 from pydantic.fields import FieldInfo
@@ -157,6 +157,36 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             # simplest case, field is not complex, we only need to add the value if it was found
             return self._coerce_env_val_strict(field, value)
 
+    def _matches_alias_path_head(self, field: FieldInfo | Any | None, key: str) -> bool:
+        """
+        Whether ``key`` matches the first element of a multi-part ``AliasPath`` on ``field``.
+
+        When a nested field is aliased via e.g. ``AliasPath('path', 0)``, the env value found
+        under ``path`` is a container that must be JSON-decoded before pydantic can navigate
+        into it (see #670). This mirrors the complexity that ``_extract_field_info`` already
+        reports for top-level ``AliasPath`` fields.
+
+        Args:
+            field: The field (or raw type) matched for ``key``.
+            key: The (case-normalized) env name segment matched for the field.
+
+        Returns:
+            Whether ``key`` is the head of a multi-element ``AliasPath``.
+        """
+        if not isinstance(field, FieldInfo):
+            return False
+        v_alias = field.validation_alias
+        paths: list[tuple[str | int, ...]] = []
+        if isinstance(v_alias, AliasPath):
+            paths.append(tuple(v_alias.path))
+        elif isinstance(v_alias, AliasChoices):
+            paths.extend(tuple(choice.path) for choice in v_alias.choices if isinstance(choice, AliasPath))
+        for path in paths:
+            head = path[0]
+            if len(path) > 1 and isinstance(head, str) and self._apply_case_sensitive(head) == key:
+                return True
+        return False
+
     def _field_is_complex(self, field: FieldInfo) -> tuple[bool, bool]:
         """
         Find out if a field is complex, and if so whether JSON errors should be ignored
@@ -275,6 +305,10 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             if (target_field or is_dict) and env_val:
                 if isinstance(target_field, FieldInfo):
                     is_complex, allow_json_failure = self._field_is_complex(target_field)
+                    if not is_complex and self._matches_alias_path_head(target_field, last_key):
+                        # The env value sits under an AliasPath head (e.g. AliasPath('path', 0));
+                        # decode it so pydantic can navigate into the container (see #670).
+                        is_complex, allow_json_failure = True, True
                     if self.env_parse_enums:
                         enum_val = _annotation_enum_name_to_val(target_field.annotation, env_val)
                         env_val = env_val if enum_val is None else enum_val

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1018,6 +1018,50 @@ def test_validation_aliases_alias_choices(env):
     assert Settings().foobar == 'val3'
 
 
+def test_validation_aliases_alias_path_in_nested_model(env):
+    """Regression test for https://github.com/pydantic/pydantic-settings/issues/670
+
+    An ``AliasPath`` used on a field of a nested model should have its env value
+    JSON-decoded so the path can navigate into the resulting container.
+    """
+
+    class Nested(BaseModel):
+        alias_path: str = Field(validation_alias=AliasPath('path', 0))
+        deep: str = Field(validation_alias=AliasPath('foo', 'bar', 1))
+        alias: str = Field(validation_alias='no_path')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_nested_delimiter='__')
+        nest: Nested
+
+    env.set('NEST__PATH', '["hello"]')
+    env.set('NEST__FOO', '{"bar": ["v0", "v1"]}')
+    env.set('NEST__NO_PATH', 'world')
+
+    settings = Settings()
+    assert settings.nest.alias_path == 'hello'
+    assert settings.nest.deep == 'v1'
+    assert settings.nest.alias == 'world'
+
+
+def test_validation_aliases_alias_choices_in_nested_model(env):
+    """A nested-model ``AliasChoices`` containing an ``AliasPath`` should still
+    prefer a plain string alias when present, and decode the ``AliasPath`` value otherwise."""
+
+    class Nested(BaseModel):
+        choice: str = Field(validation_alias=AliasChoices('plain', AliasPath('cc', 0)))
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_nested_delimiter='__')
+        nest: Nested
+
+    env.set('NEST__CC', '["fromcc"]')
+    assert Settings().nest.choice == 'fromcc'
+
+    env.set('NEST__PLAIN', 'fromplain')
+    assert Settings().nest.choice == 'fromplain'
+
+
 def test_validation_alias_alias_choices_with_alias_path_first(env):
     """Test that AliasPath in AliasChoices doesn't interfere with env var lookup.
 


### PR DESCRIPTION
Fixes #670

## Problem

An `AliasPath` used on a field of a **nested** model does not have its environment value JSON-decoded, so path navigation fails:

```python
class Nested(BaseModel):
    alias_path: str = Field(validation_alias=AliasPath('path', 0))
    alias: str = Field(validation_alias='no_path')

class Cfg(BaseSettings):
    model_config = SettingsConfigDict(env_nested_delimiter='__')
    nest: Nested

os.environ['NEST__PATH'] = '["hello"]'
os.environ['NEST__NO_PATH'] = 'hello'

Cfg()  # ValidationError: nest.path.0 Field required
```

The value under `NEST__PATH` reaches pydantic as the raw string `'["hello"]'`, so `AliasPath('path', 0)` cannot index into it.

## Cause

Top-level `AliasPath` fields already work because `_extract_field_info` reports their value as complex, so it gets JSON-decoded before path navigation. Nested fields instead go through `explode_env_vars`, which determined complexity solely from the target field's annotation (`str` -> not complex -> no decode).

## Fix

`explode_env_vars` now also treats the value as complex when the matched env key is the head of a multi-element `AliasPath` -- directly, or within an `AliasChoices` -- via a small `_matches_alias_path_head` helper. This mirrors the existing top-level behavior. A plain string alias in an `AliasChoices` still takes precedence when present.

## Tests

Added two regression tests in `tests/test_settings.py`:
- `test_validation_aliases_alias_path_in_nested_model` -- the issue repro plus a deeper `AliasPath('foo', 'bar', 1)`.
- `test_validation_aliases_alias_choices_in_nested_model` -- confirms a plain string alias still wins over an `AliasPath` inside `AliasChoices`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
