### PR TITLE
docs: recommend async settings loading pattern

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3319,13 +3319,14 @@ from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-Path('.env').write_text('api_key=secret\n', encoding='utf-8')
+env_path = Path('example.env')
+env_path.write_text('api_key=secret\n', encoding='utf-8')
 
 
 class Settings(BaseSettings):
     api_key: str
 
-    model_config = SettingsConfigDict(env_file='.env')
+    model_config = SettingsConfigDict(env_file=env_path)
 
 
 async def load_settings() -> Settings:
@@ -3335,7 +3336,8 @@ async def load_settings() -> Settings:
 settings = asyncio.run(load_settings())
 print(settings.api_key)
 #> secret
-```
+
+env_path.unlink(missing_ok=True)
 
 The same pattern applies to [in-place reloading](#in-place-reloading). If you keep a mutable settings instance, call
 `await asyncio.to_thread(settings.__init__)` instead of calling `settings.__init__()` directly on the event loop.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3240,42 +3240,6 @@ except ValidationError as exc_info:
 ```
 
 
-## Async environments
-
-Settings are loaded synchronously. When you use sources that read from disk, such as dotenv, secrets, JSON, TOML, or
-YAML files, creating a settings object in an async application can block the event loop while those files are read.
-If you need to load or reload settings from an async context, run the settings construction in a worker thread:
-
-```py
-import asyncio
-from pathlib import Path
-
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-Path('.env').write_text('api_key=secret\n', encoding='utf-8')
-
-
-class Settings(BaseSettings):
-    api_key: str
-
-    model_config = SettingsConfigDict(env_file='.env')
-
-
-async def load_settings() -> Settings:
-    return await asyncio.to_thread(Settings)
-
-
-settings = asyncio.run(load_settings())
-print(settings.api_key)
-#> secret
-```
-
-The same pattern can be used for reloading. For example, if you keep a mutable settings instance, call
-`await asyncio.to_thread(settings.__init__)` instead of calling `settings.__init__()` directly from the event loop.
-If you cache settings in your application, protect the reload path with your normal application-level locking so only
-one coroutine refreshes the cached object at a time.
-
-
 ## In-place reloading
 
 In case you want to reload in-place an existing setting, you can do it by using its `__init__` method :
@@ -3310,3 +3274,39 @@ mutable_settings.__init__()
 print(mutable_settings.foo)
 #> foo
 ```
+
+
+## Async environments
+
+Settings are loaded synchronously. When you use sources that read from disk, such as dotenv, secrets, JSON, TOML, or
+YAML files, constructing a settings object in an async application can block the event loop while those files are read.
+To load or reload settings from an async context, run the construction in a worker thread:
+
+```py
+import asyncio
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+Path('.env').write_text('api_key=secret\n', encoding='utf-8')
+
+
+class Settings(BaseSettings):
+    api_key: str
+
+    model_config = SettingsConfigDict(env_file='.env')
+
+
+async def load_settings() -> Settings:
+    return await asyncio.to_thread(Settings)
+
+
+settings = asyncio.run(load_settings())
+print(settings.api_key)
+#> secret
+```
+
+The same pattern applies to [in-place reloading](#in-place-reloading). If you keep a mutable settings instance, call
+`await asyncio.to_thread(settings.__init__)` instead of calling `settings.__init__()` directly on the event loop.
+When you cache settings, guard the reload path with your usual application-level locking so that only one coroutine
+refreshes the cached object at a time.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3338,8 +3338,43 @@ print(settings.api_key)
 #> secret
 
 env_path.unlink(missing_ok=True)
+```
 
-The same pattern applies to [in-place reloading](#in-place-reloading). If you keep a mutable settings instance, call
-`await asyncio.to_thread(settings.__init__)` instead of calling `settings.__init__()` directly on the event loop.
-When you cache settings, guard the reload path with your usual application-level locking so that only one coroutine
-refreshes the cached object at a time.
+To reload a cached settings object, prefer constructing a fresh instance in a worker thread and swapping the cached
+reference, rather than mutating a shared instance in place:
+
+```py
+import asyncio
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+env_path = Path('example.env')
+env_path.write_text('api_key=secret\n', encoding='utf-8')
+
+
+class Settings(BaseSettings):
+    api_key: str
+
+    model_config = SettingsConfigDict(env_file=env_path)
+
+
+cached_settings = Settings()
+
+
+async def reload_settings() -> None:
+    global cached_settings
+    cached_settings = await asyncio.to_thread(Settings)
+
+
+asyncio.run(reload_settings())
+print(cached_settings.api_key)
+#> secret
+
+env_path.unlink(missing_ok=True)
+```
+
+Rebinding the reference is atomic, so concurrent readers always observe a fully-initialized object. By contrast,
+[in-place reloading](#in-place-reloading) (`settings.__init__()`) mutates the object while it runs, so a coroutine that
+reads the settings during a reload may see partially-updated state; if you rely on it, guard both the reload and every
+read with application-level locking.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3240,6 +3240,42 @@ except ValidationError as exc_info:
 ```
 
 
+## Async environments
+
+Settings are loaded synchronously. When you use sources that read from disk, such as dotenv, secrets, JSON, TOML, or
+YAML files, creating a settings object in an async application can block the event loop while those files are read.
+If you need to load or reload settings from an async context, run the settings construction in a worker thread:
+
+```py
+import asyncio
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+Path('.env').write_text('api_key=secret\n', encoding='utf-8')
+
+
+class Settings(BaseSettings):
+    api_key: str
+
+    model_config = SettingsConfigDict(env_file='.env')
+
+
+async def load_settings() -> Settings:
+    return await asyncio.to_thread(Settings)
+
+
+settings = asyncio.run(load_settings())
+print(settings.api_key)
+#> secret
+```
+
+The same pattern can be used for reloading. For example, if you keep a mutable settings instance, call
+`await asyncio.to_thread(settings.__init__)` instead of calling `settings.__init__()` directly from the event loop.
+If you cache settings in your application, protect the reload path with your normal application-level locking so only
+one coroutine refreshes the cached object at a time.
+
+
 ## In-place reloading
 
 In case you want to reload in-place an existing setting, you can do it by using its `__init__` method :


### PR DESCRIPTION
## Summary
- document the recommended `asyncio.to_thread` pattern for constructing settings from async code
- call out synchronous file-backed sources and how to reload a mutable settings instance without blocking the event loop
- include a tested dotenv-backed example before the existing in-place reload section

Fixes #479

## Validation
- `uv run --group testing pytest 'tests/test_docs.py::test_docs_examples' -q -k '3249 or Async or 3271'`
- `uv run --group testing --extra azure-key-vault pytest tests/test_docs.py -q`
