### PR TITLE
fix: raise ValidationError for non-JSON env values on strict fields

### DIFF
--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -367,7 +367,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                         if not isinstance(decoded, str):
                             return TypeAdapter(field.annotation).validate_python(decoded)
                         raise
-        except ValidationError:
+        except (ValidationError, json.JSONDecodeError):
             # Allow validation error to be raised at time of instantiation
             pass
         return value

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3949,6 +3949,40 @@ def test_env_strict_coercion_optional_strict_types(env):
     assert s.my_int == 42
 
 
+def test_env_strict_coercion_non_json_value(env):
+    from pydantic import StrictBool
+
+    class Settings(BaseSettings):
+        my_bool: StrictBool | None = None
+
+    env.set('MY_BOOL', 'maybe')
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'bool_type',
+            'loc': ('my_bool',),
+            'msg': 'Input should be a valid boolean',
+            'input': 'maybe',
+        }
+    ]
+
+    class StrictSettings(BaseSettings, strict=True):
+        my_int: int = 0
+
+    env.set('MY_INT', 'not-a-number')
+    with pytest.raises(ValidationError) as exc_info:
+        StrictSettings()
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'int_type',
+            'loc': ('my_int',),
+            'msg': 'Input should be a valid integer',
+            'input': 'not-a-number',
+        }
+    ]
+
+
 def test_env_source_when_load_multi_nested_config(env):
     class EmbeddingModel(BaseModel):
         model: str = 'text-embedding-3-small'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -29,6 +29,7 @@ from pydantic import (
     RootModel,
     Secret,
     SecretStr,
+    StrictBool,
     Tag,
     ValidationError,
     field_validator,
@@ -3950,8 +3951,6 @@ def test_env_strict_coercion_optional_strict_types(env):
 
 
 def test_env_strict_coercion_non_json_value(env):
-    from pydantic import StrictBool
-
     class Settings(BaseSettings):
         my_bool: StrictBool | None = None
 


### PR DESCRIPTION
On `main` (ae25d70):

```python
import os

from pydantic import StrictBool
from pydantic_settings import BaseSettings

os.environ['MY_BOOL'] = 'maybe'


class Settings(BaseSettings):
    my_bool: StrictBool | None = None


Settings()
```

raises `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`, rewrapped as `SettingsError: error parsing value for field "my_bool" from source "EnvSettingsSource"`. Pydantic's own error is lost.

`_coerce_env_val_strict` falls back to `json.loads(value)` inside a `try` whose handler only catches `ValidationError`, so a value that is not valid JSON escapes the helper and `PydanticBaseSettingsSource.__call__` rewraps it as a `SettingsError`.

Catching `json.JSONDecodeError` there as well returns the raw string, which is already what the handler does when strict validation fails — the error is deferred to model instantiation. With the change, the snippet above ends with:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
my_bool
  Input should be a valid boolean [type=bool_type, input_value='maybe', input_type=str]
```

The same path is reachable with `strict=True` on a plain field, with `Literal[<IntEnum member>]` and no model config at all, and through `env_nested_delimiter`.

`test_env_strict_coercion_non_json_value` sits with the existing strict-coercion tests. I reverted the one-line source change and re-ran it: it fails inside the first `pytest.raises(ValidationError)` block with `SettingsError: error parsing value for field "my_bool" from source "EnvSettingsSource"`, and passes again with the change restored.

`make test`, `make lint` and `make mypy` are clean locally, including the without-PyYAML run.

An alternative is to wrap only the `json.loads` call in its own `try` and fall through to the existing `raise`, which is narrower than widening the outer handler. Happy to switch if you prefer that.
