### PR TITLE
Add debug logging for env_file and secret file resolution

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3071,6 +3071,16 @@ Resolving settings for 'Settings' (sources in priority order, highest first):
 Sources are listed from highest to lowest priority and merged using a deep update: higher-priority sources override lower-priority ones.
 For nested structures, lower-priority sources may still contribute missing sub-keys even when the top-level key is present in a higher-priority source.
 
+The same flag also traces file resolution, so you can see which dotenv and secret files were actually
+found and loaded — helpful when running the same code from a different working directory silently
+yields defaults because a relative `.env` path didn't resolve:
+
+```
+Env file not found, skipping: /home/app/.env.production
+Loading env file: /home/app/.env
+Secret file not found, skipping: /run/secrets/api_key
+```
+
 !!! warning
     The debug output includes the values loaded from every source, which may contain secrets loaded
     from environment variables, dotenv files, or the secrets directory. Only enable it in a trusted

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -3,7 +3,6 @@ from __future__ import annotations as _annotations
 import asyncio
 import inspect
 import logging
-import os
 import re
 import threading
 import warnings
@@ -42,17 +41,9 @@ from .sources import (
     get_subcommand,
 )
 from .sources.utils import InitState, _get_alias_names, _warn_if_field_info_incomplete
+from .utils import _settings_debug_enabled, logger
 
 T = TypeVar('T')
-
-logger = logging.getLogger('pydantic_settings')
-
-_DEBUG_ENV_VAR = 'PYDANTIC_SETTINGS_DEBUG'
-
-
-def _settings_debug_enabled() -> bool:
-    """Whether settings source debugging is enabled via the `PYDANTIC_SETTINGS_DEBUG` env var."""
-    return os.environ.get(_DEBUG_ENV_VAR, '').strip().lower() in ('1', 'true', 'yes', 'on')
 
 
 class SettingsConfigDict(ConfigDict, total=False):

--- a/pydantic_settings/sources/providers/dotenv.py
+++ b/pydantic_settings/sources/providers/dotenv.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations as _annotations
 
+import logging
 import os
 import warnings
 from collections.abc import Mapping
@@ -14,6 +15,7 @@ from pydantic._internal._typing_extra import (  # type: ignore[attr-defined]
 )
 from typing_inspection.introspection import is_union_origin
 
