### PR TITLE
test: move function-local imports to the top of test modules

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pathlib
 import sys
+import threading
 import uuid
 from collections.abc import Callable, Hashable
 from datetime import date, datetime, timezone
@@ -13,7 +14,7 @@ from typing import Annotated, Any, Generic, Literal, TypeVar
 from unittest import mock
 
 import pytest
-from annotated_types import MinLen
+from annotated_types import Len, MinLen
 from pydantic import (
     AliasChoices,
     AliasGenerator,
@@ -30,6 +31,7 @@ from pydantic import (
     Secret,
     SecretStr,
     StrictBool,
+    StrictInt,
     Tag,
     ValidationError,
     field_validator,
@@ -55,7 +57,7 @@ from pydantic_settings import (
     SettingsConfigDict,
     SettingsError,
 )
-from pydantic_settings.sources import DefaultSettingsSource
+from pydantic_settings.sources import DefaultSettingsSource, read_env_file
 
 try:
     import dotenv
@@ -511,8 +513,6 @@ def test_annotated_with_parameterized_type_alias(env):
     Parameterized PEP 695 type aliases should correctly substitute type params
     when determining if a field is complex.
     """
-    from annotated_types import Len
-
     T = TypeVar('T')
 
     MaxLenA = Annotated[T, Len(max_length=4)]
@@ -1762,8 +1762,6 @@ def test_read_dotenv_vars(tmp_path):
 @pytest.mark.skipif(not hasattr(os, 'mkfifo'), reason='requires os.mkfifo (Unix)')
 def test_read_dotenv_vars_from_fifo(tmp_path):
     """Named pipes / FIFOs (e.g. 1Password Environments) should be read as env files."""
-    import threading
-
     env_content = 'KEY=value\nOTHER=123'
     fifo_path = tmp_path / '.env'
     os.mkfifo(fifo_path)
@@ -1814,8 +1812,6 @@ def test_dotenvsource_override(env):
 # test that calling read_env_file issues a DeprecationWarning
 # TODO: remove this test once read_env_file is removed
 def test_read_env_file_deprecation(tmp_path):
-    from pydantic_settings.sources import read_env_file
-
     base_env = tmp_path / '.env'
     base_env.write_text(test_default_env_file)
 
@@ -3917,8 +3913,6 @@ def test_env_strict_coercion(env):
 
 
 def test_env_strict_coercion_optional_strict_types(env):
-    from pydantic import StrictBool, StrictInt
-
     class StrictSettings(BaseSettings, strict=True):
         my_bool: StrictBool | None = None
 

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -7,7 +7,8 @@ import time
 import typing
 from enum import Enum, IntEnum
 from pathlib import Path, PureWindowsPath
-from typing import Annotated, Any, Dict, Generic, List, Literal, Tuple, TypeVar, Union  # noqa: UP035
+from string import ascii_letters
+from typing import Annotated, Any, Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union  # noqa: UP035
 
 import pytest
 import typing_extensions
@@ -1905,7 +1906,6 @@ def test_cli_variadic_positional_arg_custom_type():
 
     Regression test for https://github.com/pydantic/pydantic-settings/issues/823
     """
-    from string import ascii_letters
 
     class AsciiLetters(str):
         def __new__(cls, content: object) -> typing_extensions.Self:
@@ -3167,7 +3167,6 @@ def test_cli_self_referential_model():
 
     Self-referential models should not cause infinite recursion in CLI arg parser.
     """
-    from typing import Optional
 
     class Foo(BaseModel):
         foo: Optional['Foo'] = None
@@ -3195,7 +3194,6 @@ def test_cli_mutually_recursive_models():
     Mutually recursive models (A -> B -> A) via discriminated unions should not
     cause infinite recursion in CLI arg parser.
     """
-    from typing import Annotated, Literal, Union
 
     class A(BaseModel):
         type: Literal['a'] = 'a'

--- a/tests/test_source_gcp_secret_manager.py
+++ b/tests/test_source_gcp_secret_manager.py
@@ -5,7 +5,7 @@ Test pydantic_settings.GoogleSecretSettingsSource
 from typing import Annotated
 
 import pytest
-from pydantic import Field
+from pydantic import Field, ValidationError
 from pytest_mock import MockerFixture
 
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
@@ -312,8 +312,6 @@ class TestGoogleSecretManagerSettingsSource:
         assert settings.test_secret == 'test-value'
 
     def test_pydantic_base_settings_with_unknown_attribute(self, mock_secret_client, monkeypatch, mocker):
-        from pydantic_core._pydantic_core import ValidationError
-
         class Settings(BaseSettings, case_sensitive=False):
             test_secret: str = Field(..., alias='test-secret')
             another_secret: str = Field(..., alias='ANOTHER_SECRET')
@@ -688,8 +686,6 @@ class TestGoogleSecretManagerSettingsSource:
                     ),
                 )
 
