### PR TITLE
Fix dotenv extras being claimed by complex fields sharing a name prefix

### DIFF
--- a/pydantic_settings/sources/providers/dotenv.py
+++ b/pydantic_settings/sources/providers/dotenv.py
@@ -150,7 +150,13 @@ class DotEnvSettingsSource(EnvSettingsSource):
                                 and _union_is_complex(field.annotation, field.metadata, self._init_state)
                             )
                         )
-                        and env_name.startswith(field_env_name)
+                        # A var only belongs to a complex field when it sits at the nested
+                        # delimiter boundary (`db<delim>...`, matching what explode_env_vars
+                        # consumes). A bare name-prefix match (e.g. `dbx_token` vs field `db`)
+                        # must not claim the var, otherwise it is silently dropped instead of
+                        # being kept as an extra.
+                        and bool(self.env_nested_delimiter)
+                        and env_name.startswith(f'{field_env_name}{self.env_nested_delimiter}')
                     ):
                         env_used = True
                         break

--- a/pydantic_settings/sources/providers/dotenv.py
+++ b/pydantic_settings/sources/providers/dotenv.py
@@ -155,7 +155,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
                         # consumes). A bare name-prefix match (e.g. `dbx_token` vs field `db`)
                         # must not claim the var, otherwise it is silently dropped instead of
                         # being kept as an extra.
-                        and bool(self.env_nested_delimiter)
+                        and self.env_nested_delimiter
                         and env_name.startswith(f'{field_env_name}{self.env_nested_delimiter}')
                     ):
                         env_used = True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3392,6 +3392,33 @@ def test_dotenv_extra_forbid_similar_complex_fields(tmp_path):
     ]
 
 
+def test_dotenv_extra_forbid_similar_union_complex_fields(tmp_path):
+    """Same guard applies to the union-complex branch of the field matching.
+
+    `db: dict | None` reaches the matching logic via the union-complex path
+    rather than `_annotation_is_complex`, so exercise it explicitly: `dbx_token`
+    must not be claimed by `db` and must raise under extra='forbid'.
+    """
+    p = tmp_path / '.env'
+    p.write_text('dbx_token=secret\n')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file=p, extra='forbid')
+
+        db: dict | None = None
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'extra_forbidden',
+            'loc': ('dbx_token',),
+            'msg': 'Extra inputs are not permitted',
+            'input': 'secret',
+        }
+    ]
+
+
 def test_annotation_is_complex_root_model_check():
     """Test for https://github.com/pydantic/pydantic-settings/issues/390"""
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3328,6 +3328,70 @@ def test_dotenv_extra_allow_similar_fields(tmp_path):
     assert s.model_dump() == {'POSTGRES_USER': 'postgres', 'postgres_name': 'name', 'postgres_user_2': 'postgres2'}
 
 
+def test_dotenv_extra_allow_similar_complex_fields(tmp_path):
+    """A complex field must not claim extras that merely share its name prefix.
+
+    `dbx_token` is not `db` and, without a nested delimiter, cannot belong to `db`
+    at all -- it must be kept as an extra instead of being silently dropped.
+    """
+    p = tmp_path / '.env'
+    p.write_text('dbx_token=secret\n')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file=p, extra='allow')
+
+        db: dict = {}
+
+    s = Settings()
+    assert s.db == {}
+    assert s.model_dump() == {'db': {}, 'dbx_token': 'secret'}
+
+
+def test_dotenv_extra_allow_complex_field_nested_delimiter_boundary(tmp_path):
+    """Only vars at the nested delimiter boundary belong to a complex field.
+
+    With `env_nested_delimiter='__'`, `db__host` is consumed into `db`, while
+    `db_host` and `dbx_token` are not part of `db` and must survive as extras.
+    """
+    p = tmp_path / '.env'
+    p.write_text('db__host=localhost\ndb_host=oops\ndbx_token=secret\n')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file=p, extra='allow', env_nested_delimiter='__')
+
+        db: dict = {}
+
+    s = Settings()
+    assert s.db == {'host': 'localhost'}
+    assert s.model_dump() == {'db': {'host': 'localhost'}, 'db_host': 'oops', 'dbx_token': 'secret'}
+
+
+def test_dotenv_extra_forbid_similar_complex_fields(tmp_path):
+    """With extra='forbid', a var sharing a complex field's name prefix must raise.
+
+    Previously `dbx_token` was wrongly treated as consumed by `db`, so the
+    forbidden extra was silently ignored instead of failing validation.
+    """
+    p = tmp_path / '.env'
+    p.write_text('dbx_token=secret\n')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file=p, extra='forbid')
+
+        db: dict = {}
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'extra_forbidden',
+            'loc': ('dbx_token',),
+            'msg': 'Extra inputs are not permitted',
+            'input': 'secret',
+        }
+    ]
+
+
 def test_annotation_is_complex_root_model_check():
     """Test for https://github.com/pydantic/pydantic-settings/issues/390"""
 


### PR DESCRIPTION
Fixes #911

The extras pass in `DotEnvSettingsSource.__call__` marked a var as "used" by a complex field on a bare `startswith(field_env_name)` — so `dbx_token` was claimed by a `db: dict` field and silently dropped (`extra='allow'`), or escaped the forbidden-extra error (`extra='forbid'`). This is the complex-field counterpart of the similar-name case already tested for simple fields.

The fix requires the nested delimiter boundary (`db<delimiter>...`), which is exactly what `explode_env_vars` consumes, so legitimately nested vars (`db__host`) are still not duplicated as extras.

Added three regression tests (no delimiter, delimiter boundary, forbid); all fail before the fix. Full suite, ruff, and mypy pass.

Used an AI assistant to find and fix this; I reviewed and verified everything myself.