### PR TITLE
Support Traversable for json/toml/yaml config file sources (#299)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2810,6 +2810,12 @@ The files are merged shallowly in increasing order of priority. To enable deep m
 !!! warning
     The `deep_merge` option is **not available** through the `SettingsConfigDict`.
 
+!!! note
+    In addition to `str` and `pathlib.Path`, the `json_file`, `toml_file`, and `yaml_file` options also accept a
+    [`Traversable`][importlib.resources.abc.Traversable], such as the result of `importlib.resources.files(...).joinpath(...)`.
+    This makes it possible to load a configuration file that is packaged inside your distribution, including cases where the
+    resource does not live on the filesystem (e.g. inside a zip/wheel).
+
 ```py
 from pydantic import BaseModel
 

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -21,6 +21,7 @@ from .exceptions import SettingsError
 from .sources import (
     ENV_FILE_SENTINEL,
     CliSettingsSource,
+    ConfigFileSourceType,
     DefaultSettingsSource,
     DotenvFiltering,
     DotEnvSettingsSource,
@@ -72,9 +73,9 @@ class SettingsConfigDict(ConfigDict, total=False):
     cli_kebab_case: bool | Literal['all', 'no_enums'] | None
     cli_shortcuts: Mapping[str, str | list[str]] | None
     secrets_dir: PathType | None
-    json_file: PathType | None
+    json_file: ConfigFileSourceType | None
     json_file_encoding: str | None
-    yaml_file: PathType | None
+    yaml_file: ConfigFileSourceType | None
     yaml_file_encoding: str | None
     yaml_config_section: str | None
     """
@@ -105,7 +106,7 @@ class SettingsConfigDict(ConfigDict, total=False):
     To use the root table, exclude this config setting or provide an empty tuple.
     """
 
-    toml_file: PathType | None
+    toml_file: ConfigFileSourceType | None
 
     toml_table_header: tuple[str, ...]
     """

--- a/pydantic_settings/sources/__init__.py
+++ b/pydantic_settings/sources/__init__.py
@@ -35,6 +35,7 @@ from .providers.yaml import YamlConfigSettingsSource
 from .types import (
     DEFAULT_PATH,
     ENV_FILE_SENTINEL,
+    ConfigFileSourceType,
     DotenvFiltering,
     DotenvType,
     EnvPrefixTarget,
@@ -60,6 +61,7 @@ __all__ = [
     'CliSubCommand',
     'CliSuppress',
     'CliUnknownArgs',
+    'ConfigFileSourceType',
     'DefaultSettingsSource',
     'DotEnvSettingsSource',
     'DotenvFiltering',

--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -19,7 +19,15 @@ from typing_inspection.introspection import is_union_origin
 
 from ..exceptions import SettingsError
 from ..utils import _lenient_issubclass
-from .types import EnvNoneType, EnvPrefixTarget, ForceDecode, NoDecode, PathType, PydanticModel, _CliSubCommand
+from .types import (
+    ConfigFileSourceType,
+    EnvNoneType,
+    EnvPrefixTarget,
+    ForceDecode,
+    NoDecode,
+    PydanticModel,
+    _CliSubCommand,
+)
 from .utils import (
     _annotation_is_complex,
     _get_alias_names,
@@ -32,6 +40,8 @@ from .utils import (
 
 if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
+
+    from .types import Traversable
 
 
 def get_subcommand(
@@ -199,17 +209,14 @@ class PydanticBaseSettingsSource(ABC):
 
 
 class ConfigFileSourceMixin(ABC):
-    def _read_files(self, files: PathType | None, deep_merge: bool = False) -> dict[str, Any]:
+    def _read_files(self, files: ConfigFileSourceType | None, deep_merge: bool = False) -> dict[str, Any]:
         if files is None:
             return {}
         if not isinstance(files, Sequence) or isinstance(files, str):
             files = [files]
         vars: dict[str, Any] = {}
         for file in files:
-            if isinstance(file, str):
-                file_path = Path(file)
-            else:
-                file_path = file
+            file_path: Path | Traversable = Path(file) if isinstance(file, str) else file
             if isinstance(file_path, Path):
                 file_path = file_path.expanduser()
 
@@ -224,7 +231,7 @@ class ConfigFileSourceMixin(ABC):
         return vars
 
     @abstractmethod
-    def _read_file(self, path: Path) -> dict[str, Any]:
+    def _read_file(self, path: Path | Traversable) -> dict[str, Any]:
         pass
 
 

--- a/pydantic_settings/sources/providers/json.py
+++ b/pydantic_settings/sources/providers/json.py
@@ -3,17 +3,20 @@
 from __future__ import annotations as _annotations
 
 import json
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
 )
 
 from ..base import ConfigFileSourceMixin, InitSettingsSource
-from ..types import DEFAULT_PATH, PathType
+from ..types import DEFAULT_PATH, ConfigFileSourceType
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pydantic_settings.main import BaseSettings
+
+    from ..types import Traversable
 
 
 class JsonConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
@@ -24,7 +27,7 @@ class JsonConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
     def __init__(
         self,
         settings_cls: type[BaseSettings],
-        json_file: PathType | None = DEFAULT_PATH,
+        json_file: ConfigFileSourceType | None = DEFAULT_PATH,
         json_file_encoding: str | None = None,
         deep_merge: bool = False,
     ):
@@ -37,7 +40,7 @@ class JsonConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         self.json_data = self._read_files(self.json_file_path, deep_merge=deep_merge)
         super().__init__(settings_cls, self.json_data)
 
-    def _read_file(self, file_path: Path) -> dict[str, Any]:
+    def _read_file(self, file_path: Path | Traversable) -> dict[str, Any]:
         with file_path.open(encoding=self.json_file_encoding) as json_file:
             return json.load(json_file)
 

--- a/pydantic_settings/sources/providers/toml.py
+++ b/pydantic_settings/sources/providers/toml.py
@@ -11,10 +11,12 @@ from typing import (
 )
 
 from ..base import ConfigFileSourceMixin, InitSettingsSource
-from ..types import DEFAULT_PATH, PathType
+from ..types import DEFAULT_PATH, ConfigFileSourceType
 
 if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
+
+    from ..types import Traversable
 
     if sys.version_info >= (3, 11):
         import tomllib
@@ -50,7 +52,7 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
     def __init__(
         self,
         settings_cls: type[BaseSettings],
-        toml_file: PathType | None = DEFAULT_PATH,
+        toml_file: ConfigFileSourceType | None = DEFAULT_PATH,
         toml_table_header: tuple[str, ...] = (),
         deep_merge: bool = False,
     ):
@@ -68,7 +70,7 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
 
         super().__init__(settings_cls, self.toml_data)
 
-    def _read_file(self, file_path: Path) -> dict[str, Any]:
+    def _read_file(self, file_path: Path | Traversable) -> dict[str, Any]:
         import_toml()
         with file_path.open(mode='rb') as toml_file:
             if sys.version_info < (3, 11):
@@ -76,13 +78,21 @@ class TomlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             return tomllib.load(toml_file)
 
     @staticmethod
-    def _any_file_exists(paths: PathType | None) -> bool:
+    def _any_file_exists(paths: ConfigFileSourceType | None) -> bool:
         """Check if any of the given file paths exist."""
         if paths is None:
             return False
-        if not isinstance(paths, Sequence):
+        if isinstance(paths, str) or not isinstance(paths, Sequence):
             paths = [paths]
-        return any(Path(path).exists() for path in paths)
+
+        def _exists(path: Path | str | Traversable) -> bool:
+            if isinstance(path, (str, Path)):
+                return Path(path).exists()
+            # Non-`Path` `Traversable` (e.g. a resource inside a zip/wheel) is not
+            # `os.PathLike`, so it can't be wrapped in `Path`; query it directly.
+            return path.is_file()
+
+        return any(_exists(path) for path in paths)
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(toml_file={self.toml_file_path}, toml_table_header={self.toml_table_header})'

--- a/pydantic_settings/sources/providers/yaml.py
+++ b/pydantic_settings/sources/providers/yaml.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations as _annotations
 
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
 )
 
 from ..base import ConfigFileSourceMixin, InitSettingsSource
-from ..types import DEFAULT_PATH, PathType
+from ..types import DEFAULT_PATH, ConfigFileSourceType
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import yaml
 
     from pydantic_settings.main import BaseSettings
+
+    from ..types import Traversable
 else:
     yaml = None
 
@@ -37,7 +40,7 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
     def __init__(
         self,
         settings_cls: type[BaseSettings],
-        yaml_file: PathType | None = DEFAULT_PATH,
+        yaml_file: ConfigFileSourceType | None = DEFAULT_PATH,
         yaml_file_encoding: str | None = None,
         yaml_config_section: str | None = None,
         deep_merge: bool = False,
@@ -61,7 +64,7 @@ class YamlConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
             )
         super().__init__(settings_cls, self.yaml_data)
 
-    def _read_file(self, file_path: Path) -> dict[str, Any]:
+    def _read_file(self, file_path: Path | Traversable) -> dict[str, Any]:
         import_yaml()
         with file_path.open(encoding=self.yaml_file_encoding) as yaml_file:
             return yaml.safe_load(yaml_file) or {}

--- a/pydantic_settings/sources/types.py
+++ b/pydantic_settings/sources/types.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations as _annotations
 
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable as Traversable
+else:
+    from importlib.abc import Traversable as Traversable
 
 if TYPE_CHECKING:
     from pydantic._internal._dataclasses import PydanticDataclass
@@ -34,6 +40,11 @@ class ForceDecode:
 EnvPrefixTarget = Literal['variable', 'alias', 'all']
 DotenvType = Path | str | Sequence[Path | str]
 PathType = Path | str | Sequence[Path | str]
+# Config file sources (json/toml/yaml) additionally accept packaged resources exposed as a
+# `Traversable` (e.g. `importlib.resources.files(...).joinpath(...)`), including non-filesystem
+# ones such as a file inside a zip/wheel.
+# See https://github.com/pydantic/pydantic-settings/issues/299
+ConfigFileSourceType = Path | str | Traversable | Sequence[Path | str | Traversable]
 DotenvFiltering = Literal['match_prefix', 'only_existing']
 DEFAULT_PATH: PathType = Path('')
 
@@ -80,6 +91,7 @@ class SecretVersion:
 
 
 __all__ = [
+    'ConfigFileSourceType',
     'DEFAULT_PATH',
     'ENV_FILE_SENTINEL',
     'EnvPrefixTarget',

--- a/tests/test_source_json.py
+++ b/tests/test_source_json.py
@@ -202,7 +202,7 @@ class TestTraversableSupport:
             foobar: str
 
             model_config = SettingsConfigDict(
-                # Traversable is not added in annotation, but is supported
+                # `Traversable` is part of the `json_file` type annotation and supported at runtime.
                 json_file=json_config_path,
             )
 

--- a/tests/test_source_toml.py
+++ b/tests/test_source_toml.py
@@ -2,7 +2,10 @@
 Test pydantic_settings.TomlConfigSettingsSource.
 """
 
+import importlib
 import sys
+import zipfile
+from importlib.resources import files
 from pathlib import Path
 
 import pytest
@@ -408,3 +411,75 @@ def test_toml_table_header_file_multiple_no_files(tmp_path):
 
     s = Settings()
     assert s.model_dump() == {'hello': 'world'}
+
+
+@pytest.fixture
+def zip_traversable(tmp_path):
+    """Factory returning a genuine non-Path ``Traversable`` pointing at a resource inside a zip/wheel."""
+    created: list[str] = []
+
+    def _make(pkg_name: str, filename: str, content: str):
+        zip_path = tmp_path / f'{pkg_name}.zip'
+        with zipfile.ZipFile(zip_path, 'w') as zf:
+            zf.writestr(f'{pkg_name}/__init__.py', '')
+            zf.writestr(f'{pkg_name}/{filename}', content)
+        sys.path.insert(0, str(zip_path))
+        importlib.invalidate_caches()
+        created.append(pkg_name)
+        trav = files(pkg_name).joinpath(filename)
+        # Sanity check: a zip-packaged resource is not a filesystem ``Path``.
+        assert not isinstance(trav, Path)
+        return trav
+
+    yield _make
+
+    for pkg_name in created:
+        sys.modules.pop(pkg_name, None)
+        zip_str = str(tmp_path / f'{pkg_name}.zip')
+        if zip_str in sys.path:
+            sys.path.remove(zip_str)
+    importlib.invalidate_caches()
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_toml_file_traversable(zip_traversable):
+    """A packaged resource passed as a non-Path ``Traversable`` (e.g. from inside a zip/wheel) should load. See #299."""
+    trav = zip_traversable('toml_trav_pkg', 'defaults.toml', 'foobar = "Hello"\n')
+
+    class Settings(BaseSettings):
+        foobar: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls, toml_file=trav),)
+
+    assert Settings().model_dump() == {'foobar': 'Hello'}
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_toml_table_header_traversable(zip_traversable):
+    """``toml_table_header`` relies on ``_any_file_exists``, which must handle a non-Path ``Traversable``. See #299."""
+    trav = zip_traversable('toml_trav_header_pkg', 'defaults.toml', '[app]\nfoobar = "Hello"\n')
+
+    class Settings(BaseSettings):
+        foobar: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (TomlConfigSettingsSource(settings_cls, toml_file=trav, toml_table_header=('app',)),)
+
+    assert Settings().model_dump() == {'foobar': 'Hello'}

--- a/tests/test_source_toml.py
+++ b/tests/test_source_toml.py
@@ -441,7 +441,7 @@ def zip_traversable(tmp_path):
     importlib.invalidate_caches()
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(sys.version_info < (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
 def test_toml_file_traversable(zip_traversable):
     """A packaged resource passed as a non-Path ``Traversable`` (e.g. from inside a zip/wheel) should load. See #299."""
     trav = zip_traversable('toml_trav_pkg', 'defaults.toml', 'foobar = "Hello"\n')
@@ -463,7 +463,7 @@ def test_toml_file_traversable(zip_traversable):
     assert Settings().model_dump() == {'foobar': 'Hello'}
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+@pytest.mark.skipif(sys.version_info < (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
 def test_toml_table_header_traversable(zip_traversable):
     """``toml_table_header`` relies on ``_any_file_exists``, which must handle a non-Path ``Traversable``. See #299."""
     trav = zip_traversable('toml_trav_header_pkg', 'defaults.toml', '[app]\nfoobar = "Hello"\n')

--- a/tests/test_source_yaml.py
+++ b/tests/test_source_yaml.py
@@ -611,3 +611,45 @@ def test_yaml_config_section_non_dict_intermediate(tmp_path):
 
     with pytest.raises(TypeError, match='yaml_config_section path.*cannot be traversed.*not a dictionary'):
         Settings()
+
+
+@pytest.mark.skipif(yaml is None, reason='PyYAML is not installed')
+def test_yaml_file_traversable(tmp_path):
+    """A packaged resource passed as a non-Path ``Traversable`` (e.g. from inside a zip/wheel) should load. See #299."""
+    import importlib
+    import sys
+    import zipfile
+    from importlib.resources import files
+
+    zip_path = tmp_path / 'yaml_trav_pkg.zip'
+    with zipfile.ZipFile(zip_path, 'w') as zf:
+        zf.writestr('yaml_trav_pkg/__init__.py', '')
+        zf.writestr('yaml_trav_pkg/defaults.yaml', 'foobar: "Hello"\n')
+
+    sys.path.insert(0, str(zip_path))
+    importlib.invalidate_caches()
+    try:
+        trav = files('yaml_trav_pkg').joinpath('defaults.yaml')
+        # Sanity check: a zip-packaged resource is not a filesystem ``Path``.
+        assert not isinstance(trav, Path)
+
+        class Settings(BaseSettings):
+            foobar: str
+
+            @classmethod
+            def settings_customise_sources(
+                cls,
+                settings_cls: type[BaseSettings],
+                init_settings: PydanticBaseSettingsSource,
+                env_settings: PydanticBaseSettingsSource,
+                dotenv_settings: PydanticBaseSettingsSource,
+                file_secret_settings: PydanticBaseSettingsSource,
+            ) -> tuple[PydanticBaseSettingsSource, ...]:
+                return (YamlConfigSettingsSource(settings_cls, yaml_file=trav),)
+
+        assert Settings().model_dump() == {'foobar': 'Hello'}
+    finally:
+        sys.modules.pop('yaml_trav_pkg', None)
+        if str(zip_path) in sys.path:
+            sys.path.remove(str(zip_path))
+        importlib.invalidate_caches()


### PR DESCRIPTION
## Summary

Closes #299.

Adds typing and runtime support for passing a `Traversable` (e.g. `importlib.resources.files(...).joinpath(...)`) as `json_file`, `toml_file`, or `yaml_file`. This enables loading a configuration file that is packaged inside a distribution — including resources that don't live on the filesystem, such as a file inside a zip/wheel — without a `cast` to `Path`.

### Background

Issue #299 raised two points:

1. **File options don't type-check against lists** — already resolved: `PathType` includes `Sequence[...]`.
2. **`PathType` should include `Traversable`** — still a real typing gap. The issue also noted that a `Traversable` "currently works" at runtime. That is now only partially true: a **genuine non-`Path` `Traversable`** (a zip/wheel-packaged resource) still works for JSON/YAML, but **regressed for TOML** — `TomlConfigSettingsSource._any_file_exists` wraps every path in `Path(path)`, which raises `TypeError` for an object that isn't `os.PathLike`.

### Changes

- Introduce a dedicated `ConfigFileSourceType` alias (`Path | str | Traversable | Sequence[Path | str | Traversable]`) and apply it to the config-file fields of `SettingsConfigDict` and to the `Json`/`Toml`/`Yaml` `*ConfigSettingsSource` constructors (and the shared `_read_files`/`_read_file`). `PathType` — used by `secrets_dir` — is intentionally left unchanged so directory handling keeps its `Path`-only semantics.
- Fix `TomlConfigSettingsSource._any_file_exists` to query a non-`Path` `Traversable` directly via `is_file()` instead of coercing through `Path(...)`. This also fixes a latent bug where a single `str` path was iterated character-by-character.
- Version-guard the `Traversable` import (`importlib.resources.abc` on 3.11+, `importlib.abc` on 3.10), since `importlib.abc.Traversable` was removed in 3.12+.
- Export `ConfigFileSourceType` from the package.
- Add a docs note under the config-file sources section.

### Tests

- New zip-packaged (genuine non-`Path`) `Traversable` regression tests for the TOML source (plain load and `toml_table_header`) and the YAML source.
- The JSON source already had `TestTraversableSupport`; updated its now-stale "not added in annotation" comment.

Verified locally: `mypy` clean (no new errors over baseline), `ruff` clean, full test suite green (excluding pre-existing Windows-only symlink test failures unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)