### PR TITLE
fix: EnvSettingsSource drops env vars for undeclared fields even with extra='allow'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -159,6 +159,13 @@ class Settings(BaseSettings):
     The default `env_prefix` is `''` (empty string). `env_prefix` is not only for env settings but also for
     dotenv files, secrets, and other sources.
 
+!!! note
+    With `extra='allow'` and an `env_prefix` set, environment variables that match the prefix but don't
+    correspond to a declared field are picked up as extra fields (with the prefix stripped), instead of being
+    silently ignored. This only applies when `env_prefix` is set and `extra` is explicitly `'allow'` — without
+    a prefix there's no safe boundary between this app's config and the rest of the process environment, so
+    unprefixed sources are left alone.
+
 If you want to change the environment variable name for a single field, you can use an alias.
 
 There are two ways to do this:

--- a/pydantic_settings/sources/providers/dotenv.py
+++ b/pydantic_settings/sources/providers/dotenv.py
@@ -16,6 +16,7 @@ from pydantic._internal._typing_extra import (  # type: ignore[attr-defined]
 from typing_inspection.introspection import is_union_origin
 
 from ...utils import _settings_debug_enabled, logger
+from ..base import PydanticBaseEnvSettingsSource
 from ..types import ENV_FILE_SENTINEL, DotenvFiltering, DotenvType, EnvPrefixTarget
 from ..utils import (
     InitState,
@@ -120,7 +121,13 @@ class DotEnvSettingsSource(EnvSettingsSource):
         return dotenv_vars
 
     def __call__(self) -> dict[str, Any]:  # noqa: C901
-        data: dict[str, Any] = super().__call__()
+        # Bypass EnvSettingsSource.__call__() here (rather than plain super().__call__()):
+        # it now also merges prefix-matched extra env vars into the result (see #818), which
+        # would run before we've had a chance to apply our own dotenv_filtering modes below,
+        # breaking e.g. 'only_existing's documented "just return existing fields" contract.
+        # Get the raw, declared-fields-only data instead and keep applying our own filtering
+        # on top exactly as before.
+        data: dict[str, Any] = PydanticBaseEnvSettingsSource.__call__(self)
         if self.dotenv_filtering == 'only_existing':
             # This case behaves like the EnvSettingsSource, only return existing fields
             return data

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -434,6 +434,14 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                     ):
                         env_used = True
                         break
+                # A field with an alias and populate_by_name=False is validated by its
+                # alias only, so _extract_field_info above never yields field_name itself.
+                # But pydantic's extra='allow' still stores an extra under any leftover
+                # dict key that matches the field's own declared name, colliding with (and
+                # shadowing in model_extra, though not overwriting) the real attribute. Treat
+                # the bare field_name as claimed too, or we'd inject that spoofed extra.
+                if not env_used and normalized_env_name == self._apply_case_sensitive(field_name):
+                    env_used = True
                 if env_used:
                     break
             if not env_used:

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -399,7 +399,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
 
         prefix = self._apply_case_sensitive(self.env_prefix)
         for env_name, env_value in self.env_vars.items():
-            if not env_value or not env_name.startswith(prefix) or env_name in self.settings_cls.model_fields:
+            if env_value is None or not env_name.startswith(prefix):
                 continue
             normalized_env_name = env_name[len(self.env_prefix) :]
             if normalized_env_name in data:

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -401,7 +401,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         for env_name, env_value in self.env_vars.items():
             if env_value is None or not env_name.startswith(prefix):
                 continue
-            normalized_env_name = env_name[len(self.env_prefix) :]
+            normalized_env_name = env_name[len(prefix) :]
             if normalized_env_name in data:
                 continue
             env_used = False
@@ -429,7 +429,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                         # (e.g. field alias "foo" vs env var "PREFIX_foo" normalizing to
                         # "foo") -- treat that as claimed too, or we'd inject a spoofed value
                         # under the exact key that field's own resolution expects.
-                        or normalized_env_name == field_key
+                        or normalized_env_name == self._apply_case_sensitive(field_key)
                         or matches_complex_field
                     ):
                         env_used = True

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -372,6 +372,75 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
             pass
         return value
 
