### PR TITLE
Apply case-insensitive field matching to optional nested models (#903)

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -240,6 +240,17 @@ class ConfigFileSourceMixin(ABC):
         pass
 
 
+def _unwrap_optional_annotation(annotation: Any) -> Any:
+    """Return the inner type of an ``Optional[T]`` annotation, otherwise the annotation unchanged."""
+    if is_union_origin(get_origin(annotation)):
+        args = get_args(annotation)
+        if len(args) == 2 and type(None) in args:
+            for arg in args:
+                if arg is not type(None):
+                    return arg
+    return annotation
+
+
 def _has_discriminator(field_info: FieldInfo) -> bool:
     """Check if a field uses a discriminated union (via Annotated or Field(discriminator=...))."""
     if field_info.discriminator is not None:
@@ -503,16 +514,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         for name, value in field_values.items():
             sub_model_field: FieldInfo | None = None
 
-            annotation = field.annotation
-
-            # If field is Optional, we need to find the actual type
-            if is_union_origin(get_origin(field.annotation)):
-                args = get_args(annotation)
-                if len(args) == 2 and type(None) in args:
-                    for arg in args:
-                        if arg is not None:
-                            annotation = arg
-                            break
+            annotation = _unwrap_optional_annotation(field.annotation)
 
             # This is here to make mypy happy
             # Item "None" of "Optional[Type[Any]]" has no attribute "model_fields"
@@ -537,7 +539,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
 
             if (
                 sub_model_field is not None
-                and _lenient_issubclass(sub_model_field.annotation, BaseModel)
+                and _lenient_issubclass(_unwrap_optional_annotation(sub_model_field.annotation), BaseModel)
                 and isinstance(value, dict)
             ):
                 values[field_key] = self._replace_field_names_case_insensitively(sub_model_field, value)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3190,6 +3190,25 @@ def test_case_insensitive_nested_optional(env):
     assert s.model_dump() == {'nested': {'BaR': 123, 'FOO': 'string'}}
 
 
+def test_case_insensitive_deeply_nested_optional(env):
+    """Optional nested models must still be resolved case-insensitively (#903)."""
+
+    class NestedModel(BaseModel):
+        Name: str
+
+    class ConfigModel(BaseModel):
+        nested: NestedModel | None = None
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_nested_delimiter='__', case_sensitive=False)
+
+        config: ConfigModel
+
+    env.set('config__nested__name', 'value')
+    s = Settings()
+    assert s.model_dump() == {'config': {'nested': {'Name': 'value'}}}
+
+
 def test_case_insensitive_nested_alias(env):
     """Ensure case-insensitive environment lookup works with nested aliases."""
 


### PR DESCRIPTION
Fixes #903

## Problem

With `case_sensitive=False` and `env_nested_delimiter`, environment variables fail to populate a nested model field when that nested model is declared **optional**. The raw (lowercase) env-var key is preserved instead of being resolved to the actual field-name casing:

```python
class NestedModel(BaseModel):
    Name: str

class ConfigModel(BaseModel):
    nested: Optional[NestedModel] = None

class Settings(BaseSettings):
    config: ConfigModel
    model_config = SettingsConfigDict(env_nested_delimiter="__", case_sensitive=False)

os.environ["config__nested__name"] = "value"
Settings()  # ValidationError: config.nested.Name Field required
```

Removing `Optional` makes it work, so the optional and non-optional paths diverged.

## Cause

`_replace_field_names_case_insensitively` rewrites lowercased env keys back to the real field casing by recursing through nested models. The recursion gate used:

```python
_lenient_issubclass(sub_model_field.annotation, BaseModel)
```

For a required field the annotation is `NestedModel` (→ `True`, recurses). For an optional field the annotation is `Optional[NestedModel]`, a `Union` (→ `False`), so it never recursed and the lowercase key survived. The function already unwrapped `Optional` for the *outer* field but not for this inner recursion check.

## Fix

Extract the existing `Optional[T]` unwrapping into a small `_unwrap_optional_annotation` helper and apply it both at the top of the function (dedup, same behavior) and at the recursion gate, so optional nested models are resolved the same way as required ones.

## Tests

Added `test_case_insensitive_deeply_nested_optional` mirroring the issue's repro (a required outer model containing an optional inner model — the deeper case the existing `test_case_insensitive_nested_optional` didn't cover). Verified it fails without the fix and passes with it. Full suite passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
