### PR TITLE
feat: support additional fields with pyproject source

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3038,6 +3038,53 @@ field = "default-table"
 field = "some-table"
 ```
 
+#### Loading additional fields from outside the table
+
+Sometimes you want to reuse a value declared elsewhere in "pyproject.toml" (such as the project version) without moving it into your settings table.
+`SettingsConfigDict(pyproject_toml_additional_fields=tuple[tuple[str, ...], ...])` accepts a tuple of field paths; the leaf key of each path is merged into the settings alongside the values loaded from `pyproject_toml_table_header`.
+Paths that are not present in the file are silently skipped.
+
+```python
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    PyprojectTomlConfigSettingsSource,
+    SettingsConfigDict,
+)
+
+
+class AdditionalFieldsSettings(BaseSettings):
+    """Example pulling `version` from the `[project]` table into the settings."""
+
+    model_config = SettingsConfigDict(
+        pyproject_toml_additional_fields=(('project', 'version'),)
+    )
+
+    field: str
+    version: str
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (PyprojectTomlConfigSettingsSource(settings_cls),)
+```
+
+Given the following "pyproject.toml", this results in `AdditionalFieldsSettings(field='default-table', version='1.2.3')`:
+
+```toml
+[project]
+version = "1.2.3"
+
+[tool.pydantic-settings]
+field = "default-table"
+```
+
 By default, `PyprojectTomlConfigSettingsSource` will only look for a "pyproject.toml" in the your current working directory.
 However, there are two options to change this behavior.
 

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -108,6 +108,21 @@ class SettingsConfigDict(ConfigDict, total=False):
     To use the root table, exclude this config setting or provide an empty tuple.
     """
 
+    pyproject_toml_additional_fields: tuple[tuple[str, ...], ...]
+    """
+    Additional fields to load from a `pyproject.toml` file that live outside of the table defined by
+    `pyproject_toml_table_header`.
+
+    Each entry is a `tuple[str, ...]` describing the full path to a field within the file. The field's
+    leaf key is merged into the loaded settings alongside the values from the table header, which lets
+    settings reuse values declared elsewhere in `pyproject.toml`.
+
+    For example, `pyproject_toml_additional_fields = (("project", "version"),)` makes the `version`
+    field from the `[project]` table available to the settings model.
+
+    Fields whose path is not present in the file are silently skipped. Defaults to an empty tuple.
+    """
+
     toml_file: ConfigFileSourceType | None
 
     toml_table_header: tuple[str, ...]
@@ -610,7 +625,10 @@ class BaseSettings(BaseModel):
                         )
 
         warn_if_not_used(JsonConfigSettingsSource, ('json_file', 'json_file_encoding'))
-        warn_if_not_used(PyprojectTomlConfigSettingsSource, ('pyproject_toml_depth', 'pyproject_toml_table_header'))
+        warn_if_not_used(
+            PyprojectTomlConfigSettingsSource,
+            ('pyproject_toml_depth', 'pyproject_toml_table_header', 'pyproject_toml_additional_fields'),
+        )
         warn_if_not_used(TomlConfigSettingsSource, ('toml_file', 'toml_table_header'))
         warn_if_not_used(YamlConfigSettingsSource, ('yaml_file', 'yaml_file_encoding', 'yaml_config_section'))
 

--- a/pydantic_settings/sources/providers/pyproject.py
+++ b/pydantic_settings/sources/providers/pyproject.py
@@ -31,9 +31,21 @@ class PyprojectTomlConfigSettingsSource(TomlConfigSettingsSource):
         self.toml_table_header: tuple[str, ...] = settings_cls.model_config.get(
             'pyproject_toml_table_header', ('tool', 'pydantic-settings')
         )
+        self.toml_additional_fields: tuple[tuple[str, ...], ...] = settings_cls.model_config.get(
+            'pyproject_toml_additional_fields', ()
+        )
         self.toml_data = self._read_files(self.toml_file_path)
+        additional_fields = {}
+        for field_path in self.toml_additional_fields:
+            data = self.toml_data
+            for key in field_path[:-1]:
+                data = data.get(key, {})
+            key = field_path[-1]
+            if key in data:
+                additional_fields[key] = data[key]
         for key in self.toml_table_header:
             self.toml_data = self.toml_data.get(key, {})
+        self.toml_data.update(additional_fields)
         super(TomlConfigSettingsSource, self).__init__(settings_cls, self.toml_data, _init_state=_init_state)
 
     @staticmethod

--- a/tests/test_source_pyproject_toml.py
+++ b/tests/test_source_pyproject_toml.py
@@ -56,6 +56,23 @@ class TestPyprojectTomlConfigSettingsSource:
         assert obj.toml_data == {'field': 'some'}
         assert obj.toml_file_path == tmp_path / 'pyproject.toml'
 
+    def test___init___additional_fields(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test __init__ merges additional fields from outside the table header."""
+        mocker.patch(f'{MODULE}.Path.cwd', return_value=tmp_path)
+        pyproject = tmp_path / 'pyproject.toml'
+        pyproject.write_text(SOME_TOML_DATA)
+
+        class AdditionalFieldsSettings(BaseSettings):
+            model_config = SettingsConfigDict(
+                pyproject_toml_table_header=('some', 'table'),
+                pyproject_toml_additional_fields=(('other', 'table', 'field'), ('missing', 'field')),
+            )
+
+        obj = PyprojectTomlConfigSettingsSource(AdditionalFieldsSettings)
+        # The leaf key of each present path is merged alongside the table values;
+        # missing paths are silently skipped.
+        assert obj.toml_data == {'field': 'other'}
+
     def test___init___explicit(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test __init__ explicit file."""
         mocker.patch(f'{MODULE}.Path.cwd', return_value=tmp_path)
@@ -246,6 +263,39 @@ def test_pyproject_toml_file_header(cd_tmp_path: Path):
 
     s = Settings()
     assert s.status == 'success'
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')
+def test_pyproject_toml_additional_fields(cd_tmp_path: Path):
+    pyproject = cd_tmp_path / 'pyproject.toml'
+    pyproject.write_text(
+        """
+    [project]
+    version = "1.2.3"
+
+    [tool.pydantic-settings]
+    field = "default-table"
+    """
+    )
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(
+            extra='forbid',
+            pyproject_toml_additional_fields=(('project', 'version'),),
+        )
+
+        field: str
+        version: str
+
+        @classmethod
+        def settings_customise_sources(
+            cls, settings_cls: type[BaseSettings], **_kwargs: PydanticBaseSettingsSource
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return (PyprojectTomlConfigSettingsSource(settings_cls, pyproject),)
+
+    s = Settings()
+    assert s.field == 'default-table'
+    assert s.version == '1.2.3'
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 11) and tomli is None, reason='tomli/tomllib is not installed')


### PR DESCRIPTION
I use pydantic-settings to create CLI tool that can read configuration from pyproject.toml But some values are already present in standard project table (e.g. `[project].name`). So I tried expanding the source with support for specifiing some additional fields.