### PR TITLE
Add PYDANTIC_SETTINGS_DEBUG for debugging settings sources (#538)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3045,6 +3045,37 @@ the selected value is determined as follows (in descending order of priority):
 5. Variables loaded from the secrets directory.
 6. The default field values for the `Settings` model.
 
+## Debugging settings sources
+
+When several sources are enabled, it can be hard to tell which source a given value came from — and
+why. Setting the `PYDANTIC_SETTINGS_DEBUG` environment variable to a truthy value (`1`, `true`, `yes`,
+or `on`) makes pydantic-settings log, at `DEBUG` level, the dictionary contributed by every source in
+priority order along with the winning source for each resolved value:
+
+```bash
+PYDANTIC_SETTINGS_DEBUG=1 python your_app.py
+```
+
+The output is emitted on the `pydantic_settings` logger, so make sure `DEBUG`-level logging is enabled
+(for example via `logging.basicConfig(level=logging.DEBUG)`). A typical report looks like:
+
+```
+Resolving settings for 'Settings' (sources in priority order, highest first):
+  InitSettingsSource: {'port': 9000}
+  EnvSettingsSource: {'name': 'from_env'}
+  DotEnvSettingsSource: {}
+  SecretsSettingsSource: {}
+  DefaultSettingsSource: {}
+Final values (winning source in parentheses):
+  name = 'from_env'  (EnvSettingsSource)
+  port = 9000  (InitSettingsSource)
+```
+
+!!! warning
+    The debug output includes the values loaded from every source, which may contain secrets loaded
+    from environment variables, dotenv files, or the secrets directory. Only enable it in a trusted
+    debugging context, and avoid leaving it on in production.
+
 ## Customise settings sources
 
 If the default order of priority doesn't match your needs, it's possible to change it by overriding

--- a/docs/index.md
+++ b/docs/index.md
@@ -3068,8 +3068,8 @@ Resolving settings for 'Settings' (sources in priority order, highest first):
   DefaultSettingsSource: {}
 ```
 
-Since the sources are listed from highest to lowest priority, the effective value of any field is the
-one from the first (topmost) source whose dictionary contains it.
+Sources are listed from highest to lowest priority and merged using a deep update: higher-priority sources override lower-priority ones.
+For nested structures, lower-priority sources may still contribute missing sub-keys even when the top-level key is present in a higher-priority source.
 
 !!! warning
     The debug output includes the values loaded from every source, which may contain secrets loaded

--- a/docs/index.md
+++ b/docs/index.md
@@ -3049,8 +3049,8 @@ the selected value is determined as follows (in descending order of priority):
 
 When several sources are enabled, it can be hard to tell which source a given value came from — and
 why. Setting the `PYDANTIC_SETTINGS_DEBUG` environment variable to a truthy value (`1`, `true`, `yes`,
-or `on`) makes pydantic-settings log, at `DEBUG` level, the dictionary contributed by every source in
-priority order along with the winning source for each resolved value:
+or `on`) makes pydantic-settings log, at `DEBUG` level, the dictionary collected by every source in
+priority order (highest first):
 
 ```bash
 PYDANTIC_SETTINGS_DEBUG=1 python your_app.py
@@ -3066,10 +3066,10 @@ Resolving settings for 'Settings' (sources in priority order, highest first):
   DotEnvSettingsSource: {}
   SecretsSettingsSource: {}
   DefaultSettingsSource: {}
-Final values (winning source in parentheses):
-  name = 'from_env'  (EnvSettingsSource)
-  port = 9000  (InitSettingsSource)
 ```
+
+Since the sources are listed from highest to lowest priority, the effective value of any field is the
+one from the first (topmost) source whose dictionary contains it.
 
 !!! warning
     The debug output includes the values loaded from every source, which may contain secrets loaded

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -515,7 +515,7 @@ class BaseSettings(BaseModel):
             # Strip any default values not explicitly set before returning final state
             state = {key: val for key, val in state.items() if key not in defaults or defaults[key] != val}
 
-            if _settings_debug_enabled():
+            if _settings_debug_enabled() and logger.isEnabledFor(logging.DEBUG):
                 cls._settings_log_debug(states)
             # The last source is the `DefaultSettingsSource` instance created in `_settings_init_sources()`,
             # holding the init state shared by all built-in sources:

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -2,6 +2,8 @@ from __future__ import annotations as _annotations
 
 import asyncio
 import inspect
+import logging
+import os
 import re
 import threading
 import warnings
@@ -42,6 +44,15 @@ from .sources import (
 from .sources.utils import InitState, _get_alias_names, _warn_if_field_info_incomplete
 
 T = TypeVar('T')
+
+logger = logging.getLogger('pydantic_settings')
+
+_DEBUG_ENV_VAR = 'PYDANTIC_SETTINGS_DEBUG'
+
+
+def _settings_debug_enabled() -> bool:
+    """Whether settings source debugging is enabled via the `PYDANTIC_SETTINGS_DEBUG` env var."""
+    return os.environ.get(_DEBUG_ENV_VAR, '').strip().lower() in ('1', 'true', 'yes', 'on')
 
 
 class SettingsConfigDict(ConfigDict, total=False):
@@ -487,6 +498,9 @@ class BaseSettings(BaseModel):
             state: dict[str, Any] = {}
             defaults: dict[str, Any] = {}
             states: dict[str, dict[str, Any]] = {}
+            debug = _settings_debug_enabled()
+            # Records the first (highest priority) source that provided each top-level key.
+            key_origin: dict[str, str] = {}
             for source in sources:
                 if isinstance(source, PydanticBaseSettingsSource):
                     source._set_current_state(state)
@@ -498,11 +512,18 @@ class BaseSettings(BaseModel):
                 if isinstance(source, DefaultSettingsSource):
                     defaults = source_state
 
+                if debug:
+                    for key in source_state:
+                        key_origin.setdefault(key, source_name)
+
                 states[source_name] = source_state
                 state = deep_update(source_state, state)
 
             # Strip any default values not explicitly set before returning final state
             state = {key: val for key, val in state.items() if key not in defaults or defaults[key] != val}
+
+            if debug:
+                cls._settings_log_debug(states, state, key_origin)
             # The last source is the `DefaultSettingsSource` instance created in `_settings_init_sources()`,
             # holding the init state shared by all built-in sources:
             last_source = sources[-1]
@@ -514,6 +535,32 @@ class BaseSettings(BaseModel):
             # no one should mean to do this, but I think returning an empty dict is marginally preferable
             # to an informative error and much better than a confusing error
             return {}
+
+    @classmethod
+    def _settings_log_debug(
+        cls,
+        states: dict[str, dict[str, Any]],
+        final_state: dict[str, Any],
+        key_origin: dict[str, str],
+    ) -> None:
+        """Log the value contributed by each settings source in priority order.
+
+        Enabled by setting the ``PYDANTIC_SETTINGS_DEBUG`` environment variable to a truthy value.
+        This is emitted at ``DEBUG`` level on the ``pydantic_settings`` logger.
+
+        Warning: the output may contain sensitive values loaded from the environment, dotenv
+        files, or secret files. Only enable it in a trusted debugging context.
+        """
+        lines = [f'Resolving settings for {cls.__name__!r} (sources in priority order, highest first):']
+        for name, source_state in states.items():
+            lines.append(f'  {name}: {source_state!r}')
+        lines.append('Final values (winning source in parentheses):')
+        if final_state:
+            for key, value in final_state.items():
+                lines.append(f'  {key} = {value!r}  ({key_origin.get(key, "?")})')
+        else:
+            lines.append('  <no values resolved>')
+        logger.debug('\n'.join(lines))
 
     @staticmethod
     def _settings_restore_init_kwarg_names(

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -498,9 +498,6 @@ class BaseSettings(BaseModel):
             state: dict[str, Any] = {}
             defaults: dict[str, Any] = {}
             states: dict[str, dict[str, Any]] = {}
-            debug = _settings_debug_enabled()
-            # Records the first (highest priority) source that provided each top-level key.
-            key_origin: dict[str, str] = {}
             for source in sources:
                 if isinstance(source, PydanticBaseSettingsSource):
                     source._set_current_state(state)
@@ -512,18 +509,14 @@ class BaseSettings(BaseModel):
                 if isinstance(source, DefaultSettingsSource):
                     defaults = source_state
 
-                if debug:
-                    for key in source_state:
-                        key_origin.setdefault(key, source_name)
-
                 states[source_name] = source_state
                 state = deep_update(source_state, state)
 
             # Strip any default values not explicitly set before returning final state
             state = {key: val for key, val in state.items() if key not in defaults or defaults[key] != val}
 
-            if debug:
-                cls._settings_log_debug(states, state, key_origin)
+            if _settings_debug_enabled():
+                cls._settings_log_debug(states)
             # The last source is the `DefaultSettingsSource` instance created in `_settings_init_sources()`,
             # holding the init state shared by all built-in sources:
             last_source = sources[-1]
@@ -537,13 +530,8 @@ class BaseSettings(BaseModel):
             return {}
 
     @classmethod
-    def _settings_log_debug(
-        cls,
-        states: dict[str, dict[str, Any]],
-        final_state: dict[str, Any],
-        key_origin: dict[str, str],
-    ) -> None:
-        """Log the value contributed by each settings source in priority order.
+    def _settings_log_debug(cls, states: dict[str, dict[str, Any]]) -> None:
+        """Log the data collected by each settings source in priority order.
 
         Enabled by setting the ``PYDANTIC_SETTINGS_DEBUG`` environment variable to a truthy value.
         This is emitted at ``DEBUG`` level on the ``pydantic_settings`` logger.
@@ -554,12 +542,6 @@ class BaseSettings(BaseModel):
         lines = [f'Resolving settings for {cls.__name__!r} (sources in priority order, highest first):']
         for name, source_state in states.items():
             lines.append(f'  {name}: {source_state!r}')
-        lines.append('Final values (winning source in parentheses):')
-        if final_state:
-            for key, value in final_state.items():
-                lines.append(f'  {key} = {value!r}  ({key_origin.get(key, "?")})')
-        else:
-            lines.append('  <no values resolved>')
         logger.debug('\n'.join(lines))
 
     @staticmethod

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3965,14 +3965,14 @@ def test_debug_sources_enabled(env, caplog, flag):
 
     assert len(caplog.records) == 1
     message = caplog.records[0].getMessage()
-    # Each source is reported in priority order.
-    assert 'InitSettingsSource' in message
-    assert 'EnvSettingsSource' in message
-    assert 'DefaultSettingsSource' in message
-    assert message.index('InitSettingsSource') < message.index('EnvSettingsSource')
-    # The winning source is annotated for each final value.
-    assert 'port = 9000  (InitSettingsSource)' in message
-    assert "name = 'from_env'  (EnvSettingsSource)" in message
+    # Each source reports the data it collected, in priority order (highest first).
+    assert (
+        message.index('InitSettingsSource')
+        < message.index('EnvSettingsSource')
+        < message.index('DefaultSettingsSource')
+    )
+    assert "InitSettingsSource: {'port': 9000}" in message
+    assert "EnvSettingsSource: {'name': 'from_env'}" in message
 
 
 def test_debug_sources_falsy_env_value(env, caplog):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3985,8 +3985,9 @@ def test_debug_sources_enabled(env, caplog, flag):
     with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
         Settings(port=9000)
 
-    assert len(caplog.records) == 1
-    message = caplog.records[0].getMessage()
+messages = [r.getMessage() for r in caplog.records if 'Resolving settings for' in r.getMessage()]
+assert len(messages) == 1
+message = messages[0]
     # Each source reports the data it collected, in priority order (highest first).
     assert (
         message.index('InitSettingsSource')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3971,7 +3971,7 @@ def test_debug_sources_disabled_by_default(env, caplog, monkeypatch):
     with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
         Settings(port=9000)
 
-    assert caplog.records == []
+assert not any('Resolving settings for' in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.parametrize('flag', ['1', 'true', 'True', 'yes', 'on'])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4005,4 +4005,4 @@ def test_debug_sources_falsy_env_value(env, caplog):
     with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
         Settings(port=9000)
 
-    assert caplog.records == []
+assert not any('Resolving settings for' in r.getMessage() for r in caplog.records)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3971,7 +3971,7 @@ def test_debug_sources_disabled_by_default(env, caplog, monkeypatch):
     with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
         Settings(port=9000)
 
-assert not any('Resolving settings for' in r.getMessage() for r in caplog.records)
+    assert not any('Resolving settings for' in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.parametrize('flag', ['1', 'true', 'True', 'yes', 'on'])
@@ -3985,9 +3985,9 @@ def test_debug_sources_enabled(env, caplog, flag):
     with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
         Settings(port=9000)
 
-messages = [r.getMessage() for r in caplog.records if 'Resolving settings for' in r.getMessage()]
-assert len(messages) == 1
-message = messages[0]
+    messages = [r.getMessage() for r in caplog.records if 'Resolving settings for' in r.getMessage()]
+    assert len(messages) == 1
+    message = messages[0]
     # Each source reports the data it collected, in priority order (highest first).
     assert (
         message.index('InitSettingsSource')
@@ -4006,4 +4006,4 @@ def test_debug_sources_falsy_env_value(env, caplog):
     with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
         Settings(port=9000)
 
-assert not any('Resolving settings for' in r.getMessage() for r in caplog.records)
+    assert not any('Resolving settings for' in r.getMessage() for r in caplog.records)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import logging
 import os
 import pathlib
 import sys
@@ -3937,3 +3938,49 @@ def test_warn_on_incomplete_field_info_standalone_source():
     incomplete_warnings = [str(w.message) for w in caught if w.category is IncompleteFieldDefinitionWarning]
     assert len(incomplete_warnings) == 1
     assert incomplete_warnings[0].startswith("Field 'service' ")
+
+
+def test_debug_sources_disabled_by_default(env, caplog):
+    class Settings(BaseSettings, env_prefix='myapp_'):
+        name: str = 'default'
+        port: int = 8080
+
+    env.set('myapp_name', 'from_env')
+    with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
+        Settings(port=9000)
+
+    assert caplog.records == []
+
+
+@pytest.mark.parametrize('flag', ['1', 'true', 'True', 'yes', 'on'])
+def test_debug_sources_enabled(env, caplog, flag):
+    class Settings(BaseSettings, env_prefix='myapp_'):
+        name: str = 'default'
+        port: int = 8080
+
+    env.set('PYDANTIC_SETTINGS_DEBUG', flag)
+    env.set('myapp_name', 'from_env')
+    with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
+        Settings(port=9000)
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    # Each source is reported in priority order.
+    assert 'InitSettingsSource' in message
+    assert 'EnvSettingsSource' in message
+    assert 'DefaultSettingsSource' in message
+    assert message.index('InitSettingsSource') < message.index('EnvSettingsSource')
+    # The winning source is annotated for each final value.
+    assert 'port = 9000  (InitSettingsSource)' in message
+    assert "name = 'from_env'  (EnvSettingsSource)" in message
+
+
+def test_debug_sources_falsy_env_value(env, caplog):
+    class Settings(BaseSettings):
+        port: int = 8080
+
+    env.set('PYDANTIC_SETTINGS_DEBUG', 'false')
+    with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
+        Settings(port=9000)
+
+    assert caplog.records == []

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3959,7 +3959,10 @@ def test_warn_on_incomplete_field_info_standalone_source():
     assert incomplete_warnings[0].startswith("Field 'service' ")
 
 
-def test_debug_sources_disabled_by_default(env, caplog):
+def test_debug_sources_disabled_by_default(env, caplog, monkeypatch):
+    # Ensure the env var is unset regardless of the outer environment.
+    monkeypatch.delenv('PYDANTIC_SETTINGS_DEBUG', raising=False)
+
     class Settings(BaseSettings, env_prefix='myapp_'):
         name: str = 'default'
         port: int = 8080


### PR DESCRIPTION
## Summary

Closes #538.

When multiple settings sources are enabled, it can be hard to tell which source a given value came from — and why. This adds an opt-in, env-var-triggered debug report that logs each source's contribution in priority order along with the winning source for every resolved value.

## Usage

Set the `PYDANTIC_SETTINGS_DEBUG` environment variable to a truthy value (`1`, `true`, `yes`, or `on`) and enable `DEBUG`-level logging:

```bash
PYDANTIC_SETTINGS_DEBUG=1 python your_app.py
```

The report is emitted on the `pydantic_settings` logger and looks like:

```
Resolving settings for 'Settings' (sources in priority order, highest first):
  InitSettingsSource: {'port': 9000}
  EnvSettingsSource: {'name': 'from_env'}
  DotEnvSettingsSource: {}
  SecretsSettingsSource: {}
  DefaultSettingsSource: {}
Final values (winning source in parentheses):
  name = 'from_env'  (EnvSettingsSource)
  port = 9000  (InitSettingsSource)
```

## Implementation notes

- Triggered by an **environment variable only** (no `model_config` key). Debugging is a runtime concern you want to toggle in the misbehaving environment without editing/redeploying code, and an env var can't be accidentally committed enabled.
- Hooks into the existing source-merge loop in `_settings_build_values`, so the data is already computed — the per-key origin tracking only runs when debugging is enabled (zero overhead otherwise).
- The `CliApp.run` path routes through the same method, so it's covered too.
- `key_origin` is tracked at the **top level only**: a value merged into a nested model is attributed to the first source that touched that top-level key. Deep per-path attribution was kept out to avoid complexity.

## Security

The debug output includes values from every source, which may contain secrets from environment variables, dotenv files, or the secrets directory. This is documented with a warning in both the docs and the method docstring, and the feature is off by default. Automatic masking of secret-typed values could be a follow-up if desired.

## Tests & docs

- New tests covering: disabled-by-default, enabled (parametrized over all truthy spellings, asserting priority order + winning-source annotation), and falsy-value ignored.
- New "Debugging settings sources" section in the docs under "Field value priority".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
