### PR TITLE
Ensure nested models aliased by plain strings are also reachable by their field name (#923)

### DIFF
--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -14,6 +14,7 @@ from pydantic._internal._typing_extra import (  # type: ignore[attr-defined]
     get_origin,
 )
 from pydantic._internal._utils import deep_update, is_model_class
+from pydantic.dataclasses import is_pydantic_dataclass
 from pydantic.fields import FieldInfo
 from typing_inspection.introspection import is_union_origin
 
@@ -250,6 +251,16 @@ def _unwrap_optional_annotation(annotation: Any) -> Any:
     return annotation
 
 
+def _nested_model_annotation(annotation: Any) -> bool:
+    """Whether ``annotation`` describes a nested model or pydantic dataclass.
+
+    ``Optional[T]`` is unwrapped so that a field aliased by a plain string keeps being
+    reachable by its real field name even when the field is optional (see #923).
+    """
+    annotation = _unwrap_optional_annotation(annotation)
+    return is_model_class(annotation) or is_pydantic_dataclass(annotation)
+
+
 def _has_discriminator(field_info: FieldInfo) -> bool:
     """Check if a field uses a discriminated union (via Annotated or Field(discriminator=...))."""
     if field_info.discriminator is not None:
@@ -472,6 +483,17 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
                 field_info.append((field_name, self._apply_case_sensitive(env_prefix + field_name), True))
             else:
                 field_info.append((field_name, self._apply_case_sensitive(env_prefix + field_name), False))
+        elif isinstance(v_alias, str) and _nested_model_annotation(
+            _strip_annotated(_resolve_type_alias(field.annotation))
+        ):
+            # A nested model field aliased by a plain string must also be reachable by
+            # its real field name so that lower-priority sources (e.g. a config file or
+            # another env source) which use the field name instead of the alias can
+            # populate -- and be merged with -- the same nested model (see #923).
+            # This is scoped to complex model/dataclass fields in order to leave scalar
+            # alias input behavior unchanged.
+            name_prefix = self.env_prefix if self.env_prefix_target in ('variable', 'all') else ''
+            field_info.append((field_name, self._apply_case_sensitive(name_prefix + field_name), False))
 
         return field_info
 

--- a/tests/test_precedence_and_merging.py
+++ b/tests/test_precedence_and_merging.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 from pathlib import Path
 from typing import Literal
 
-from pydantic import AliasChoices, AliasGenerator, AnyHttpUrl, Field
+from pydantic import AliasChoices, AliasGenerator, AnyHttpUrl, BaseModel, Field
 from pydantic.alias_generators import to_camel
 
 from pydantic_settings import (
@@ -163,6 +163,77 @@ def test_env_overrides_init_with_alias_choices_and_custom_source_order(env):
     env.set('data_store_path', '/env-data-2')
     s = Settings(data_store_path='/init-data')
     assert s.data_store_path == '/env-data-2'
+
+
+def test_nested_model_alias_merged_env_and_dotenv(tmp_path: Path, env):
+    """Regression for https://github.com/pydantic/pydantic-settings/issues/923
+
+    A nested model field aliased by a plain string must also be reachable by its real
+    field name, so that a lower-priority source (e.g. ``.env``) using the field name
+    prefix can populate -- and be merged with -- the nested model populated from the
+    alias prefix in env.
+    """
+    env_file = tmp_path / '.env'
+    env_file.write_text('SUBMODEL_VAR1="var1 from dotenv"\nSUBMODEL_VAR2="var2 from dotenv"\n')
+
+    class SubModel(BaseModel):
+        var1: str | None = None
+        var2: str | None = None
+
+    class Settings(BaseSettings):
+        submodel: SubModel | None = Field(alias='SUB', default=None)
+        model_config = SettingsConfigDict(env_file=env_file, env_nested_delimiter='_')
+
+    env.set('SUB_VAR1', 'var1 from env')
+    s = Settings()
+    assert s.submodel is not None
+    assert s.submodel.var1 == 'var1 from env'
+    assert s.submodel.var2 == 'var2 from dotenv'
+
+
+def test_nested_model_alias_field_name_dotenv_only(tmp_path: Path):
+    """Field-name prefix should populate an aliased nested model from dotenv alone."""
+    env_file = tmp_path / '.env'
+    env_file.write_text('SUBMODEL_VAR1="var1 from dotenv"\n')
+
+    class SubModel(BaseModel):
+        var1: str
+
+    class Settings(BaseSettings):
+        submodel: SubModel = Field(alias='SUB')
+        model_config = SettingsConfigDict(env_file=env_file, env_nested_delimiter='_')
+
+    s = Settings()
+    assert s.submodel.var1 == 'var1 from dotenv'
+
+
+def test_nested_model_alias_choices_field_name_env(env):
+    """AliasChoices listing both the alias and field name still resolve from env."""
+
+    class SubModel(BaseModel):
+        var1: str
+
+    class Settings(BaseSettings):
+        submodel: SubModel = Field(validation_alias=AliasChoices('SUB', 'SUBMODEL'))
+        model_config = SettingsConfigDict(env_nested_delimiter='_')
+
+    env.set('SUBMODEL_VAR1', 'from env')
+    s = Settings()
+    assert s.submodel.var1 == 'from env'
+
+
+def test_scalar_alias_field_name_does_not_claim_nested_prefix(tmp_path: Path):
+    """A scalar field's alias must not be broadened to its field name (see #923 scoping)."""
+    env_file = tmp_path / '.env'
+    env_file.write_text('SUBMODEL_VAR1="x"\n')
+
+    class Settings(BaseSettings):
+        sub: str = Field(alias='SUB', default='d')
+        model_config = SettingsConfigDict(env_file=env_file, env_nested_delimiter='_', extra='allow')
+
+    s = Settings()
+    assert s.sub == 'd'
+    assert s.model_extra == {'submodel_var1': 'x'}
 
 
 def test_init_kwargs_override_env_with_alias_and_extra_forbid(env):


### PR DESCRIPTION
Fixes #923

## Change

A nested model field aliased by a plain string (`Field(alias='SUB')`) is currently only reachable under the alias-based prefix in every settings source. A lower-priority source that uses the field's real name (e.g. a `.env` file with `SUBMODEL_VAR1=...`) then never contributes to that field: its values fall through to top-level extras and are never merged into the aliased nested model.

This PR makes such aliased complex fields **also resolvable by their real field name**, so both sources produce a value for the same field and the existing `deep_update` merge combines them:

```python
class SubModel(BaseModel):
    var1: str | None = None
    var2: str | None = None

class SettingsWithAlias(BaseSettings):
    submodel: SubModel | None = Field(alias='SUB', default=None)
    model_config = SettingsConfigDict(env_nested_delimiter='_')

# env:  SUB_VAR1=var1 from env
# dotenv: SUBMODEL_VAR1=var1 from dotenv, SUBMODEL_VAR2=var2 from dotenv
# result: submodel=SubModel(var1='var1 from env', var2='var2 from dotenv')
```

The change is scoped narrowly in `_extract_field_info` to nested `BaseModel` / pydantic-dataclass fields (including `Optional[...]`). Scalar fields keep their existing alias-only input behavior.

## Notes for reviewers

- The merge path in `_settings_build_values` is untouched: sources still hand back plain dicts keyed by the (uniquely normalized) alias, so `deep_update` merges as before.
- `populate_by_name=True` / explicit `AliasChoices` already worked — this instead makes the plain-string-alias case behave the same way automatically, without requiring those settings.
- Covered by tests in `tests/test_precedence_and_merging.py` for both merged split-across-sources and dotenv-only field-name sourcing, plus a guard that scalar aliases are not broadened to their field name.

## Checklist

- [x] Tests added / updated
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy pydantic_settings` passes for the changed module
- [x] Full test suite passes (613 passed, 14 skipped)
