### PR TITLE
fix: do not leak SecretStr values in ValidationError

### DIFF
--- a/pydantic_settings/sources/providers/secrets.py
+++ b/pydantic_settings/sources/providers/secrets.py
@@ -6,11 +6,16 @@ import logging
 import os
 import warnings
 from pathlib import Path
+from types import UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
+    Union,
+    get_args,
+    get_origin,
 )
 
+from pydantic import SecretBytes, SecretStr
 from pydantic.fields import FieldInfo
 
 from pydantic_settings.utils import _settings_debug_enabled, logger, path_type_label
@@ -22,6 +27,33 @@ from ..utils import InitState
 
 if TYPE_CHECKING:
     from pydantic_settings.main import BaseSettings
+
+
+def _secret_type(annotation: Any) -> type[SecretStr | SecretBytes] | None:
+    """Return SecretStr/SecretBytes if *annotation* is one of those types (or Optional/Annotated of them)."""
+    if annotation is SecretStr:
+        return SecretStr
+    if annotation is SecretBytes:
+        return SecretBytes
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(args) == 1:
+            return _secret_type(args[0])
+    if origin is not None and getattr(origin, '__name__', None) == 'Annotated':
+        args = get_args(annotation)
+        if args:
+            return _secret_type(args[0])
+    return None
+
+
+def _wrap_secret_value(field: FieldInfo, value: str) -> Any:
+    secret_cls = _secret_type(field.annotation)
+    if secret_cls is SecretStr:
+        return SecretStr(value)
+    if secret_cls is SecretBytes:
+        return SecretBytes(value.encode())
+    return value
 
 
 class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
@@ -130,7 +162,8 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
                     # Explicit encoding: `read_text()` would otherwise decode with the
                     # locale encoding, so a UTF-8 secret is corrupted on a non-UTF-8
                     # Windows code page (silently, when every byte happens to map).
-                    return path.read_text(encoding='utf-8').strip(), field_key, value_is_complex
+                    raw = path.read_text(encoding='utf-8').strip()
+                    return _wrap_secret_value(field, raw), field_key, value_is_complex
                 else:
                     warnings.warn(
                         f'attempted to load secret file "{path}" but found a {path_type_label(path)} instead.',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1864,6 +1864,36 @@ def test_prefix_on_parent(env):
     assert MySubSettings().model_dump() == {'var': 'new'}
 
 
+def test_secrets_source_does_not_leak_secretstr_in_validation_error(tmp_path):
+    """SecretsSettingsSource must not put plaintext secrets into ValidationError (#937)."""
+    the_password = 'super_secret'
+    (tmp_path / 'password').write_text(the_password)
+
+    class Settings(BaseSettings):
+        the_username: str
+        password: SecretStr
+
+        model_config = SettingsConfigDict(secrets_dir=tmp_path)
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return init_settings, file_secret_settings
+
+    settings = Settings(the_username='my_user')
+    assert settings.password.get_secret_value() == the_password
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+    assert the_password not in str(exc_info.value)
+
+
 def test_secrets_path(tmp_path):
     p = tmp_path / 'foo'
     p.write_text('foo_secret_value_str')


### PR DESCRIPTION
## Summary

Fixes #937.

`SecretsSettingsSource` loaded secret files as plain strings and passed them into `BaseModel.__init__`. When validation failed for another reason (e.g. a required field missing), `ValidationError` included the secret in `input_value`:

```
input_value={'password': 'super_secret'}
```

This wraps `SecretStr` / `SecretBytes` fields at load time so pydantic redacts them in the error. Fields that are not secret types (including JSON-shaped secrets used as nested models) stay plain strings.

## Test plan

- [x] `test_secrets_source_does_not_leak_secretstr_in_validation_error` — the #937 case
- [x] `test_secrets_path` / `test_secrets_path_utf8` / `test_secrets_path_json` — existing secrets_dir behavior unchanged