### PR TITLE
fix: decode secret files as UTF-8

### DIFF
--- a/pydantic_settings/sources/providers/nested_secrets.py
+++ b/pydantic_settings/sources/providers/nested_secrets.py
@@ -202,7 +202,7 @@ class NestedSecretsSettingsSource(EnvSettingsSource):
 
     @classmethod
     def load_secrets(cls, path: Path) -> dict[str, str]:
-        return {str(p.relative_to(path)): p.read_text().strip() for p in cls._iter_secret_files(path)}
+        return {str(p.relative_to(path)): p.read_text(encoding='utf-8').strip() for p in cls._iter_secret_files(path)}
 
     def __repr__(self) -> str:
         return f'NestedSecretsSettingsSource(secrets_dir={self.secrets_dir!r})'

--- a/pydantic_settings/sources/providers/secrets.py
+++ b/pydantic_settings/sources/providers/secrets.py
@@ -129,7 +129,7 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
                 if path.is_file():
                     if debug:
                         logger.debug('Loading secret file: %s', path.resolve())
-                    return path.read_text().strip(), field_key, value_is_complex
+                    return path.read_text(encoding='utf-8').strip(), field_key, value_is_complex
                 else:
                     warnings.warn(
                         f'attempted to load secret file "{path}" but found a {path_type_label(path)} instead.',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1879,6 +1879,22 @@ def test_secrets_path(tmp_path):
     assert Settings().model_dump() == {'foo': 'foo_secret_value_str'}
 
 
+def test_secrets_path_utf8_bytes_independent_of_locale(tmp_path, monkeypatch):
+    """Secret files are UTF-8 on disk; do not decode with the process locale (#916)."""
+    expected = 'pässwörd-\U0001f510'
+    (tmp_path / 'token').write_bytes(expected.encode('utf-8'))
+
+    class Settings(BaseSettings):
+        token: str
+
+        model_config = SettingsConfigDict(secrets_dir=tmp_path)
+
+    # Force a non-UTF-8 preferred encoding so a bare read_text() would mis-decode.
+    monkeypatch.setattr('locale.getpreferredencoding', lambda do_setlocale=True: 'cp936')
+
+    assert Settings().token == expected
+
+
 def test_secrets_path_multiple(tmp_path):
     d1 = tmp_path / 'dir1'
     d2 = tmp_path / 'dir2'

--- a/tests/test_source_nested_secrets.py
+++ b/tests/test_source_nested_secrets.py
@@ -501,6 +501,31 @@ def test_multiple_secrets_dirs(conf: SettingsConfigDict, secrets, dirs, expected
         raise AssertionError('unreachable')
 
 
+def test_nested_secrets_utf8_bytes_independent_of_locale(tmp_path, monkeypatch):
+    """Nested secret files must decode as UTF-8 regardless of locale (#916)."""
+    expected = 'pässwörd-\U0001f510'
+    secrets = tmp_path / 'secrets'
+    secrets.mkdir()
+    (secrets / 'app_key').write_bytes(expected.encode('utf-8'))
+    (secrets / 'db').mkdir()
+    (secrets / 'db' / 'user').write_text('u', encoding='utf-8')
+    (secrets / 'db' / 'passwd').write_bytes(expected.encode('utf-8'))
+
+    monkeypatch.setattr('locale.getpreferredencoding', lambda do_setlocale=True: 'cp936')
+
+    class Settings(AppSettings):
+        model_config = SettingsConfigDict(
+            secrets_dir=secrets,
+            env_nested_delimiter='__',
+            secrets_nested_subdir=True,
+        )
+
+    conf = Settings()
+    assert conf.app_key == expected
+    assert conf.db.user == 'u'
+    assert conf.db.passwd == expected
+
+
 def test_strip_whitespace(env, tmp_files):
     env.set('DB__USER', 'user')
     tmp_files.write(


### PR DESCRIPTION
## Summary
Fixes #916.

`SecretsSettingsSource` and `NestedSecretsSettingsSource` read secret files with `Path.read_text()` without an encoding. On Windows systems whose locale encoding is not UTF-8, a UTF-8 secret file can be decoded with the active code page and **silently** produce a wrong string (no `UnicodeDecodeError`).

### Changes
- Always use `encoding='utf-8'` when reading secret files in both sources.
- Add regression tests that force a non-UTF-8 preferred encoding via `locale.getpreferredencoding` and assert multi-byte UTF-8 secrets round-trip correctly (including nested secret trees).

## Test plan
- [x] `pytest tests/test_settings.py::test_secrets_path_utf8_bytes_independent_of_locale -q`
- [x] `pytest tests/test_source_nested_secrets.py::test_nested_secrets_utf8_bytes_independent_of_locale -q`
- [x] Existing secrets suites still intended to pass (locale-independent decode).