### PR TITLE
Support case_sensitive in InitSettingsSource and config file sources

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -290,30 +290,47 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         init_kwargs: dict[str, Any],
         nested_model_default_partial_update: bool | None = None,
     ):
+        case_sensitive = settings_cls.model_config.get('case_sensitive', False)
+        include_name = settings_cls.model_config.get('populate_by_name', False) or settings_cls.model_config.get(
+            'validate_by_name', False
+        )
+
+        def normalize(name: str) -> str:
+            # When case_sensitive is False, matching is done on lower-cased names.
+            return name if case_sensitive else name.lower()
+
         self.init_kwargs = {}
         init_kwarg_names = set(init_kwargs.keys())
+        # Map each provided key by its normalized form so it can be matched against
+        # field aliases without losing the original key used to look up the value.
+        normalized_provided = {normalize(key): key for key in init_kwargs}
         for field_name, field_info in settings_cls.model_fields.items():
-            alias_names, *_ = _get_alias_names(field_name, field_info)
+            # Canonical (case-preserving) alias names determine the output key, so the value
+            # still matches pydantic's validation aliases, which are always case-sensitive.
+            canonical_alias_names, *_ = _get_alias_names(field_name, field_info)
+            # Match alias names respect case_sensitive when matching against provided keys.
+            match_alias_names, *_ = _get_alias_names(field_name, field_info, case_sensitive=case_sensitive)
             # When populate_by_name is True, allow using the field name as an input key,
             # but normalize to the preferred alias to keep keys consistent across sources.
-            matchable_names = set(alias_names)
-            include_name = settings_cls.model_config.get('populate_by_name', False) or settings_cls.model_config.get(
-                'validate_by_name', False
-            )
+            matchable_names = list(match_alias_names)
             if include_name:
-                matchable_names.add(field_name)
-            init_kwarg_name = init_kwarg_names & matchable_names
-            if init_kwarg_name:
-                preferred_alias = alias_names[0] if alias_names else field_name
-                # Choose provided key deterministically: prefer the first alias in alias_names order;
-                # fall back to field_name if allowed and provided.
-                provided_key = next((alias for alias in alias_names if alias in init_kwarg_names), None)
-                if provided_key is None and include_name and field_name in init_kwarg_names:
-                    provided_key = field_name
-                # provided_key should not be None here because init_kwarg_name is non-empty
-                assert provided_key is not None
-                init_kwarg_names -= init_kwarg_name
-                self.init_kwargs[preferred_alias] = init_kwargs[provided_key]
+                name = normalize(field_name)
+                if name not in matchable_names:
+                    matchable_names.append(name)
+            # All provided keys matching this field, in matchable_names preference order
+            # (aliases first, then the field name). Only keys not yet consumed by an
+            # earlier field are considered.
+            matched_keys = [
+                normalized_provided[name]
+                for name in matchable_names
+                if name in normalized_provided and normalized_provided[name] in init_kwarg_names
+            ]
+            if matched_keys:
+                preferred_alias = canonical_alias_names[0] if canonical_alias_names else field_name
+                # Prefer the first match in preference order; drop the remaining matches
+                # so they are not re-added as extras.
+                init_kwarg_names.difference_update(matched_keys)
+                self.init_kwargs[preferred_alias] = init_kwargs[matched_keys[0]]
         # Include any remaining init kwargs (e.g., extras) unchanged
         # Note: If populate_by_name is True and the provided key is the field name, but
         # no alias exists, we keep it as-is so it can be processed as extra if allowed.

--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -301,9 +301,13 @@ class InitSettingsSource(PydanticBaseSettingsSource):
 
         self.init_kwargs = {}
         init_kwarg_names = set(init_kwargs.keys())
-        # Map each provided key by its normalized form so it can be matched against
-        # field aliases without losing the original key used to look up the value.
-        normalized_provided = {normalize(key): key for key in init_kwargs}
+        # Map each normalized name to all provided keys sharing it, so field aliases can
+        # be matched without losing the original key used to look up the value. A 1-to-many
+        # mapping is required because case_sensitive=False can collapse distinct keys
+        # (e.g. ``TeSt`` and ``TEST``) onto the same normalized name.
+        normalized_provided: dict[str, list[str]] = {}
+        for key in init_kwargs:
+            normalized_provided.setdefault(normalize(key), []).append(key)
         for field_name, field_info in settings_cls.model_fields.items():
             # Canonical (case-preserving) alias names determine the output key, so the value
             # still matches pydantic's validation aliases, which are always case-sensitive.