+from ...utils import _settings_debug_enabled, logger
 from ..types import ENV_FILE_SENTINEL, DotenvFiltering, DotenvType, EnvPrefixTarget
 from ..utils import (
     InitState,
@@ -103,11 +105,17 @@ class DotEnvSettingsSource(EnvSettingsSource):
         if isinstance(env_files, (str, os.PathLike)):
             env_files = [env_files]
 
+        debug = _settings_debug_enabled() and logger.isEnabledFor(logging.DEBUG)
+
         dotenv_vars: dict[str, str | None] = {}
         for env_file in env_files:
             env_path = Path(env_file).expanduser()
             if env_path.is_file() or env_path.is_fifo():
+                if debug:
+                    logger.debug('Loading env file: %s', env_path.resolve())
                 dotenv_vars.update(self._read_env_file(env_path))
+            elif debug:
+                logger.debug('Env file not found, skipping: %s', env_path.resolve())
 
         return dotenv_vars
 

--- a/pydantic_settings/sources/providers/secrets.py
+++ b/pydantic_settings/sources/providers/secrets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations as _annotations
 
+import logging
 import os
 import warnings
 from pathlib import Path
@@ -12,7 +13,7 @@ from typing import (
 
 from pydantic.fields import FieldInfo
 
-from pydantic_settings.utils import path_type_label
+from pydantic_settings.utils import _settings_debug_enabled, logger, path_type_label
 
 from ...exceptions import SettingsError
 from ..base import PydanticBaseEnvSettingsSource
@@ -113,15 +114,21 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
                 a flag to determine whether value is complex.
         """
 
+        debug = _settings_debug_enabled() and logger.isEnabledFor(logging.DEBUG)
+
         for field_key, env_name, value_is_complex in self._extract_field_info(field, field_name):
             # paths reversed to match the last-wins behaviour of `env_file`
             for secrets_path in reversed(self.secrets_paths):
                 path = self.find_case_path(secrets_path, env_name, self.case_sensitive)
                 if not path:
                     # path does not exist, we currently don't return a warning for this
+                    if debug:
+                        logger.debug('Secret file not found, skipping: %s', (secrets_path / env_name).resolve())
                     continue
 
                 if path.is_file():
+                    if debug:
+                        logger.debug('Loading secret file: %s', path.resolve())
                     return path.read_text().strip(), field_key, value_is_complex
                 else:
                     warnings.warn(

--- a/pydantic_settings/utils.py
+++ b/pydantic_settings/utils.py
@@ -1,6 +1,18 @@
+import logging
+import os
 import types
 from pathlib import Path
 from typing import Any, _Final, _GenericAlias, get_origin  # type: ignore [attr-defined]
+
+logger = logging.getLogger('pydantic_settings')
+
+_DEBUG_ENV_VAR = 'PYDANTIC_SETTINGS_DEBUG'
+
+
+def _settings_debug_enabled() -> bool:
+    """Whether settings source debugging is enabled via the `PYDANTIC_SETTINGS_DEBUG` env var."""
+    return os.environ.get(_DEBUG_ENV_VAR, '').strip().lower() in ('1', 'true', 'yes', 'on')
+
 
 _PATH_TYPE_LABELS = {
     Path.is_dir: 'directory',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4107,3 +4107,54 @@ def test_debug_sources_falsy_env_value(env, caplog):
         Settings(port=9000)
 
     assert not any('Resolving settings for' in r.getMessage() for r in caplog.records)
+
+
+def test_debug_env_file_resolution(env, caplog, tmp_path):
+    present = tmp_path / '.env'
+    present.write_text('name=from_dotenv')
+    missing = tmp_path / '.env.missing'
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file=[missing, present])
+        name: str = 'default'
+
+    env.set('PYDANTIC_SETTINGS_DEBUG', '1')
+    with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
+        s = Settings()
+
+    assert s.name == 'from_dotenv'
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(f'Loading env file: {present.resolve()}' == m for m in messages)
+    assert any(f'Env file not found, skipping: {missing.resolve()}' == m for m in messages)
+
+
+def test_debug_env_file_resolution_disabled_by_default(env, caplog, tmp_path, monkeypatch):
+    monkeypatch.delenv('PYDANTIC_SETTINGS_DEBUG', raising=False)
+    missing = tmp_path / '.env.missing'
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file=missing)
+        name: str = 'default'
+
+    with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
+        Settings()
+
+    assert not any('env file' in r.getMessage().lower() for r in caplog.records)
+
+
+def test_debug_secret_file_resolution(env, caplog, tmp_path):
+    (tmp_path / 'name').write_text('from_secret')
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(secrets_dir=tmp_path)
+        name: str = 'default'
+        missing: str = 'default'
+
+    env.set('PYDANTIC_SETTINGS_DEBUG', '1')
+    with caplog.at_level(logging.DEBUG, logger='pydantic_settings'):
+        s = Settings()
+
+    assert s.name == 'from_secret'
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(f'Loading secret file: {(tmp_path / "name").resolve()}' == m for m in messages)
+    assert any('Secret file not found, skipping' in m and 'missing' in m for m in messages)


### PR DESCRIPTION
Closes #909

## Summary

Extends the existing `PYDANTIC_SETTINGS_DEBUG` mechanism (added in #906) to also trace **file resolution**, so users can see which dotenv and secret files were probed, which were loaded, and which were skipped.

Previously, a missing `env_file` — e.g. a relative `.env` path that doesn't resolve from the current working directory — was silently skipped with no indication why, which is the exact confusion reported in #909 (and echoed across #4, #266, #354, #215, #795). This reuses the existing opt-in gate and `pydantic_settings` logger rather than introducing a parallel logging path.

## Changes

- `DotEnvSettingsSource._read_env_files` now emits `DEBUG` lines for each candidate `env_file` — `Loading env file: <resolved path>` or `Env file not found, skipping: <resolved path>`. The `if is_file()` branch previously had no `else`, so misses were invisible.
- `SecretsSettingsSource.get_field_value` gets the same treatment for per-field secret files (which had an explicit `# we currently don't return a warning for this` comment).
- The `logger`, `_DEBUG_ENV_VAR`, and `_settings_debug_enabled()` helper move into the dependency-free `utils` module so the sources can share them without a circular import. `pydantic_settings.main` re-imports them, so existing references keep working.
- Docs and tests added.

## Behavior

Opt-in and off by default — output only appears when `PYDANTIC_SETTINGS_DEBUG` is truthy **and** `DEBUG`-level logging is enabled on the `pydantic_settings` logger. No change to default behavior.

```
Env file not found, skipping: /home/app/.env.production
Loading env file: /home/app/.env
Secret file not found, skipping: /run/secrets/api_key
```

The resolved absolute paths can leak usernames/layout, so this sits behind the same opt-in gate covered by the existing sensitive-output warning in the docs.

## Tests

Added `test_debug_env_file_resolution`, `test_debug_env_file_resolution_disabled_by_default`, and `test_debug_secret_file_resolution`. All debug tests pass; `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