-        from pydantic import ValidationError
-
         with pytest.raises(ValidationError) as excinfo:
             Settings()
 
@@ -769,8 +765,6 @@ class TestGoogleSecretManagerSettingsSource:
                 file_secret_settings: PydanticBaseSettingsSource,
             ) -> tuple[PydanticBaseSettingsSource, ...]:
                 return (GoogleSecretManagerSettingsSource(cls, secret_client=client, project_id='test-project'),)
-
-        from pydantic import ValidationError
 
         # EXPECTATION: ValidationError because v1 is missing.
         # REALITY (Bug): It gets 'latest-val' and succeeds.


### PR DESCRIPTION
Follow-up to #926, where the review asked for a function-local `StrictBool` import to be moved to the top of the file. This applies the same standard to the rest of the test suite.

## What changed

Hoists 10 function-local imports across three test modules:

- **`tests/test_settings.py`** — `threading`, `annotated_types.Len`, `StrictInt`, `read_env_file`, and the now-redundant `StrictBool` (shadowed by the top-level import added in #926).
- **`tests/test_source_cli.py`** — `string.ascii_letters` and `typing.Optional`. Two other local `typing` imports (`Annotated, Literal, Union`) were exact duplicates of the top-level import and were simply removed.
- **`tests/test_source_gcp_secret_manager.py`** — three separate `ValidationError` imports collapsed into one top-level import. Two spelled it `from pydantic` and one `from pydantic_core._pydantic_core`; these resolve to the same object (`pydantic.ValidationError is pydantic_core._pydantic_core.ValidationError`).

Net −14 lines. No test logic touched.

## What was deliberately left alone

Ruff's `PLC0415` flags 30 sites in total; the 20 not touched here are load-bearing rather than stylistic:

- **16 in `pydantic_settings/`** are lazy imports of optional extras (`boto3`, `azure.*`, `google.*`, `tomli`, `yaml`), each wrapped in `try/except ImportError` that raises a `pip install pydantic-settings[...]` hint. Hoisting them would turn every optional dependency into a hard import-time requirement.
- **`tests/test_source_yaml.py:672-675`** imports `zipfile`/`importlib`/`sys` inside a test that builds a zip and mutates `sys.path`, and the module relies on the `try: import yaml / except ImportError: yaml = None` guard.

For that reason `PLC0415` is **not** added to `extend-select` in `pyproject.toml` — enabling it would need ~20 `# noqa` comments to stay green. If it's wanted as an enforced rule, the cleaner approach is enabling it alongside a `per-file-ignores` entry for the provider modules. Happy to do that in a separate PR.

## Verification

- `pytest tests/` — 693 passed, 5 skipped.
- `ruff check tests/` and `ruff format --check tests/` — clean.

Note: `make lint` currently fails on a pre-existing `RUF100` in `pydantic_settings/sources/types.py:11,13`, already present on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)