@@ -321,9 +325,11 @@ class InitSettingsSource(PydanticBaseSettingsSource):
             # (aliases first, then the field name). Only keys not yet consumed by an
             # earlier field are considered.
             matched_keys = [
-                normalized_provided[name]
+                original
                 for name in matchable_names
-                if name in normalized_provided and normalized_provided[name] in init_kwarg_names
+                if name in normalized_provided
+                for original in normalized_provided[name]
+                if original in init_kwarg_names
             ]
             if matched_keys:
                 preferred_alias = canonical_alias_names[0] if canonical_alias_names else field_name

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1167,6 +1167,51 @@ def test_case_sensitive_windows_env_fallback(env):
     assert Settings().model_dump() == {'redis': {'host': 'localhost', 'port': 6379}}
 
 
+def test_init_source_case_insensitive():
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
+        test: str = 'default'
+
+    # A differently-cased init kwarg populates the field (see #562).
+    assert Settings(TeSt='override').model_dump() == {'test': 'override'}
+
+
+def test_init_source_case_insensitive_with_alias():
+    class Settings(BaseSettings):
+        foo: str = Field(..., alias='FOO')
+        model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
+
+    settings = Settings(Foo='foo_value', extra_field='extra_value')
+    assert settings.foo == 'foo_value'
+    assert settings.__pydantic_extra__ == {'extra_field': 'extra_value'}
+
+
+def test_init_source_case_sensitive():
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(case_sensitive=True, extra='allow')
+        test: str = 'default'
+
+    # With case_sensitive=True, a differently-cased key stays an extra.
+    assert Settings(TeSt='override').model_dump() == {'test': 'default', 'TeSt': 'override'}
+
+
+def test_config_file_source_case_insensitive(tmp_path):
+    from pydantic_settings import JsonConfigSettingsSource
+
+    p = tmp_path / '.env.json'
+    p.write_text('{"API_KEY": "secret"}')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(case_sensitive=False, json_file=p)
+        api_key: str = 'none'
+
+        @classmethod
+        def settings_customise_sources(cls, settings_cls, **_kwargs):
+            return (JsonConfigSettingsSource(settings_cls),)
+
+    assert Settings().model_dump() == {'api_key': 'secret'}
+
+
 def test_nested_dataclass(env):
     @pydantic_dataclasses.dataclass
     class DeepNestedDataclass:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -44,6 +44,7 @@ from pydantic_settings import (
     EnvSettingsSource,
     ForceDecode,
     InitSettingsSource,
+    JsonConfigSettingsSource,
     NoDecode,
     PydanticBaseSettingsSource,
     SecretsSettingsSource,
@@ -1176,6 +1177,16 @@ def test_init_source_case_insensitive():
     assert Settings(TeSt='override').model_dump() == {'test': 'override'}
 
 
+def test_init_source_case_insensitive_collision():
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(case_sensitive=False, extra='allow')
+        test: str = 'default'
+
+    # Multiple keys that differ only by case all resolve to the field; none leak
+    # through as an extra. The first provided key wins the value.
+    assert Settings(TeSt='a', TEST='b').model_dump() == {'test': 'a'}
+
+
 def test_init_source_case_insensitive_with_alias():
     class Settings(BaseSettings):
         foo: str = Field(..., alias='FOO')
@@ -1196,8 +1207,6 @@ def test_init_source_case_sensitive():
 
 
 def test_config_file_source_case_insensitive(tmp_path):
-    from pydantic_settings import JsonConfigSettingsSource
-
     p = tmp_path / '.env.json'
     p.write_text('{"API_KEY": "secret"}')
 


### PR DESCRIPTION
# Issue

Closes #562

`case_sensitive=False` was not applied to `InitSettingsSource` or to the config file sources that derive from it (`JsonConfigSettingsSource`, `TomlConfigSettingsSource`, `YamlConfigSettingsSource`), so a differently-cased key such as `Settings(TeSt=...)` did not populate a `test` field. This is the opposite approach to #899, which documents the current behavior instead of changing it — only one of the two should be merged.

# Changes

Make `InitSettingsSource.__init__` respect `case_sensitive` when matching provided keys to fields:

- Matching is done on **normalized** names (lower-cased when `case_sensitive=False`), while the **canonical**, case-preserving alias is used as the output key so values still match pydantic's case-sensitive validation aliases.
- A single change covers all four sources, since the config file sources funnel through `InitSettingsSource.__init__`.
- Leverages the existing `case_sensitive` support in `_get_alias_names()`.

Added tests: `test_init_source_case_insensitive`, `test_init_source_case_insensitive_with_alias`, `test_init_source_case_sensitive`, `test_config_file_source_case_insensitive`.

# Caveats

- **Behavior change to a default:** `case_sensitive` defaults to `False`, so case-insensitive matching becomes the default for init kwargs and config files.
- **Top-level only:** nested-model keys are still matched case-sensitively by pydantic (e.g. `{"NESTED": {"HOST": "h"}}` matches `nested` but not `nested.host`). Full nested support would be considerably more involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)