### PR TITLE
fix: parse enum names through nested annotations

### DIFF
--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -250,10 +250,15 @@ def _strip_annotated(annotation: Any) -> Any:
 
 
 def _annotation_enum_val_to_name(annotation: type[Any] | None, value: Any) -> str | None:
-    for type_ in (annotation, get_origin(annotation), *get_args(annotation)):
+    for type_ in (annotation, get_origin(annotation)):
         if _lenient_issubclass(type_, Enum):
-            if value in type_.__members__.values():
-                return type_(value).name
+            enum_type = cast('type[Enum]', type_)
+            if value in enum_type.__members__.values():
+                return enum_type(value).name
+    for arg in get_args(annotation):
+        enum_name = _annotation_enum_val_to_name(arg, value)
+        if enum_name is not None:
+            return enum_name
     return None
 
 

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -260,8 +260,9 @@ def _annotation_enum_val_to_name(annotation: type[Any] | None, value: Any) -> st
 def _annotation_enum_name_to_val(annotation: type[Any] | None, name: Any) -> Any:
     for type_ in (annotation, get_origin(annotation)):
         if _lenient_issubclass(type_, Enum):
-            if name in type_.__members__.keys():
-                return type_[name]
+            enum_type = cast('type[Enum]', type_)
+            if name in enum_type.__members__.keys():
+                return enum_type[name]
     for arg in get_args(annotation):
         enum_val = _annotation_enum_name_to_val(arg, name)
         if enum_val is not None:

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -258,10 +258,14 @@ def _annotation_enum_val_to_name(annotation: type[Any] | None, value: Any) -> st
 
 
 def _annotation_enum_name_to_val(annotation: type[Any] | None, name: Any) -> Any:
-    for type_ in (annotation, get_origin(annotation), *get_args(annotation)):
+    for type_ in (annotation, get_origin(annotation)):
         if _lenient_issubclass(type_, Enum):
             if name in type_.__members__.keys():
                 return type_[name]
+    for arg in get_args(annotation):
+        enum_val = _annotation_enum_name_to_val(arg, name)
+        if enum_val is not None:
+            return enum_val
     return None
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2822,6 +2822,15 @@ def test_env_parse_enums(env):
     assert s.nested.fruit == FruitsEnum.lime
 
 
+def test_env_parse_enums_with_nested_annotated(env):
+    class Settings(BaseSettings):
+        fruit: Annotated[FruitsEnum, Field(description='fruit')] | None = None
+
+    env.set('FRUIT', 'kiwi')
+
+    assert Settings(_env_parse_enums=True).fruit == FruitsEnum.kiwi
+
+
 def test_env_parse_none_str(env):
     env.set('x', 'null')
     env.set('y', 'y_override')

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -2726,6 +2726,19 @@ def test_cli_user_settings_source_exceptions():
         CliSettingsSource(CfgWithSubCommand, add_subparsers_method=None)
 
 
+def test_cli_enum_default_through_nested_annotation(capsys, monkeypatch):
+    class Cfg(BaseSettings, cli_parse_args=True, cli_prog_name='example.py'):
+        fruit: Annotated[FruitsEnum, Field(description='fruit')] | None = FruitsEnum.kiwi
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ['example.py', '--help'])
+
+        with pytest.raises(SystemExit):
+            Cfg()
+
+        assert '(default: kiwi)' in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
     'value,expected',
     [


### PR DESCRIPTION
With `env_parse_enums=True`, enum names inside nested wrappers such as `Optional[Annotated[MyEnum, ...]]` were left as strings and failed validation. Resolve enum members recursively through annotation arguments, while preserving existing direct and union handling; the regression test fails before the source change and passes with it.