### PR TITLE
Warn when using fields not fully resolved at instantiation

### DIFF
--- a/pydantic_settings/__init__.py
+++ b/pydantic_settings/__init__.py
@@ -1,4 +1,4 @@
-from .exceptions import SettingsError
+from .exceptions import IncompleteFieldDefinitionWarning, SettingsError
 from .main import BaseSettings, CliApp, SettingsConfigDict
 from .sources import (
     CLI_SUPPRESS,
@@ -51,6 +51,7 @@ __all__ = (
     'EnvSettingsSource',
     'ForceDecode',
     'GoogleSecretManagerSettingsSource',
+    'IncompleteFieldDefinitionWarning',
     'InitSettingsSource',
     'JsonConfigSettingsSource',
     'NestedSecretsSettingsSource',

--- a/pydantic_settings/exceptions.py
+++ b/pydantic_settings/exceptions.py
@@ -2,3 +2,13 @@ class SettingsError(ValueError):
     """Base exception for settings-related errors."""
 
     pass
+
+
+class IncompleteFieldDefinitionWarning(UserWarning):
+    """Warning emitted when a field with an incomplete definition is used during settings resolution.
+
+    A field definition is incomplete when its annotation contains unresolved forward references,
+    in which case settings sources may fail to correctly resolve its value.
+    """
+
+    pass

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -180,8 +180,8 @@ class BaseSettings(BaseModel):
         _cli_kebab_case: CLI args use kebab case. Defaults to `False`.
         _cli_shortcuts: Mapping of target field name to alias names. Defaults to `None`.
         _secrets_dir: The secret files directory or a sequence of directories. Defaults to `None`.
-        _build_sources: Pre-initialized sources, init kwargs and init state to use for building instantiation
-            values. Defaults to `None`.
+        _build_sources: Pre-initialized sources and init kwargs to use for building instantiation values.
+            Defaults to `None`.
     """
 
     # Note: when adding new parameters, make sure to use `object` instead of `Any` to avoid issues with the Mypy plugin
@@ -217,10 +217,10 @@ class BaseSettings(BaseModel):
         _cli_kebab_case: bool | Literal['all', 'no_enums'] | None = None,
         _cli_shortcuts: Mapping[str, str | list[str]] | None = None,
         _secrets_dir: PathType | None = None,
-        _build_sources: tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any], InitState] | None = None,
+        _build_sources: tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any]] | None = None,
         **values: Any,
     ) -> None:
-        sources, init_kwargs, init_state = (
+        sources, init_kwargs = (
             _build_sources
             if _build_sources is not None
             else __pydantic_self__.__class__._settings_init_sources(
@@ -256,7 +256,7 @@ class BaseSettings(BaseModel):
             )
         )
 
-        super().__init__(**__pydantic_self__.__class__._settings_build_values(sources, init_kwargs, init_state))
+        super().__init__(**__pydantic_self__.__class__._settings_build_values(sources, init_kwargs))
 
     @classmethod
     def settings_customise_sources(
@@ -314,7 +314,7 @@ class BaseSettings(BaseModel):
         _cli_shortcuts: Mapping[str, str | list[str]] | None = None,
         _secrets_dir: PathType | None = None,
         _init_kwargs: dict[str, Any] | None = None,
-    ) -> tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any], InitState]:
+    ) -> tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any]]:
         # Determine settings config values
         case_sensitive = _case_sensitive if _case_sensitive is not None else cls.model_config.get('case_sensitive')
         env_prefix = _env_prefix if _env_prefix is not None else cls.model_config.get('env_prefix')
@@ -476,14 +476,11 @@ class BaseSettings(BaseModel):
 
         cls._settings_warn_unused_config_keys(sources, cls.model_config)
 
-        return sources, _init_kwargs if _init_kwargs is not None else {}, init_state
+        return sources, _init_kwargs if _init_kwargs is not None else {}
 
     @classmethod
     def _settings_build_values(
-        cls,
-        sources: tuple[PydanticBaseSettingsSource, ...],
-        init_kwargs: dict[str, Any],
-        init_state: InitState,
+        cls, sources: tuple[PydanticBaseSettingsSource, ...], init_kwargs: dict[str, Any]
     ) -> dict[str, Any]:
         if sources:
             state: dict[str, Any] = {}
@@ -505,6 +502,10 @@ class BaseSettings(BaseModel):
 
             # Strip any default values not explicity set before returning final state
             state = {key: val for key, val in state.items() if key not in defaults or defaults[key] != val}
+            # The last source is the `DefaultSettingsSource` instance created in `_settings_init_sources()`,
+            # holding the init state shared by all built-in sources:
+            last_source = sources[-1]
+            init_state = last_source._init_state if isinstance(last_source, PydanticBaseSettingsSource) else InitState()
             cls._settings_restore_init_kwarg_names(cls, init_kwargs, state, init_state)
 
             return state
@@ -760,27 +761,27 @@ class CliApp:
 
         if not issubclass(model_cls, BaseSettings):
             base_settings_cls = CliApp._get_base_settings_cls(model_cls)
-            sources, init_kwargs, init_state = base_settings_cls._settings_init_sources(
+            sources, init_kwargs = base_settings_cls._settings_init_sources(
                 _cli_parse_args=cli_parse_args,  # type: ignore[arg-type]
                 _cli_exit_on_error=cli_exit_on_error,
                 _cli_show_env_vars=cli_show_env_vars,
                 _cli_settings_source=cli_settings,
                 _init_kwargs=model_init_data,
             )
-            model = base_settings_cls(**base_settings_cls._settings_build_values(sources, init_kwargs, init_state))
+            model = base_settings_cls(**base_settings_cls._settings_build_values(sources, init_kwargs))
             model_init_data = {}
             for field_name, field_info in base_settings_cls.model_fields.items():
                 model_init_data[_field_name_for_signature(field_name, field_info)] = getattr(model, field_name)
             command = model_cls(**model_init_data)
         else:
-            sources, init_kwargs, init_state = model_cls._settings_init_sources(
+            sources, init_kwargs = model_cls._settings_init_sources(
                 _cli_parse_args=cli_parse_args,  # type: ignore[arg-type]
                 _cli_exit_on_error=cli_exit_on_error,
                 _cli_show_env_vars=cli_show_env_vars,
                 _cli_settings_source=cli_settings,
                 _init_kwargs=model_init_data,
             )
-            command = model_cls(_build_sources=(sources, init_kwargs, init_state))
+            command = model_cls(_build_sources=(sources, init_kwargs))
 
         subcommand_dest = ':subcommand'
         cli_settings_source = [source for source in sources if isinstance(source, CliSettingsSource)][0]

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -38,7 +38,7 @@ from .sources import (
     YamlConfigSettingsSource,
     get_subcommand,
 )
-from .sources.utils import _get_alias_names
+from .sources.utils import InitState, _get_alias_names, _warn_if_field_info_incomplete
 
 T = TypeVar('T')
 
@@ -180,8 +180,8 @@ class BaseSettings(BaseModel):
         _cli_kebab_case: CLI args use kebab case. Defaults to `False`.
         _cli_shortcuts: Mapping of target field name to alias names. Defaults to `None`.
         _secrets_dir: The secret files directory or a sequence of directories. Defaults to `None`.
-        _build_sources: Pre-initialized sources and init kwargs to use for building instantiation values.
-            Defaults to `None`.
+        _build_sources: Pre-initialized sources, init kwargs and init state to use for building instantiation
+            values. Defaults to `None`.
     """
 
     # Note: when adding new parameters, make sure to use `object` instead of `Any` to avoid issues with the Mypy plugin
@@ -217,10 +217,10 @@ class BaseSettings(BaseModel):
         _cli_kebab_case: bool | Literal['all', 'no_enums'] | None = None,
         _cli_shortcuts: Mapping[str, str | list[str]] | None = None,
         _secrets_dir: PathType | None = None,
-        _build_sources: tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any]] | None = None,
+        _build_sources: tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any], InitState] | None = None,
         **values: Any,
     ) -> None:
-        sources, init_kwargs = (
+        sources, init_kwargs, init_state = (
             _build_sources
             if _build_sources is not None
             else __pydantic_self__.__class__._settings_init_sources(
@@ -256,7 +256,7 @@ class BaseSettings(BaseModel):
             )
         )
 
-        super().__init__(**__pydantic_self__.__class__._settings_build_values(sources, init_kwargs))
+        super().__init__(**__pydantic_self__.__class__._settings_build_values(sources, init_kwargs, init_state))
 
     @classmethod
     def settings_customise_sources(
@@ -314,7 +314,7 @@ class BaseSettings(BaseModel):
         _cli_shortcuts: Mapping[str, str | list[str]] | None = None,
         _secrets_dir: PathType | None = None,
         _init_kwargs: dict[str, Any] | None = None,
-    ) -> tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any]]:
+    ) -> tuple[tuple[PydanticBaseSettingsSource, ...], dict[str, Any], InitState]:
         # Determine settings config values
         case_sensitive = _case_sensitive if _case_sensitive is not None else cls.model_config.get('case_sensitive')
         env_prefix = _env_prefix if _env_prefix is not None else cls.model_config.get('env_prefix')
@@ -388,14 +388,17 @@ class BaseSettings(BaseModel):
 
         secrets_dir = _secrets_dir if _secrets_dir is not None else cls.model_config.get('secrets_dir')
 
