### PR TITLE
Document that case_sensitive does not affect init or config file sources

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -305,6 +305,15 @@ except ValidationError as e:
     This only applies to environment variables. Values loaded from dotenv (`.env`) files preserve
     case, so `case_sensitive=True` is still respected for those, including on Windows.
 
+!!! note
+    The `case_sensitive` setting only affects sources that resolve values by name, such as environment
+    variables, dotenv files, CLI arguments, and secret files. It has **no effect** on values passed at
+    initialization (`Settings(FieLd=...)`) or loaded from config files via `JsonConfigSettingsSource`,
+    `TomlConfigSettingsSource`, and `YamlConfigSettingsSource`. Those values are matched to fields
+    case-sensitively (respecting field names and aliases as-is), just like data passed directly to a
+    pydantic model, so a key such as `FieLd` will not populate a `field` attribute even when
+    `case_sensitive=False`.
+
 ## Parsing environment variable values
 
 By default environment variables are parsed verbatim, including if the value is empty. You can choose to


### PR DESCRIPTION
# Issue

Closes #562

`case_sensitive=False` does not make matching case-insensitive for values passed at initialization (`InitSettingsSource`) or loaded from `JsonConfigSettingsSource` / `TomlConfigSettingsSource` / `YamlConfigSettingsSource` (which inherit from `InitSettingsSource`).

As discussed in #609, this is intended behavior: `case_sensitive` is scoped to name-resolving sources (env vars, dotenv, CLI, secrets), and init/config-file values are matched like data passed directly to a pydantic model. We decided not to change the code, but the docs were never updated to state this.

# Changes

Add a note in the case-sensitivity section of the docs clarifying that `case_sensitive` has no effect on init kwargs or the JSON/TOML/YAML config file sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)