### PR TITLE
docs: fix typos in docs and source comments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -578,7 +578,7 @@ print(Settings().model_dump())
 ## Nested model default partial updates
 
 By default, Pydantic settings does not allow partial updates to nested model default objects. This behavior can be
-overriden by setting the `nested_model_default_partial_update` flag to `True`, which will allow partial updates on
+overridden by setting the `nested_model_default_partial_update` flag to `True`, which will allow partial updates on
 nested model default object fields.
 
 ```py
@@ -1605,7 +1605,7 @@ except SettingsError as e:
 
 #### Enforce Required Arguments at CLI
 
-Pydantic settings is designed to pull values in from various sources when instantating a model. This means a field that
+Pydantic settings is designed to pull values in from various sources when instantiating a model. This means a field that
 is required is not strictly required from any single source (e.g. the CLI). Instead, all that matters is that one of the
 sources provides the required value.
 
@@ -2591,10 +2591,10 @@ To use Google Cloud Secret Manager, you need to:
            gcp_settings = GoogleSecretManagerSettingsSource(
                settings_cls,
                # If not provided, will use google.auth.default()
-               # to get credentials from the environemnt
+               # to get credentials from the environment
                # credentials=your_credentials,
                # If not provided, will use google.auth.default()
-               # to get project_id from the environemnt
+               # to get project_id from the environment
                project_id='your-gcp-project-id',
            )
 
@@ -3193,7 +3193,7 @@ class MyCustomSource(PydanticBaseSettingsSource):
         current_state = self.current_state
         current_state.get('some_setting')
 
-        # Retrive settings from all sources individually
+        # Retrieve settings from all sources individually
         # self.settings_sources_data["SettingsSourceName"]: dict[str, Any]
         settings_sources_data = self.settings_sources_data
         settings_sources_data['SomeSettingsSource'].get('some_setting')

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -501,7 +501,7 @@ class BaseSettings(BaseModel):
                 states[source_name] = source_state
                 state = deep_update(source_state, state)
 
-            # Strip any default values not explicity set before returning final state
+            # Strip any default values not explicitly set before returning final state
             state = {key: val for key, val in state.items() if key not in defaults or defaults[key] != val}
             # The last source is the `DefaultSettingsSource` instance created in `_settings_init_sources()`,
             # holding the init state shared by all built-in sources:
@@ -886,7 +886,7 @@ class CliApp:
                   Example: `--config '{"host": "localhost", "port": 5432}'`
                 - 'env':
                   The dictionary is flattened into multiple CLI flags using
-                  environment-variable-style assignement.
+                  environment-variable-style assignment.
                   Example: `--config host=localhost --config port=5432`
             positionals_first: Controls whether positional arguments should be serialized
                 first compared to optional arguments. Defaults to `False`.

--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -1671,7 +1671,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             )
 
             if arg.is_alias_path_only:
-                # For alias path only, we wont know the complete value until we've finished parsing the entire class. In
+                # For alias path only, we won't know the complete value until we've finished parsing the entire class. In
                 # this case, insert value as a non-string reference pointing to the relevant alias_path_only_defaults
                 # entry and convert into completed string value later.
                 value = self._update_alias_path_only_default(arg_name, value, field_info, alias_path_only_defaults)


### PR DESCRIPTION
Fixed 8 typos found by codespell across docs and source code:

**docs/index.md**
- `overriden` → `overridden`
- `instantating` → `instantiating`
- `environemnt` → `environment` (two occurrences)
- `Retrive` → `Retrieve`

**pydantic_settings/main.py**
- `explicity` → `explicitly`
- `assignement` → `assignment`

**pydantic_settings/sources/providers/cli.py**
- `wont` → `won't`

All changes are in prose comments and documentation text — no identifiers, fixtures, or generated files were touched.