### PR TITLE
docs: clarify alias + nested model env lookup with populate_by_name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -169,17 +169,19 @@ There are two ways to do this:
 Check the [`Field` aliases documentation](fields.md#field-aliases) for more information about aliases.
 
 !!! note
-    When a nested model field has an alias, environment variables for its sub-fields are looked up using
-    *only* that alias as the prefix — the field's own name is not considered, even for values coming from a
-    dotenv file or other sources. If different sources for the same nested field use different naming (e.g. one
-    source uses the alias, another uses the field name), only the alias-based values will be found; the rest
-    aren't recognized as belonging to that field at all. What then happens to them depends on your `extra`
-    setting: with the default `extra='forbid'`, an unmatched dotenv entry is kept as an extra input and raises
-    a `ValidationError`, while a plain environment variable (not from a dotenv file) is simply not picked up.
-    With `extra='ignore'` both are dropped silently. Either way, the underlying issue is the same: those values
-    were never associated with the field's alias in the first place. Set `populate_by_name=True` (or
-    `validate_by_name=True`) so that both the alias *and* the field's own name are recognized, letting
-    mixed-naming sources merge correctly:
+    Setting an alias on a nested model field *narrows* which environment variables can reach it: its
+    sub-fields are then looked up using only that alias as the prefix, in every source. The field's own name
+    is not an accepted name at all, including for dotenv files and other non-env sources.
+
+    This matters most when sources disagree on naming. If a higher-priority source uses the alias and a
+    lower-priority one uses the field name, only the alias-based values are found — the others were never
+    associated with the field, so there is nothing to merge and the lower-priority values appear to be
+    ignored. What happens to them depends on `extra`: with the default `extra='forbid'` an unmatched dotenv
+    entry is kept as an extra input and raises a `ValidationError`, while a plain environment variable is
+    simply not picked up; with `extra='ignore'` both are dropped silently.
+
+    To accept both spellings, widen the set of accepted names — either globally with `populate_by_name=True`
+    (or `validate_by_name=True`), or per field with `AliasChoices`. Both let mixed-naming sources merge:
 
     ```py
     import os
@@ -198,6 +200,41 @@ Check the [`Field` aliases documentation](fields.md#field-aliases) for more info
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(env_nested_delimiter='_', populate_by_name=True)
         submodel: SubModel | None = Field(alias='SUB', default=None)
+
+
+    dotenv_file = Path('example.env')
+    dotenv_file.write_text("SUBMODEL_VAR2='var2 from dotenv'")
+    os.environ['SUB_VAR1'] = 'var1 from env'
+
+    print(Settings(_env_file=dotenv_file).model_dump())
+    #> {'submodel': {'var1': 'var1 from env', 'var2': 'var2 from dotenv'}}
+    dotenv_file.unlink(missing_ok=True)
+    del os.environ['SUB_VAR1']
+    ```
+
+    `AliasChoices` is often the better fit when only some fields need both spellings — for example a
+    configuration file that spells section names out in full alongside abbreviated environment variables.
+    It states per field exactly which names are accepted, instead of accepting every field name globally:
+
+    ```py
+    import os
+    from pathlib import Path
+
+    from pydantic import AliasChoices, BaseModel, Field
+
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+    class SubModel(BaseModel):
+        var1: str | None = None
+        var2: str | None = None
+
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_nested_delimiter='_')
+        submodel: SubModel | None = Field(
+            validation_alias=AliasChoices('SUB', 'SUBMODEL'), default=None
+        )
 
 
     dotenv_file = Path('example.env')

--- a/docs/index.md
+++ b/docs/index.md
@@ -195,13 +195,13 @@ Check the [`Field` aliases documentation](fields.md#field-aliases) for more info
         submodel: SubModel | None = Field(alias='SUB', default=None)
 
 
-    dotenv_file = Path('.env')
+    dotenv_file = Path('example.env')
     dotenv_file.write_text("SUBMODEL_VAR2='var2 from dotenv'")
     os.environ['SUB_VAR1'] = 'var1 from env'
 
     print(Settings(_env_file=dotenv_file).model_dump())
     #> {'submodel': {'var1': 'var1 from env', 'var2': 'var2 from dotenv'}}
-    dotenv_file.unlink()
+    dotenv_file.unlink(missing_ok=True)
     ```
 
 To apply `env_prefix` not only to variable names but also to aliases, set `env_prefix_target='all'`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -202,6 +202,7 @@ Check the [`Field` aliases documentation](fields.md#field-aliases) for more info
     print(Settings(_env_file=dotenv_file).model_dump())
     #> {'submodel': {'var1': 'var1 from env', 'var2': 'var2 from dotenv'}}
     dotenv_file.unlink(missing_ok=True)
+    del os.environ['SUB_VAR1']
     ```
 
 To apply `env_prefix` not only to variable names but also to aliases, set `env_prefix_target='all'`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -169,9 +169,10 @@ There are two ways to do this:
 Check the [`Field` aliases documentation](fields.md#field-aliases) for more information about aliases.
 
 !!! note
-    Setting an alias on a nested model field *narrows* which environment variables can reach it: its
+    By default, setting an alias on a nested model field *narrows* which environment variables can reach it: its
     sub-fields are then looked up using only that alias as the prefix, in every source. The field's own name
-    is not an accepted name at all, including for dotenv files and other non-env sources.
+    is not accepted as a lookup prefix unless `populate_by_name=True` (or `validate_by_name=True`) is enabled,
+    including for dotenv files and other non-env sources.
 
     This matters most when sources disagree on naming. If a higher-priority source uses the alias and a
     lower-priority one uses the field name, only the alias-based values are found — the others were never

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,7 +181,8 @@ Check the [`Field` aliases documentation](fields.md#field-aliases) for more info
     simply not picked up; with `extra='ignore'` both are dropped silently.
 
     To accept both spellings, widen the set of accepted names — either globally with `populate_by_name=True`
-    (or `validate_by_name=True`), or per field with `AliasChoices`. Both let mixed-naming sources merge:
+    (or `validate_by_name=True`), or per field with [`AliasChoices`][pydantic.AliasChoices]. Both let
+    mixed-naming sources merge:
 
     ```py
     import os
@@ -214,7 +215,8 @@ Check the [`Field` aliases documentation](fields.md#field-aliases) for more info
 
     `AliasChoices` is often the better fit when only some fields need both spellings — for example a
     configuration file that spells section names out in full alongside abbreviated environment variables.
-    It states per field exactly which names are accepted, instead of accepting every field name globally:
+    It states per field exactly which names are accepted, instead of accepting every field name globally,
+    and lets you opt each nesting level into both spellings independently:
 
     ```py
     import os

--- a/docs/index.md
+++ b/docs/index.md
@@ -172,9 +172,14 @@ Check the [`Field` aliases documentation](fields.md#field-aliases) for more info
     When a nested model field has an alias, environment variables for its sub-fields are looked up using
     *only* that alias as the prefix — the field's own name is not considered, even for values coming from a
     dotenv file or other sources. If different sources for the same nested field use different naming (e.g. one
-    source uses the alias, another uses the field name), only the alias-based values will be found; the rest are
-    silently missed rather than merged in. Set `populate_by_name=True` (or `validate_by_name=True`) so that both
-    the alias *and* the field's own name are recognized, letting mixed-naming sources merge correctly:
+    source uses the alias, another uses the field name), only the alias-based values will be found; the rest
+    aren't recognized as belonging to that field at all. What then happens to them depends on your `extra`
+    setting: with the default `extra='forbid'`, an unmatched dotenv entry is kept as an extra input and raises
+    a `ValidationError`, while a plain environment variable (not from a dotenv file) is simply not picked up.
+    With `extra='ignore'` both are dropped silently. Either way, the underlying issue is the same: those values
+    were never associated with the field's alias in the first place. Set `populate_by_name=True` (or
+    `validate_by_name=True`) so that both the alias *and* the field's own name are recognized, letting
+    mixed-naming sources merge correctly:
 
     ```py
     import os

--- a/docs/index.md
+++ b/docs/index.md
@@ -168,6 +168,41 @@ There are two ways to do this:
 
 Check the [`Field` aliases documentation](fields.md#field-aliases) for more information about aliases.
 
+!!! note
+    When a nested model field has an alias, environment variables for its sub-fields are looked up using
+    *only* that alias as the prefix — the field's own name is not considered, even for values coming from a
+    dotenv file or other sources. If different sources for the same nested field use different naming (e.g. one
+    source uses the alias, another uses the field name), only the alias-based values will be found; the rest are
+    silently missed rather than merged in. Set `populate_by_name=True` (or `validate_by_name=True`) so that both
+    the alias *and* the field's own name are recognized, letting mixed-naming sources merge correctly:
+
+    ```py
+    import os
+    from pathlib import Path
+
+    from pydantic import BaseModel, Field
+
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+    class SubModel(BaseModel):
+        var1: str | None = None
+        var2: str | None = None
+
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_nested_delimiter='_', populate_by_name=True)
+        submodel: SubModel | None = Field(alias='SUB', default=None)
+
+
+    dotenv_file = Path('.env')
+    dotenv_file.write_text("SUBMODEL_VAR2='var2 from dotenv'")
+    os.environ['SUB_VAR1'] = 'var1 from env'
+
+    print(Settings(_env_file=dotenv_file).model_dump())
+    #> {'submodel': {'var1': 'var1 from env', 'var2': 'var2 from dotenv'}}
+    dotenv_file.unlink()
+    ```
 
 To apply `env_prefix` not only to variable names but also to aliases, set `env_prefix_target='all'`.
 To apply `env_prefix` only to aliases and not to variable names, set `env_prefix_target='alias'`.


### PR DESCRIPTION
## Summary

Related to #923.

I investigated #923 (nested model fields not merging across sources when the field uses an `alias`) expecting to find a source-merge-ordering bug. It isn't one: a nested field with an `alias` is looked up, in **every** source (env, dotenv, etc.), using only that alias as the prefix. I confirmed via `_extract_field_info`/`explode_env_vars` that the field's own name is never considered anywhere in the resolution pipeline unless `populate_by_name`/`validate_by_name` is set.

So when the reporter's dotenv file used `SUBMODEL_*` naming for a field aliased `SUB`, those vars were never visible to that field from any source — they weren't "lost in a merge," they were unmatched from the start and fell through as unrelated top-level extras. Setting `populate_by_name=True` (making both the alias and the plain field name valid lookup prefixes) resolves their exact repro correctly. I verified this and left a comment on #923 explaining it.

Since this is working-as-designed alias behavior rather than a bug, I don't think a code change is warranted — changing default alias-resolution semantics here could have surprising effects for other alias users, and isn't my call to make unilaterally. What I think *is* worth fixing is that this is a genuinely easy trap to fall into (I fell into it myself while investigating) and wasn't documented anywhere.

## Change

Adds a `!!! note` with a small runnable example under the alias section in `docs/index.md`, showing the gotcha and the `populate_by_name=True` fix, right where someone setting an alias on a nested field would actually be reading.

## Test plan

- [x] Verified the example's printed output matches real execution exactly.
- [x] `pytest tests/test_docs.py` → my example (`docs/index.md:186-214`... shifts to `:190-...` in the current diff) passes both the `pytest-examples` black-formatting check and its actual runtime output assertion. The only failures are 3 pre-existing, unrelated `ModuleNotFoundError: azure` examples further down the file (missing optional `azure` extra in my local env, not something this PR touches).
- [x] `docs/index.md` isn't part of the repo's `ruff` lint target (`Makefile`'s `sources = pydantic_settings tests`), so no lint step applies beyond the doc-example check above.