### PR TITLE
docs: show AliasChoices for nested fields with an alias

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -168,6 +168,41 @@ There are two ways to do this:
 
 Check the [`Field` aliases documentation](fields.md#field-aliases) for more information about aliases.
 
+When a nested model field has an alias, that alias **narrows** which source keys can reach it: the field's
+sub-keys are looked up only under the alias prefix, so a lower-priority source that uses the field's real name
+contributes nothing and its values are silently ignored. When you want each nesting level to accept *both* the
+alias and the field's own name explicitly, use [`AliasChoices`][pydantic.AliasChoices] instead of a single alias:
+
+```py
+import os
+from pathlib import Path
+
+from pydantic import AliasChoices, BaseModel, Field
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SubModel(BaseModel):
+    var1: str | None = None
+    var2: str | None = None
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_nested_delimiter='_')
+    submodel: SubModel | None = Field(
+        validation_alias=AliasChoices('SUB', 'SUBMODEL'), default=None
+    )
+
+
+dotenv_file = Path('example.env')
+dotenv_file.write_text("SUBMODEL_VAR2='var2 from dotenv'")
+os.environ['SUB_VAR1'] = 'var1 from env'
+
+print(Settings(_env_file=dotenv_file).model_dump())
+#> {'submodel': {'var1': 'var1 from env', 'var2': 'var2 from dotenv'}}
+dotenv_file.unlink(missing_ok=True)
+del os.environ['SUB_VAR1']
+```
 
 To apply `env_prefix` not only to variable names but also to aliases, set `env_prefix_target='all'`.
 To apply `env_prefix` only to aliases and not to variable names, set `env_prefix_target='alias'`.


### PR DESCRIPTION
## Summary

Follow-up to #923 and the closed #934. When a nested model field has an alias, that alias **narrows** which
source keys can reach it ,the field's sub-keys are only looked up under the alias prefix, so a lower-priority
source using the field's real name contributes nothing and looks silently ignored.

#933 already covers the gotcha and the `populate_by_name=True` fix. This PR adds the complementary spelling:
using `AliasChoices('SUB', 'SUBMODEL')` to make each nesting level accept both the alias and the field's own
name explicitly, with a runnable example showing the env + dotenv merge working.

## Change

- `docs/index.md`: short explanation of the narrowing behavior plus a `AliasChoices` example that merges
  `SUB_VAR1` (env, higher priority) with `SUBMODEL_VAR2` (dotenv, lower priority).

## Test plan

- Verified the example output on `2.15.0` (installed from this branch's fork): prints
  `{'submodel': {'var1': 'var1 from env', 'var2': 'var2 from dotenv'}}`.
- Confirmed the example passes the `pytest-examples` black-format check (`string_normalization=False`,
  line-length 88) unchanged.