-        # Configure built-in sources
+        # Configure built-in sources, sharing the same init state so that incomplete
+        # fields are only warned about once per settings resolution.
+        init_state: InitState = {'field_info_ids': set()}
         default_settings = DefaultSettingsSource(
-            cls, nested_model_default_partial_update=nested_model_default_partial_update
+            cls, nested_model_default_partial_update=nested_model_default_partial_update, _init_state=init_state
         )
         init_settings = InitSettingsSource(
             cls,
             init_kwargs=_init_kwargs if _init_kwargs is not None else {},
             nested_model_default_partial_update=nested_model_default_partial_update,
+            _init_state=default_settings._init_state,
         )
         env_settings = EnvSettingsSource(
             cls,
@@ -407,6 +410,7 @@ class BaseSettings(BaseModel):
             env_ignore_empty=env_ignore_empty,
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,
+            _init_state=init_settings._init_state,
         )
         dotenv_settings = DotEnvSettingsSource(
             cls,
@@ -420,6 +424,7 @@ class BaseSettings(BaseModel):
             env_ignore_empty=env_ignore_empty,
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,
+            _init_state=env_settings._init_state,
         )
 
         file_secret_settings = SecretsSettingsSource(
@@ -428,6 +433,7 @@ class BaseSettings(BaseModel):
             case_sensitive=case_sensitive,
             env_prefix=env_prefix,
             env_prefix_target=env_prefix_target,
+            _init_state=dotenv_settings._init_state,
         )
         # Provide a hook to set built-in sources priority and add / remove sources
         sources = cls.settings_customise_sources(
@@ -444,6 +450,7 @@ class BaseSettings(BaseModel):
             elif cli_parse_args is not None:
                 cli_settings = CliSettingsSource[Any](
                     cls,
+                    _init_state=file_secret_settings._init_state,
                     cli_prog_name=cli_prog_name,
                     cli_parse_args=cli_parse_args,
                     cli_parse_none_str=cli_parse_none_str,
@@ -469,11 +476,14 @@ class BaseSettings(BaseModel):
 
         cls._settings_warn_unused_config_keys(sources, cls.model_config)
 
-        return sources, _init_kwargs if _init_kwargs is not None else {}
+        return sources, _init_kwargs if _init_kwargs is not None else {}, init_state
 
     @classmethod
     def _settings_build_values(
-        cls, sources: tuple[PydanticBaseSettingsSource, ...], init_kwargs: dict[str, Any]
+        cls,
+        sources: tuple[PydanticBaseSettingsSource, ...],
+        init_kwargs: dict[str, Any],
+        init_state: InitState,
     ) -> dict[str, Any]:
         if sources:
             state: dict[str, Any] = {}
@@ -495,7 +505,7 @@ class BaseSettings(BaseModel):
 
             # Strip any default values not explicity set before returning final state
             state = {key: val for key, val in state.items() if key not in defaults or defaults[key] != val}
-            cls._settings_restore_init_kwarg_names(cls, init_kwargs, state)
+            cls._settings_restore_init_kwarg_names(cls, init_kwargs, state, init_state)
 
             return state
         else:
@@ -505,7 +515,10 @@ class BaseSettings(BaseModel):
 
     @staticmethod
     def _settings_restore_init_kwarg_names(
-        settings_cls: type[BaseSettings], init_kwargs: dict[str, Any], state: dict[str, Any]
+        settings_cls: type[BaseSettings],
+        init_kwargs: dict[str, Any],
+        state: dict[str, Any],
+        init_state: InitState,
     ) -> None:
         """
         Restore the init_kwarg key names to the final merged state dictionary.
@@ -517,6 +530,7 @@ class BaseSettings(BaseModel):
             state_kwarg_names = set(state.keys())
             init_kwarg_names = set(init_kwargs.keys())
             for field_name, field_info in settings_cls.model_fields.items():
+                _warn_if_field_info_incomplete(field_info, field_name, init_state)
                 alias_names, *_ = _get_alias_names(field_name, field_info)
                 matchable_names = set(alias_names)
                 include_name = settings_cls.model_config.get(
@@ -746,27 +760,27 @@ class CliApp:
 
         if not issubclass(model_cls, BaseSettings):
             base_settings_cls = CliApp._get_base_settings_cls(model_cls)
-            sources, init_kwargs = base_settings_cls._settings_init_sources(
+            sources, init_kwargs, init_state = base_settings_cls._settings_init_sources(
                 _cli_parse_args=cli_parse_args,  # type: ignore[arg-type]
                 _cli_exit_on_error=cli_exit_on_error,
                 _cli_show_env_vars=cli_show_env_vars,
                 _cli_settings_source=cli_settings,
                 _init_kwargs=model_init_data,
             )
-            model = base_settings_cls(**base_settings_cls._settings_build_values(sources, init_kwargs))
+            model = base_settings_cls(**base_settings_cls._settings_build_values(sources, init_kwargs, init_state))
             model_init_data = {}
             for field_name, field_info in base_settings_cls.model_fields.items():
                 model_init_data[_field_name_for_signature(field_name, field_info)] = getattr(model, field_name)
             command = model_cls(**model_init_data)
         else:
-            sources, init_kwargs = model_cls._settings_init_sources(
+            sources, init_kwargs, init_state = model_cls._settings_init_sources(
                 _cli_parse_args=cli_parse_args,  # type: ignore[arg-type]
                 _cli_exit_on_error=cli_exit_on_error,
                 _cli_show_env_vars=cli_show_env_vars,
                 _cli_settings_source=cli_settings,
                 _init_kwargs=model_init_data,
             )
-            command = model_cls(_build_sources=(sources, init_kwargs))
+            command = model_cls(_build_sources=(sources, init_kwargs, init_state))
 
         subcommand_dest = ':subcommand'
         cli_settings_source = [source for source in sources if isinstance(source, CliSettingsSource)][0]

--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -21,6 +21,7 @@ from ..exceptions import SettingsError
 from ..utils import _lenient_issubclass
 from .types import EnvNoneType, EnvPrefixTarget, ForceDecode, NoDecode, PathType, PydanticModel, _CliSubCommand
 from .utils import (
+    InitState,
     _annotation_is_complex,
     _get_alias_names,
     _get_field_metadata,
@@ -28,6 +29,7 @@ from .utils import (
     _resolve_type_alias,
     _strip_annotated,
     _union_is_complex,
+    _warn_if_field_info_incomplete,
 )
 
 if TYPE_CHECKING:
@@ -74,6 +76,8 @@ def get_subcommand(
             if getattr(model, field_name) is not None:
                 return getattr(model, field_name)
             subcommands.append(field_name)
+        # TODO: we could warn if no sub command was found and one of `field_info`s
+        # isn't complete.
 
     if is_required:
         error_message = (
@@ -94,7 +98,8 @@ class PydanticBaseSettingsSource(ABC):
     Abstract base class for settings sources, every settings source classes should inherit from it.
     """
 
-    def __init__(self, settings_cls: type[BaseSettings]):
+    def __init__(self, settings_cls: type[BaseSettings], _init_state: InitState | None = None):
+        self._init_state: InitState = _init_state or {}
         self.settings_cls = settings_cls
         self.config = settings_cls.model_config
         self._current_state: dict[str, Any] = {}
@@ -154,7 +159,7 @@ class PydanticBaseSettingsSource(ABC):
         Returns:
             Whether the field is complex.
         """
-        return _annotation_is_complex(field.annotation, field.metadata)
+        return _annotation_is_complex(field.annotation, field.metadata, self._init_state)
 
     def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
         """
@@ -247,8 +252,13 @@ class DefaultSettingsSource(PydanticBaseSettingsSource):
             Defaults to `False`.
     """
 
-    def __init__(self, settings_cls: type[BaseSettings], nested_model_default_partial_update: bool | None = None):
-        super().__init__(settings_cls)
+    def __init__(
+        self,
+        settings_cls: type[BaseSettings],
+        nested_model_default_partial_update: bool | None = None,
+        _init_state: InitState | None = None,
+    ):
+        super().__init__(settings_cls, _init_state)
         self.defaults: dict[str, Any] = {}
         self.nested_model_default_partial_update = (
             nested_model_default_partial_update
@@ -257,6 +267,7 @@ class DefaultSettingsSource(PydanticBaseSettingsSource):
         )
         if self.nested_model_default_partial_update:
             for field_name, field_info in settings_cls.model_fields.items():
+                _warn_if_field_info_incomplete(field_info, field_name, self._init_state)
                 if _has_discriminator(field_info):
                     continue
                 alias_names, *_ = _get_alias_names(field_name, field_info)
@@ -289,10 +300,13 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         settings_cls: type[BaseSettings],
         init_kwargs: dict[str, Any],
         nested_model_default_partial_update: bool | None = None,
+        _init_state: InitState | None = None,
     ):
+        super().__init__(settings_cls, _init_state)
         self.init_kwargs = {}
         init_kwarg_names = set(init_kwargs.keys())
         for field_name, field_info in settings_cls.model_fields.items():
+            _warn_if_field_info_incomplete(field_info, field_name, self._init_state)
             alias_names, *_ = _get_alias_names(field_name, field_info)
             # When populate_by_name is True, allow using the field name as an input key,
             # but normalize to the preferred alias to keep keys consistent across sources.
@@ -319,7 +333,6 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         # no alias exists, we keep it as-is so it can be processed as extra if allowed.
         self.init_kwargs.update({key: val for key, val in init_kwargs.items() if key in init_kwarg_names})
 
-        super().__init__(settings_cls)
         self.nested_model_default_partial_update = (
             nested_model_default_partial_update
             if nested_model_default_partial_update is not None
@@ -351,8 +364,9 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         env_ignore_empty: bool | None = None,
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
-        super().__init__(settings_cls)
+        super().__init__(settings_cls, _init_state)
         self.case_sensitive = case_sensitive if case_sensitive is not None else self.config.get('case_sensitive', False)
         self.env_prefix = env_prefix if env_prefix is not None else self.config.get('env_prefix', '')
         self.env_prefix_target = (
@@ -386,6 +400,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         Returns:
             list[tuple[str, str, bool]]: List of tuples, each tuple contains field_key, env_name, and value_is_complex.
         """
+        _warn_if_field_info_incomplete(field, field_name, self._init_state)
         field_info: list[tuple[str, str, bool]] = []
         if isinstance(field.validation_alias, (AliasChoices, AliasPath)):
             v_alias: str | list[str | int] | list[list[str | int]] | None = field.validation_alias.convert_to_aliases()
@@ -415,7 +430,9 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         if not v_alias or self.config.get('populate_by_name', False) or self.config.get('validate_by_name', False):
             annotation = _strip_annotated(_resolve_type_alias(field.annotation))
             env_prefix = self.env_prefix if self.env_prefix_target in ('variable', 'all') else ''
-            if is_union_origin(get_origin(annotation)) and _union_is_complex(annotation, field.metadata):
+            if is_union_origin(get_origin(annotation)) and _union_is_complex(
+                annotation, field.metadata, self._init_state
+            ):
                 field_info.append((field_name, self._apply_case_sensitive(env_prefix + field_name), True))
             else:
                 field_info.append((field_name, self._apply_case_sensitive(env_prefix + field_name), False))
@@ -480,6 +497,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
             # Find field in sub model by looking in fields case insensitively
             field_key: str | None = None
             for sub_model_field_name, sub_model_field in model_fields.items():
+                _warn_if_field_info_incomplete(sub_model_field, sub_model_field_name, self._init_state)
                 aliases, _ = _get_alias_names(sub_model_field_name, sub_model_field)
                 _search = (alias for alias in aliases if alias.lower() == name.lower())
                 if field_key := next(_search, None):
@@ -551,6 +569,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         data: dict[str, Any] = {}
 
         for field_name, field in self.settings_cls.model_fields.items():
+            _warn_if_field_info_incomplete(field, field_name, self._init_state)
             try:
                 field_value, field_key, value_is_complex = self._get_resolved_field_value(field, field_name)
             except Exception as e:

--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -99,7 +99,7 @@ class PydanticBaseSettingsSource(ABC):
     """
 
     def __init__(self, settings_cls: type[BaseSettings], _init_state: InitState | None = None):
-        self._init_state: InitState = _init_state or {}
+        self._init_state: InitState = {} if _init_state is None else _init_state
         self.settings_cls = settings_cls
         self.config = settings_cls.model_config
         self._current_state: dict[str, Any] = {}

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
-from ..utils import parse_env_vars
+from ..utils import InitState, parse_env_vars
 from .env import EnvSettingsSource
 
 if TYPE_CHECKING:
@@ -43,6 +43,7 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
         version_id: str | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
         import_aws_secrets_manager()
         self._secretsmanager_client = boto3_client('secretsmanager', region_name=region_name, endpoint_url=endpoint_url)  # type: ignore
@@ -56,6 +57,7 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
             env_ignore_empty=False,
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,
+            _init_state=_init_state,
         )
 
     def _load_env_vars(self) -> Mapping[str, str | None]:

--- a/pydantic_settings/sources/providers/azure.py
+++ b/pydantic_settings/sources/providers/azure.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from pydantic.alias_generators import to_snake
 from pydantic.fields import FieldInfo
 
+from ..utils import InitState
 from .env import EnvSettingsSource
 
 if TYPE_CHECKING:
@@ -117,6 +118,7 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
         env_prefix: str | None = None,
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
         import_azure_key_vault()
         self._url = url
@@ -131,6 +133,7 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
             env_ignore_empty=False,
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,
+            _init_state=_init_state,
         )
 
     def _load_env_vars(self) -> Mapping[str, str | None]:

--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -61,6 +61,7 @@ from ..types import (
     _CliUnknownArgs,
 )
 from ..utils import (
+    InitState,
     _annotation_contains_types,
     _annotation_enum_val_to_name,
     _get_alias_names,
@@ -378,6 +379,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         format_help_method: Callable[..., Any] | None = ArgumentParser.format_help,
         formatter_class: Any = RawDescriptionHelpFormatter,
         _env_settings_source: EnvSettingsSource | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
         self.cli_prog_name = (
             cli_prog_name if cli_prog_name is not None else settings_cls.model_config.get('cli_prog_name', sys.argv[0])
@@ -457,6 +459,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             env_prefix=self.cli_prefix,
             case_sensitive=case_sensitive,
             env_nested_max_split=0,
+            _init_state=_init_state,
         )
 
         root_parser = (

--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -843,7 +843,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             raise SettingsError(f'{cli_flag_name} argument {model.__name__}.{field_name} is not of type bool')
 
     def _sort_arg_fields(self, model: type[BaseModel]) -> list[tuple[str, FieldInfo]]:
-        positional_variadic_arg = []
+        positional_variadic_arg: list[tuple[str, FieldInfo]] = []
         positional_args, subcommand_args, optional_args = [], [], []
         for field_name, field_info in _get_model_fields(model).items():
             if _CliSubCommand in field_info.metadata:

--- a/pydantic_settings/sources/providers/dotenv.py
+++ b/pydantic_settings/sources/providers/dotenv.py
@@ -16,6 +16,7 @@ from typing_inspection.introspection import is_union_origin
 
 from ..types import ENV_FILE_SENTINEL, DotenvFiltering, DotenvType, EnvPrefixTarget
 from ..utils import (
+    InitState,
     _annotation_is_complex,
     _union_is_complex,
     parse_env_vars,
@@ -45,6 +46,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
         env_ignore_empty: bool | None = None,
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
         self.env_file = env_file if env_file != ENV_FILE_SENTINEL else settings_cls.model_config.get('env_file')
         self.env_file_encoding = (
@@ -63,6 +65,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
             env_ignore_empty,
             env_parse_none_str,
             env_parse_enums,
+            _init_state,
         )
 
     def _load_env_vars(self) -> Mapping[str, str | None]:
@@ -141,10 +144,10 @@ class DotEnvSettingsSource(EnvSettingsSource):
                 for _, field_env_name, _ in self._extract_field_info(field, field_name):
                     if env_name == field_env_name or (
                         (
-                            _annotation_is_complex(field.annotation, field.metadata)
+                            _annotation_is_complex(field.annotation, field.metadata, self._init_state)
                             or (
                                 is_union_origin(get_origin(field.annotation))
-                                and _union_is_complex(field.annotation, field.metadata)
+                                and _union_is_complex(field.annotation, field.metadata, self._init_state)
                             )
                         )
                         and env_name.startswith(field_env_name)

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -20,6 +20,7 @@ from ...utils import _lenient_issubclass
 from ..base import PydanticBaseEnvSettingsSource
 from ..types import EnvNoneType, EnvPrefixTarget
 from ..utils import (
+    InitState,
     _annotation_contains_types,
     _annotation_enum_name_to_val,
     _annotation_is_complex,
@@ -59,6 +60,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         env_ignore_empty: bool | None = None,
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
         super().__init__(
             settings_cls,
@@ -68,6 +70,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             env_ignore_empty,
             env_parse_none_str,
             env_parse_enums,
+            _init_state,
         )
         self.env_nested_delimiter = (
             env_nested_delimiter if env_nested_delimiter is not None else self.config.get('env_nested_delimiter')
@@ -193,7 +196,9 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         """
         if self.field_is_complex(field):
             allow_parse_failure = False
-        elif is_union_origin(get_origin(field.annotation)) and _union_is_complex(field.annotation, field.metadata):
+        elif is_union_origin(get_origin(field.annotation)) and _union_is_complex(
+            field.annotation, field.metadata, self._init_state
+        ):
             allow_parse_failure = True
         else:
             return False, False
@@ -314,7 +319,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                         env_val = env_val if enum_val is None else enum_val
                 elif target_field:
                     # target_field is a raw type (e.g. from dict value type annotation)
-                    is_complex = _annotation_is_complex(target_field, [])
+                    is_complex = _annotation_is_complex(target_field, [], self._init_state)
                     allow_json_failure = True
                 else:
                     # nested field type is dict

--- a/pydantic_settings/sources/providers/gcp.py
+++ b/pydantic_settings/sources/providers/gcp.py
@@ -9,6 +9,7 @@ from pydantic.fields import FieldInfo
 
 from ...exceptions import SettingsError
 from ..types import SecretVersion
+from ..utils import InitState
 from .env import EnvSettingsSource
 
 if TYPE_CHECKING:
@@ -170,6 +171,7 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
         secret_client: SecretManagerServiceClient | None = None,
         case_sensitive: bool | None = True,
         project_id_field: str = 'project_id',
+        _init_state: InitState | None = None,
     ) -> None:
         """Settings source that reads secrets from Google Cloud Secret Manager.
 
@@ -214,6 +216,7 @@ class GoogleSecretManagerSettingsSource(EnvSettingsSource):
             env_ignore_empty=False,
             env_parse_none_str=env_parse_none_str,
             env_parse_enums=env_parse_enums,
+            _init_state=_init_state,
         )
         # __init__ is past; subsequent _load_env_vars() calls may now resolve the project.
         self._env_vars_loaded = True

--- a/pydantic_settings/sources/providers/json.py
+++ b/pydantic_settings/sources/providers/json.py
@@ -11,6 +11,7 @@ from typing import (
 
 from ..base import ConfigFileSourceMixin, InitSettingsSource
 from ..types import DEFAULT_PATH, PathType
+from ..utils import InitState
 
 if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
@@ -27,6 +28,7 @@ class JsonConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         json_file: PathType | None = DEFAULT_PATH,
         json_file_encoding: str | None = None,
         deep_merge: bool = False,
+        _init_state: InitState | None = None,
     ):
         self.json_file_path = json_file if json_file != DEFAULT_PATH else settings_cls.model_config.get('json_file')
         self.json_file_encoding = (
@@ -35,7 +37,7 @@ class JsonConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             else settings_cls.model_config.get('json_file_encoding')
         )
         self.json_data = self._read_files(self.json_file_path, deep_merge=deep_merge)
-        super().__init__(settings_cls, self.json_data)
+        super().__init__(settings_cls, self.json_data, _init_state=_init_state)
 
     def _read_file(self, file_path: Path) -> dict[str, Any]:
         with file_path.open(encoding=self.json_file_encoding) as json_file:

--- a/pydantic_settings/sources/providers/nested_secrets.py
+++ b/pydantic_settings/sources/providers/nested_secrets.py
@@ -116,7 +116,7 @@ class NestedSecretsSettingsSource(EnvSettingsSource):
             env_ignore_empty=False,  # match SecretsSettingsSource behaviour
             env_parse_enums=True,  # we can pass everything here, it will still behave as "True"
             env_parse_none_str=None,  # match SecretsSettingsSource behaviour
-            _init_state=_init_state or getattr(file_secret_settings, '_init_state', None),
+            _init_state=_init_state if _init_state is not None else getattr(file_secret_settings, '_init_state', None),
         )
         self.env_parse_none_str = None  # update manually because of None
 

--- a/pydantic_settings/sources/providers/nested_secrets.py
+++ b/pydantic_settings/sources/providers/nested_secrets.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 from ...exceptions import SettingsError
 from ...utils import path_type_label
 from ..base import PydanticBaseSettingsSource
-from ..utils import parse_env_vars
+from ..utils import InitState, parse_env_vars
 from .env import EnvSettingsSource
 from .secrets import SecretsSettingsSource
 
@@ -34,6 +34,7 @@ class NestedSecretsSettingsSource(EnvSettingsSource):
         # args for compatibility with SecretsSettingsSource, don't use directly
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
         # We allow the first argument to be settings_cls like original
         # SecretsSettingsSource. However, it is recommended to pass
@@ -106,7 +107,7 @@ class NestedSecretsSettingsSource(EnvSettingsSource):
         for path in self.secrets_paths:
             self.validate_secrets_path(path)
 
-        # construct parent
+        # construct parent, inheriting the init state of the wrapped source if not provided
         super().__init__(
             settings_cls,
             case_sensitive=self.case_sensitive,
@@ -115,6 +116,7 @@ class NestedSecretsSettingsSource(EnvSettingsSource):
             env_ignore_empty=False,  # match SecretsSettingsSource behaviour
             env_parse_enums=True,  # we can pass everything here, it will still behave as "True"
             env_parse_none_str=None,  # match SecretsSettingsSource behaviour
+            _init_state=_init_state or getattr(file_secret_settings, '_init_state', None),
         )
         self.env_parse_none_str = None  # update manually because of None
 

--- a/pydantic_settings/sources/providers/pyproject.py
+++ b/pydantic_settings/sources/providers/pyproject.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from ..utils import InitState
 from .toml import TomlConfigSettingsSource
 
 if TYPE_CHECKING:
@@ -22,6 +23,7 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSource):
         self,
         settings_cls: type[BaseSettings],
         toml_file: Path | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
         self.toml_file_path = self._pick_pyproject_toml_file(
             toml_file, settings_cls.model_config.get('pyproject_toml_depth', 0)
@@ -32,7 +34,7 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSource):
         self.toml_data = self._read_files(self.toml_file_path)
         for key in self.toml_table_header:
             self.toml_data = self.toml_data.get(key, {})
-        super(TomlConfigSettingsSource, self).__init__(settings_cls, self.toml_data)
+        super(TomlConfigSettingsSource, self).__init__(settings_cls, self.toml_data, _init_state=_init_state)
 
     @staticmethod
     def _pick_pyproject_toml_file(provided: Path | None, depth: int) -> Path:

--- a/pydantic_settings/sources/providers/secrets.py
+++ b/pydantic_settings/sources/providers/secrets.py
@@ -17,6 +17,7 @@ from pydantic_settings.utils import path_type_label
 from ...exceptions import SettingsError
 from ..base import PydanticBaseEnvSettingsSource
 from ..types import EnvPrefixTarget, PathType
+from ..utils import InitState
 
 if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
@@ -37,6 +38,7 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
         env_ignore_empty: bool | None = None,
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
+        _init_state: InitState | None = None,
     ) -> None:
         super().__init__(
             settings_cls,
@@ -46,6 +48,7 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
             env_ignore_empty,
             env_parse_none_str,
             env_parse_enums,
+            _init_state,
         )
         self.secrets_dir = secrets_dir if secrets_dir is not None else self.config.get('secrets_dir')
 

--- a/pydantic_settings/sources/providers/toml.py
+++ b/pydantic_settings/sources/providers/toml.py
@@ -12,6 +12,7 @@ from typing import (
 
 from ..base import ConfigFileSourceMixin, InitSettingsSource
 from ..types import DEFAULT_PATH, PathType
+from ..utils import InitState
 
 if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
@@ -53,6 +54,7 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         toml_file: PathType | None = DEFAULT_PATH,
         toml_table_header: tuple[str, ...] = (),
         deep_merge: bool = False,
+        _init_state: InitState | None = None,
     ):
         self.toml_file_path = toml_file if toml_file != DEFAULT_PATH else settings_cls.model_config.get('toml_file')
         self.toml_table_header = (
@@ -66,7 +68,7 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
                     raise KeyError(f'toml_table_header key "{key}" not found in {self.toml_file_path}')
                 self.toml_data = self.toml_data[key]
 
-        super().__init__(settings_cls, self.toml_data)
+        super().__init__(settings_cls, self.toml_data, _init_state=_init_state)
 
     def _read_file(self, file_path: Path) -> dict[str, Any]:
         import_toml()

--- a/pydantic_settings/sources/providers/yaml.py
+++ b/pydantic_settings/sources/providers/yaml.py
@@ -10,6 +10,7 @@ from typing import (
 
 from ..base import ConfigFileSourceMixin, InitSettingsSource
 from ..types import DEFAULT_PATH, PathType
+from ..utils import InitState
 
 if TYPE_CHECKING:
     import yaml
@@ -41,6 +42,7 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         yaml_file_encoding: str | None = None,
         yaml_config_section: str | None = None,
         deep_merge: bool = False,
+        _init_state: InitState | None = None,
     ):
         self.yaml_file_path = yaml_file if yaml_file != DEFAULT_PATH else settings_cls.model_config.get('yaml_file')
         self.yaml_file_encoding = (
@@ -59,7 +61,7 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             self.yaml_data = self._traverse_nested_section(
                 self.yaml_data, self.yaml_config_section, self.yaml_config_section
             )
-        super().__init__(settings_cls, self.yaml_data)
+        super().__init__(settings_cls, self.yaml_data, _init_state=_init_state)
 
     def _read_file(self, file_path: Path) -> dict[str, Any]:
         import_yaml()

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations as _annotations
 
+import warnings
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import is_dataclass
 from enum import Enum
-from typing import Any, TypeVar, cast, get_args, get_origin
+from typing import Any, TypedDict, TypeVar, cast, get_args, get_origin
 
 from pydantic import BaseModel, Json, RootModel, Secret
 from pydantic._internal._utils import is_model_class
@@ -16,9 +17,40 @@ from pydantic.types import Strict
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
-from ..exceptions import SettingsError
+from ..exceptions import IncompleteFieldDefinitionWarning, SettingsError
 from ..utils import _lenient_issubclass
 from .types import EnvNoneType
+
+
+class InitState(TypedDict, total=False):
+    """State shared between settings sources during a single settings resolution."""
+
+    field_info_ids: set[int]
+    """The `id()`s of the incomplete `FieldInfo` instances that were already warned about."""
+
+
+def _warn_if_field_info_incomplete(field_info: FieldInfo, field_name: str, init_state: InitState) -> None:
+    """Warn if the field is incomplete, i.e. its annotation contains unresolved forward references.
+
+    An incomplete `FieldInfo` instance is unsafe to inspect — any of its attributes (annotation,
+    aliases, metadata, default) may rely on the unresolved annotation, so settings sources may
+    silently fail to resolve the field's value. Each instance is only warned about once per
+    `init_state`, so that a field accessed by multiple sources during a single settings
+    resolution doesn't emit duplicate warnings.
+    """
+    if getattr(field_info, '_complete', True):
+        return
+    warned_ids = init_state.setdefault('field_info_ids', set())
+    if id(field_info) in warned_ids:
+        return
+    warned_ids.add(id(field_info))
+    warnings.warn(
+        f'Field {field_name!r} has an incomplete definition: its annotation contains an unresolved '
+        'forward reference, so settings sources may fail to correctly resolve its value. '
+        'Call `model_rebuild()` on the model where the field is defined, once all the referenced '
+        'types are defined.',
+        IncompleteFieldDefinitionWarning,
+    )
 
 
 def _get_env_var_key(key: str, case_sensitive: bool = False) -> str:
@@ -81,13 +113,16 @@ def _resolve_type_alias(annotation: Any) -> Any:
     return annotation
 
 
-def _annotation_is_complex(annotation: Any, metadata: list[Any]) -> bool:
+def _annotation_is_complex(annotation: Any, metadata: list[Any], init_state: InitState | None = None) -> bool:
     # If the model is a root model, the root annotation should be used to
     # evaluate the complexity.
     annotation = _resolve_type_alias(annotation)
     if annotation is not None and _lenient_issubclass(annotation, RootModel) and annotation is not RootModel:
         annotation = cast('type[RootModel[Any]]', annotation)
-        root_annotation = annotation.model_fields['root'].annotation
+        root_field = annotation.model_fields['root']
+        if init_state is not None:
+            _warn_if_field_info_incomplete(root_field, f'{annotation.__name__}.root', init_state)
+        root_annotation = root_field.annotation
         if root_annotation is not None:  # pragma: no branch
             annotation = root_annotation
 
@@ -100,7 +135,7 @@ def _annotation_is_complex(annotation: Any, metadata: list[Any]) -> bool:
     if typing_objects.is_annotated(origin):
         # Return result of recursive call on inner type.
         inner, *meta = get_args(annotation)
-        return _annotation_is_complex(inner, meta)
+        return _annotation_is_complex(inner, meta, init_state)
 
     if origin is Secret:
         return False
@@ -132,10 +167,10 @@ def _annotation_is_complex_inner(annotation: type[Any] | None) -> bool:
     ) or is_dataclass(annotation)
 
 
-def _union_is_complex(annotation: type[Any] | None, metadata: list[Any]) -> bool:
+def _union_is_complex(annotation: type[Any] | None, metadata: list[Any], init_state: InitState | None = None) -> bool:
     """Check if a union type contains any complex types."""
     for arg in get_args(annotation):
-        if _annotation_is_complex(arg, metadata):
+        if _annotation_is_complex(arg, metadata, init_state):
             return True
         # _annotation_is_complex doesn't handle bare Union types, so when an arg
         # is Annotated[Union[X, Y], ...], stripping Annotated yields a bare Union
@@ -147,7 +182,7 @@ def _union_is_complex(annotation: type[Any] | None, metadata: list[Any]) -> bool
             if any(isinstance(md, Json) for md in inner_meta):  # type: ignore[misc]
                 continue
         if is_union_origin(get_origin(inner)):
-            if _union_is_complex(inner, metadata):
+            if _union_is_complex(inner, metadata, init_state):
                 return True
     return False
 
@@ -311,6 +346,7 @@ def _is_function(obj: Any) -> bool:
 
 
 __all__ = [
+    'InitState',
     '_annotation_contains_types',
     '_annotation_enum_name_to_val',
     '_annotation_enum_val_to_name',
@@ -326,5 +362,6 @@ __all__ = [
     '_strip_annotated',
     '_union_has_strict_types',
     '_union_is_complex',
+    '_warn_if_field_info_incomplete',
     'parse_env_vars',
 ]

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -244,7 +244,7 @@ def _literal_has_numeric_enum(annotation: type[Any] | None) -> bool:
     return False
 
 
-def _get_model_fields(model_cls: type[Any]) -> dict[str, Any]:
+def _get_model_fields(model_cls: type[Any]) -> dict[str, FieldInfo]:
     """Get fields from a pydantic model or dataclass."""
 
     if is_pydantic_dataclass(model_cls) and hasattr(model_cls, '__pydantic_fields__'):
@@ -256,7 +256,7 @@ def _get_model_fields(model_cls: type[Any]) -> dict[str, Any]:
 
 def _get_alias_names(
     field_name: str,
-    field_info: Any,
+    field_info: FieldInfo,
     alias_path_args: dict[str, int | None] | None = None,
     case_sensitive: bool = True,
     populate_by_name: bool = False,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,6 +24,7 @@ from pydantic import (
     HttpUrl,
     Json,
     PostgresDsn,
+    PydanticUserError,
     RootModel,
     Secret,
     SecretStr,
@@ -43,6 +44,7 @@ from pydantic_settings import (
     DotEnvSettingsSource,
     EnvSettingsSource,
     ForceDecode,
+    IncompleteFieldDefinitionWarning,
     InitSettingsSource,
     NoDecode,
     PydanticBaseSettingsSource,
@@ -3806,3 +3808,78 @@ def test_field_named_cls():
 
     s = Settings.model_validate({'cls': 'Foo'})
     assert s.cls == 'Foo'
+
+
+def test_warn_on_incomplete_field_info():
+    """Settings sources should emit a single `IncompleteFieldDefinitionWarning` per incomplete
+    `FieldInfo` (i.e. with an annotation containing unresolved forward references) per settings resolution.
+    """
+
+    class App(BaseSettings):
+        service: 'Service | None' = None  # noqa: F821
+
+    assert not App.model_fields['service']._complete
+
+    with pytest.warns(IncompleteFieldDefinitionWarning) as caught:
+        with pytest.raises(PydanticUserError, match='`App` is not fully defined'):
+            App()
+
+    incomplete_warnings = [str(w.message) for w in caught if w.category is IncompleteFieldDefinitionWarning]
+    # The shared init state deduplicates warnings across all sources within a single resolution:
+    assert len(incomplete_warnings) == 1
+    assert incomplete_warnings[0].startswith("Field 'service' ")
+
+
+def test_warn_on_incomplete_field_info_nested_model(env):
+    """The incomplete field warning is also emitted for fields of nested models, reached
+    when resolving nested environment variables.
+
+    In this scenario (the forward reference is resolvable when the settings class builds
+    its schema, but the nested model's `model_fields` was never rebuilt), instantiation
+    succeeds while nested env overrides for the incomplete field are silently ignored.
+    The warning is the only signal that something is wrong.
+    """
+
+    class ServiceConfig(BaseModel):
+        connector: 'ConnectorConfig'
+
+    class ConnectorConfig(BaseModel):
+        apiKey: str = 'orig-key'
+        endpoint: str = 'orig-endpoint'
+
+    class AppSettings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='app_', env_nested_delimiter='_', case_sensitive=False)
+        service: ServiceConfig
+
+    assert not ServiceConfig.model_fields['connector']._complete
+
+    env.set('APP_SERVICE_CONNECTOR_apiKey', 'ENV_KEY')
+    env.set('APP_SERVICE_CONNECTOR_endpoint', 'ENV_ENDPOINT')
+
+    with pytest.warns(IncompleteFieldDefinitionWarning) as caught:
+        s = AppSettings()
+
+    incomplete_warnings = [str(w.message) for w in caught if w.category is IncompleteFieldDefinitionWarning]
+    assert len(incomplete_warnings) == 1
+    assert incomplete_warnings[0].startswith("Field 'connector' ")
+
+    # The `apiKey` override is silently ignored because of the incomplete field:
+    assert s.service.connector.apiKey == 'orig-key'
+    assert s.service.connector.endpoint == 'ENV_ENDPOINT'
+
+
+def test_warn_on_incomplete_field_info_standalone_source():
+    """A source instantiated on its own still warns (and deduplicates) using its own init state."""
+
+    class App(BaseSettings):
+        service: 'Service | None' = None  # noqa: F821
+
+    source = EnvSettingsSource(App)
+
+    with pytest.warns(IncompleteFieldDefinitionWarning) as caught:
+        source()
+        source()
+
+    incomplete_warnings = [str(w.message) for w in caught if w.category is IncompleteFieldDefinitionWarning]
+    assert len(incomplete_warnings) == 1
+    assert incomplete_warnings[0].startswith("Field 'service' ")


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic-settings/issues/775, closes https://github.com/pydantic/pydantic-settings/pull/855.

https://github.com/pydantic/pydantic-settings/pull/855 had a wrong approach, at it was scoped per source, which would result in duplicate warnings.