+    def __call__(self) -> dict[str, Any]:
+        data = super().__call__()
+        return self._merge_extra_env_vars(data)
+
+    def _merge_extra_env_vars(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Add prefixed environment variables that don't correspond to a declared field into ``data``.
+
+        Without this, environment variables for undeclared fields were silently dropped even
+        when the model allows extras (``extra='allow'``), instead of being made available for
+        pydantic to pick up as extra fields (see #818).
+
+        This only kicks in when ``extra`` is explicitly ``'allow'``, and only ever considers
+        variables matching ``env_prefix``:
+
+        - ``extra='forbid'`` is pydantic-settings' own default. Unlike `DotEnvSettingsSource`
+          (whose `env_vars` are scoped to a small, developer-controlled `.env` file), `env_vars`
+          here is effectively the entire process environment -- surfacing every unrelated,
+          prefix-coincidental var as a hard validation error under the *default* config would
+          be a significant behavior change for existing users who never opted into this.
+        - Without an explicit `env_prefix` there's similarly no safe boundary between "this
+          app's config" and everything else in `os.environ`.
+        """
+        if self.config.get('extra') != 'allow' or not self.env_prefix:
+            return data
+
+        prefix = self._apply_case_sensitive(self.env_prefix)
+        for env_name, env_value in self.env_vars.items():
+            if not env_value or not env_name.startswith(prefix) or env_name in self.settings_cls.model_fields:
+                continue
+            normalized_env_name = env_name[len(self.env_prefix) :]
+            if normalized_env_name in data:
+                continue
+            env_used = False
+            for field_name, field in self.settings_cls.model_fields.items():
+                for field_key, field_env_name, _ in self._extract_field_info(field, field_name):
+                    is_complex = _annotation_is_complex(field.annotation, field.metadata, self._init_state) or (
+                        is_union_origin(get_origin(field.annotation))
+                        and _union_is_complex(field.annotation, field.metadata, self._init_state)
+                    )
+                    # A var only belongs to a complex field when it sits at the nested
+                    # delimiter boundary (`db<delim>...`, matching what explode_env_vars
+                    # consumes). A bare name-prefix match (e.g. `dbx_token` vs field `db`)
+                    # must not claim the var, otherwise it is silently dropped instead of
+                    # being kept as an extra.
+                    matches_complex_field = (
+                        is_complex
+                        and self.env_nested_delimiter
+                        and env_name.startswith(f'{field_env_name}{self.env_nested_delimiter}')
+                    )
+                    if (
+                        env_name == field_env_name
+                        # A field whose validation_alias isn't prefix-targeted (the default)
+                        # is looked up by its bare alias, bypassing env_prefix entirely. Our
+                        # prefix-stripped name can still collide with that bare field_key
+                        # (e.g. field alias "foo" vs env var "PREFIX_foo" normalizing to
+                        # "foo") -- treat that as claimed too, or we'd inject a spoofed value
+                        # under the exact key that field's own resolution expects.
+                        or normalized_env_name == field_key
+                        or matches_complex_field
+                    ):
+                        env_used = True
+                        break
+                if env_used:
+                    break
+            if not env_used:
+                data[normalized_env_name] = env_value
+
+        return data
+
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(env_nested_delimiter={self.env_nested_delimiter!r}, '

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -416,8 +416,12 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                     # consumes). A bare name-prefix match (e.g. `dbx_token` vs field `db`)
                     # must not claim the var, otherwise it is silently dropped instead of
                     # being kept as an extra.
+                    # A scalar field that's the head of a multi-part AliasPath (e.g.
+                    # AliasPath('path', 'child')) is consumed the same way a genuinely
+                    # complex field is -- explode_env_vars/_matches_alias_path_head already
+                    # treats it as such -- even though _annotation_is_complex says no.
                     matches_complex_field = (
-                        is_complex
+                        (is_complex or self._matches_alias_path_head(field, self._apply_case_sensitive(field_key)))
                         and self.env_nested_delimiter
                         and env_name.startswith(f'{field_env_name}{self.env_nested_delimiter}')
                     )

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -437,6 +437,11 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
                 if env_used:
                     break
             if not env_used:
+                # Mirror the EnvNoneType -> None conversion PydanticBaseEnvSettingsSource.__call__
+                # already applies to declared fields, so an extra doesn't leak the raw
+                # env_parse_none_str sentinel (e.g. the literal string 'null') instead of None.
+                if self.env_parse_none_str is not None and isinstance(env_value, EnvNoneType):
+                    env_value = None
                 data[normalized_env_name] = env_value
 
         return data

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2869,6 +2869,46 @@ def test_env_settings_source_extra_allow_converts_none_str(env):
     assert s.__pydantic_extra__['option'] is None
 
 
+def test_env_settings_source_extra_allow_case_insensitive_prefix(env):
+    """The prefix is stripped using its case-normalized length, not the raw
+    env_prefix's length.
+
+    Caught by automated review on the PR: with case-insensitive matching, if
+    lowercasing ever changes a prefix's length (e.g. certain Unicode
+    characters), slicing by the raw env_prefix length produces a mis-sliced,
+    malformed extra key. This test covers the ordinary case-insensitive path.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='allow', case_sensitive=False)
+        apple: str = 'default'
+
+    env.set('prefix_banana', 'x')
+    s = Settings()
+    assert s.__pydantic_extra__ == {'banana': 'x'}
+
+
+def test_env_settings_source_extra_allow_does_not_spoof_aliased_field_case_insensitive(env):
+    """The field_key collision guard from #818 also applies case-insensitively.
+
+    Caught by automated review on the PR: comparing the case-normalized
+    normalized_env_name against the raw-case field_key meant an uppercase
+    validation_alias (looked up unprefixed, per the default env_prefix_target)
+    wasn't recognized as claimed under case_sensitive=False, so a
+    coincidentally-prefixed var was wrongly injected as a stray extra instead
+    of being left alone.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='allow', case_sensitive=False)
+        foobar: str = Field(default='unset', validation_alias='FOO')
+
+    env.set('PREFIX_FOO', 'should_not_become_an_extra')
+    s = Settings()
+    assert s.foobar == 'unset'
+    assert s.__pydantic_extra__ == {}
+
+
 def test_env_json_field(env):
     class Settings(BaseSettings):
         x: Json

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2819,6 +2819,37 @@ def test_env_settings_source_extra_allow_does_not_spoof_aliased_field(env):
     assert Settings().foobar == 'satisfies_foobar'
 
 
+def test_env_settings_source_extra_allow_preserves_empty_value(env):
+    """An empty-string env var is still a real value (with the default
+    env_ignore_empty=False) and must be kept as an extra, not silently dropped.
+
+    Caught by automated review on the PR: the original `if not env_value` check treated an
+    empty string the same as an absent variable.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='allow')
+        apple: str = 'default'
+
+    env.set('PREFIX_option', '')
+    s = Settings()
+    assert s.__pydantic_extra__ == {'option': ''}
+
+
+def test_env_settings_source_extra_allow_ignores_empty_value_when_configured(env):
+    """With env_ignore_empty=True, an empty-string extra is dropped like any other
+    empty-string value, consistent with how declared fields already behave.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='allow', env_ignore_empty=True)
+        apple: str = 'default'
+
+    env.set('PREFIX_option', '')
+    s = Settings()
+    assert 'option' not in s.__pydantic_extra__
+
+
 def test_env_json_field(env):
     class Settings(BaseSettings):
         x: Json

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2744,6 +2744,81 @@ def test_env_prefix_from_args(env):
     assert s.apple == 'has_prefix'
 
 
+def test_env_settings_source_extra_allow(env):
+    """Env vars for undeclared fields become extras when extra='allow' (#818)."""
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='allow')
+        apple: str = 'default'
+
+    env.set('PREFIX_apple', 'from_env')
+    env.set('PREFIX_banana', 'also_from_env')
+    s = Settings()
+    assert s.apple == 'from_env'
+    assert s.__pydantic_extra__ == {'banana': 'also_from_env'}
+
+
+def test_env_settings_source_extra_forbid_unaffected(env):
+    """extra='forbid' (the pydantic-settings default) is a no-op here, unaffected by #818's fix.
+
+    Env vars for undeclared fields are a common, often coincidental occurrence in real
+    deployments (shared prefixes, orchestration-injected vars, etc). Unlike
+    `DotEnvSettingsSource` -- whose vars come from a small, curated `.env` file, so raising for
+    an unexpected one is more likely to reflect a real config typo -- turning every
+    prefix-matching stray process env var into a hard validation error under the *default*
+    config would be a surprising, unrequested behavior change. So this only ever activates for
+    explicit extra='allow'.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='forbid')
+        apple: str = 'default'
+
+    env.set('PREFIX_banana', 'unexpected')
+    assert Settings().model_dump() == {'apple': 'default'}
+
+
+def test_env_settings_source_extra_allow_no_prefix_does_not_leak_environ(env):
+    """Without an explicit env_prefix, extras are not pulled from the whole environment.
+
+    `env_vars` for `EnvSettingsSource` is effectively `os.environ`, unlike
+    `DotEnvSettingsSource`, whose `env_vars` are scoped to a small `.env` file. Surfacing
+    every unrelated process env var as an "extra" field would be a footgun, so this is
+    deliberately conservative and requires an explicit prefix to opt in.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(extra='allow')
+
+    env.set('SOME_UNRELATED_VAR', 'should_not_appear')
+    s = Settings()
+    assert 'SOME_UNRELATED_VAR' not in s.__pydantic_extra__
+    assert 'some_unrelated_var' not in s.__pydantic_extra__
+
+
+def test_env_settings_source_extra_allow_does_not_spoof_aliased_field(env):
+    """A prefix-stripped extra can't accidentally satisfy a field whose validation_alias
+    bypasses env_prefix (the default, when env_prefix_target isn't 'alias'/'all').
+
+    Regression for an edge case caught while fixing #818: a field aliased "foo" is looked up
+    unprefixed, so an unrelated env var like "PREFIX_foo" must not get treated as an extra
+    normalized down to the exact key "foo" -- that would silently (and wrongly) satisfy the
+    aliased field via a completely different, coincidentally-prefixed variable.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='allow')
+        foobar: str = Field(default='unset', validation_alias='foo')
+
+    env.set('PREFIX_foo', 'should_not_satisfy_foobar')
+    s = Settings()
+    assert s.foobar == 'unset'
+    assert s.__pydantic_extra__ == {}
+
+    env.set('foo', 'satisfies_foobar')
+    assert Settings().foobar == 'satisfies_foobar'
+
+
 def test_env_json_field(env):
     class Settings(BaseSettings):
         x: Json

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2819,6 +2819,28 @@ def test_env_settings_source_extra_allow_does_not_spoof_aliased_field(env):
     assert Settings().foobar == 'satisfies_foobar'
 
 
+def test_env_settings_source_extra_allow_does_not_spoof_field_by_its_own_name(env):
+    """A field with populate_by_name=False (the default) and a validation_alias is looked
+    up only by that alias, so _extract_field_info never yields the field's own declared
+    name. An env var that normalizes down to that bare name must still not be injected as
+    an extra under the same key -- that would silently shadow the real field's value in
+    model_extra, even though it doesn't overwrite the actual attribute.
+
+    Regression for a finding from automated review on PR #932: field ``foobar`` aliased to
+    ``foo`` was allowing ``PREFIX_foobar`` through as a spoofed ``model_extra['foobar']``.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='allow')
+        foobar: str = Field(validation_alias='foo')
+
+    env.set('foo', 'real_value')
+    env.set('PREFIX_foobar', 'leaked_value')
+    s = Settings()
+    assert s.foobar == 'real_value'
+    assert s.__pydantic_extra__ == {}
+
+
 def test_env_settings_source_extra_allow_preserves_empty_value(env):
     """An empty-string env var is still a real value (with the default
     env_ignore_empty=False) and must be kept as an extra, not silently dropped.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2841,6 +2841,28 @@ def test_env_settings_source_extra_allow_does_not_spoof_field_by_its_own_name(en
     assert s.__pydantic_extra__ == {}
 
 
+def test_env_settings_source_extra_allow_does_not_duplicate_alias_path_head(env):
+    """A scalar field whose validation_alias is a multi-part AliasPath (e.g.
+    AliasPath('path', 'child')) is consumed, at the nested-delimiter boundary, by the
+    AliasPath-head special case in explode_env_vars/_matches_alias_path_head -- even though
+    the field's own annotation isn't "complex" by _annotation_is_complex's normal definition.
+    _merge_extra_env_vars must recognize that too, or it duplicates the already-consumed
+    value into extras under the literal nested-delimiter env var name.
+
+    Regression for a finding from automated review on PR #932.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(
+            env_prefix='APP_', env_prefix_target='alias', env_nested_delimiter='__', extra='allow'
+        )
+        x: str = Field(validation_alias=AliasPath('path', 'child'))
+
+    env.set('APP_path__child', 'value_from_path_child')
+    s = EnvSettingsSource(Settings)()
+    assert 'path__child' not in s
+
+
 def test_env_settings_source_extra_allow_preserves_empty_value(env):
     """An empty-string env var is still a real value (with the default
     env_ignore_empty=False) and must be kept as an extra, not silently dropped.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2850,6 +2850,25 @@ def test_env_settings_source_extra_allow_ignores_empty_value_when_configured(env
     assert 'option' not in s.__pydantic_extra__
 
 
+def test_env_settings_source_extra_allow_converts_none_str(env):
+    """An extra whose raw value matches env_parse_none_str becomes real None,
+    not the internal EnvNoneType sentinel leaking out as a literal string.
+
+    Caught by automated review on the PR: PydanticBaseEnvSettingsSource.__call__
+    already does this conversion for declared fields; _merge_extra_env_vars needs
+    the same conversion for extras.
+    """
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_prefix='PREFIX_', extra='allow', env_parse_none_str='null')
+        apple: str = 'default'
+
+    env.set('PREFIX_option', 'null')
+    s = Settings()
+    assert s.__pydantic_extra__ == {'option': None}
+    assert s.__pydantic_extra__['option'] is None
+
+
 def test_env_json_field(env):
     class Settings(BaseSettings):
         x: Json


### PR DESCRIPTION
## Summary

Fixes #818.

With `env_prefix` set and `extra='allow'`, an environment variable for a field not declared on the model was silently dropped instead of becoming an extra field. `EnvSettingsSource.__call__()` (inherited from `PydanticBaseEnvSettingsSource`) only ever iterates `settings_cls.model_fields` — it never looks at `extra`/undeclared vars at all. `DotEnvSettingsSource` already has equivalent logic for `.env`-file-sourced vars; plain `EnvSettingsSource` (raw `os.environ`) never got the same treatment.

## Approach

I initially tried porting `DotEnvSettingsSource`'s existing extras-merging block as-is, and I want to flag why I *didn't* end up doing that, since it's a meaningful design choice:

- **Scope is very different.** `DotEnvSettingsSource.env_vars` is scoped to a small, developer-controlled `.env` file. `EnvSettingsSource.env_vars` is effectively the entire process environment. A naive port would've offered every single OS/shell env var as a candidate extra field — I caught this locally before it went further (see test plan).
- **`extra='forbid'` is pydantic-settings' own default.** DotEnv's original logic still surfaces an unmatched var (under its raw name) even when `extra='forbid'`, so pydantic's own validation raises a clear error — reasonable for a curated `.env` file, where an unexpected entry likely means a typo. Applying that same policy to `os.environ` would mean any existing user with `env_prefix` set (extremely common) and the *default* `extra='forbid'` could start getting a brand new crash from a completely unrelated, coincidentally-prefixed env var they never had a problem with before. So this only activates for **explicit** `extra='allow'`.
- **Requires an explicit `env_prefix`.** Without one there's no safe boundary between "this app's config" and the rest of `os.environ`.
- **One more edge case I hit while testing** (see `test_env_settings_source_extra_allow_does_not_spoof_aliased_field`): a field with `validation_alias='foo'` (and the default, non-`'alias'`/`'all'` `env_prefix_target`) is looked up *unprefixed*. A var like `PREFIX_foo`, once prefix-stripped to `foo`, would otherwise be treated as an unclaimed extra under the exact key that field's own resolution expects — silently spoofing its value from a completely different, coincidentally-named variable. Added a `field_key` collision check to prevent this.

`DotEnvSettingsSource.__call__()` is otherwise untouched — its own extras logic stays exactly as it was. I did have to change one line there: it now calls `PydanticBaseEnvSettingsSource.__call__(self)` explicitly instead of `super().__call__()`, because `super()` would otherwise resolve to the new `EnvSettingsSource.__call__()` override and run extras-merging *before* `dotenv_filtering`'s `'only_existing'` mode gets to early-return, breaking its documented "just return existing fields" contract.

## Test plan

- [x] Reproduced the exact scenario from #818 (env var + JSON config source via `settings_customise_sources`) — fixed.
- [x] Caught (locally, before pushing) that a naive port would leak the entire `os.environ` as extras — added the `env_prefix` requirement to prevent it, with a regression test (`test_env_settings_source_extra_allow_no_prefix_does_not_leak_environ`).
- [x] Caught (via the existing suite) that treating `!= 'forbid'` as "allowed" broke `extra='forbid'` being the actual default — narrowed to `== 'allow'` only, with a regression test asserting `extra='forbid'` (default) stays a no-op (`test_env_settings_source_extra_forbid_unaffected`).
- [x] Caught (via the existing suite, `test_validation_alias_with_env_prefix`) the aliased-field collision described above — added the `field_key` check plus a dedicated regression test.
- [x] Added `test_env_settings_source_extra_allow` for the core fix.
- [x] Full suite: `pytest tests/ --ignore=tests/test_docs.py` (deselecting the AWS/Azure/GCP cloud-secret suites, which need live cloud credentials, and `test_docs.py`, which needs the optional `azure` extra installed — neither related to this change) → 562 passed, 5 skipped, up from 558 pre-change (4 new tests).
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy pydantic_settings` clean on the changed files (2 pre-existing, unrelated errors in `gcp.py`/`azure.py` from missing optional deps in my local env).
- [x] Documented the new behavior in `docs/index.md` under "Environment variable names".