### PR TITLE
Add env_file_depth for parent directory env file lookup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -731,7 +731,19 @@ validating them.
 
 !!! note
     If a filename is specified for `env_file`, Pydantic will only check the current working directory and
-    won't check any parent directories for the `.env` file.
+    won't check any parent directories for the `.env` file. Set `env_file_depth` to the number of
+    directory levels **up** from the current working directory that should also be checked:
+
+```py
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file='.env', env_file_depth=2)
+```
+
+    This is only used when the file is not found in the current working directory, and only applies to
+    relative paths. It can also be set via the `_env_file_depth` keyword argument on instantiation.
 
 !!! tip
     Named pipes (FIFOs) are also supported as dotenv files. This is useful for tools like

--- a/docs/index.md
+++ b/docs/index.md
@@ -735,11 +735,11 @@ validating them.
     directory levels **up** from the current working directory that should also be checked:
 
     ```py
-        from pydantic_settings import BaseSettings, SettingsConfigDict
+    from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-        class Settings(BaseSettings):
-            model_config = SettingsConfigDict(env_file='.env', env_file_depth=2)
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_file='.env', env_file_depth=2)
     ```
 
     This is only used when the file is not found in the current working directory, and only applies to

--- a/docs/index.md
+++ b/docs/index.md
@@ -734,13 +734,13 @@ validating them.
     won't check any parent directories for the `.env` file. Set `env_file_depth` to the number of
     directory levels **up** from the current working directory that should also be checked:
 
-```py
-    from pydantic_settings import BaseSettings, SettingsConfigDict
+    ```py
+        from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-    class Settings(BaseSettings):
-        model_config = SettingsConfigDict(env_file='.env', env_file_depth=2)
-```
+        class Settings(BaseSettings):
+            model_config = SettingsConfigDict(env_file='.env', env_file_depth=2)
+    ```
 
     This is only used when the file is not found in the current working directory, and only applies to
     relative paths. It can also be set via the `_env_file_depth` keyword argument on instantiation.

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -88,6 +88,13 @@ class SettingsConfigDict(ConfigDict, total=False):
     and you only want to load a specific subset into your settings model.
     """
 
+    env_file_depth: int
+    """
+    Number of levels **up** from the current working directory to attempt to find the env file.
+
+    This is only used when the env file is not found in the current working directory.
+    """
+
     pyproject_toml_depth: int
     """
     Number of levels **up** from the current working directory to attempt to find a pyproject.toml
@@ -149,6 +156,8 @@ class BaseSettings(BaseModel):
             means that the value from `model_config['env_file']` should be used. You can also pass
             `None` to indicate that environment variables should not be loaded from an env file.
         _env_file_encoding: The env file encoding, e.g. `'latin-1'`. Defaults to `None`.
+        _env_file_depth: The number of parent directories of the current working directory to
+            search for the env file if it is not found there. Defaults to `0` (no search).
         _env_ignore_empty: Ignore environment variables where the value is an empty string. Default to `False`.
         _env_nested_delimiter: The nested env values delimiter. Defaults to `None`.
         _env_nested_max_split: The nested env values maximum nesting. Defaults to `None`, which means no limit.
@@ -198,6 +207,7 @@ class BaseSettings(BaseModel):
         _env_prefix_target: EnvPrefixTarget | None = None,
         _env_file: DotenvType | None = ENV_FILE_SENTINEL,
         _env_file_encoding: str | None = None,
+        _env_file_depth: int | None = None,
         _env_ignore_empty: bool | None = None,
         _env_nested_delimiter: str | None = None,
         _env_nested_max_split: int | None = None,
@@ -233,6 +243,7 @@ class BaseSettings(BaseModel):
                 _env_prefix_target=_env_prefix_target,
                 _env_file=_env_file,
                 _env_file_encoding=_env_file_encoding,
+                _env_file_depth=_env_file_depth,
                 _env_ignore_empty=_env_ignore_empty,
                 _env_nested_delimiter=_env_nested_delimiter,
                 _env_nested_max_split=_env_nested_max_split,
@@ -294,6 +305,7 @@ class BaseSettings(BaseModel):
         _env_prefix_target: EnvPrefixTarget | None = None,
         _env_file: DotenvType | None = ENV_FILE_SENTINEL,
         _env_file_encoding: str | None = None,
+        _env_file_depth: int | None = None,
         _env_ignore_empty: bool | None = None,
         _env_nested_delimiter: str | None = None,
         _env_nested_max_split: int | None = None,
@@ -333,6 +345,7 @@ class BaseSettings(BaseModel):
         env_file_encoding = (
             _env_file_encoding if _env_file_encoding is not None else cls.model_config.get('env_file_encoding')
         )
+        env_file_depth = _env_file_depth if _env_file_depth is not None else cls.model_config.get('env_file_depth')
         env_ignore_empty = (
             _env_ignore_empty if _env_ignore_empty is not None else cls.model_config.get('env_ignore_empty')
         )
@@ -419,6 +432,7 @@ class BaseSettings(BaseModel):
             cls,
             env_file=env_file,
             env_file_encoding=env_file_encoding,
+            env_file_depth=env_file_depth,
             case_sensitive=case_sensitive,
             env_prefix=env_prefix,
             env_prefix_target=env_prefix_target,
@@ -624,6 +638,7 @@ class BaseSettings(BaseModel):
         nested_model_default_partial_update=False,
         env_file=None,
         env_file_encoding=None,
+        env_file_depth=0,
         env_ignore_empty=False,
         env_nested_delimiter=None,
         env_nested_max_split=None,

--- a/pydantic_settings/sources/providers/dotenv.py
+++ b/pydantic_settings/sources/providers/dotenv.py
@@ -17,12 +17,7 @@ from typing_inspection.introspection import is_union_origin
 
 from ...utils import _settings_debug_enabled, logger
 from ..types import ENV_FILE_SENTINEL, DotenvFiltering, DotenvType, EnvPrefixTarget
-from ..utils import (
-    InitState,
-    _annotation_is_complex,
-    _union_is_complex,
-    parse_env_vars,
-)
+from ..utils import InitState, _annotation_is_complex, _resolve_config_file, _union_is_complex, parse_env_vars
 from .env import EnvSettingsSource
 
 if TYPE_CHECKING:
@@ -39,6 +34,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
         settings_cls: type[BaseSettings],
         env_file: DotenvType | None = ENV_FILE_SENTINEL,
         env_file_encoding: str | None = None,
+        env_file_depth: int | None = None,
         dotenv_filtering: DotenvFiltering | None = None,
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,
@@ -53,6 +49,9 @@ class DotEnvSettingsSource(EnvSettingsSource):
         self.env_file = env_file if env_file != ENV_FILE_SENTINEL else settings_cls.model_config.get('env_file')
         self.env_file_encoding = (
             env_file_encoding if env_file_encoding is not None else settings_cls.model_config.get('env_file_encoding')
+        )
+        self.env_file_depth = (
+            env_file_depth if env_file_depth is not None else settings_cls.model_config.get('env_file_depth', 0)
         )
         self.dotenv_filtering = (
             dotenv_filtering if dotenv_filtering is not None else settings_cls.model_config.get('dotenv_filtering')
@@ -109,13 +108,13 @@ class DotEnvSettingsSource(EnvSettingsSource):
 
         dotenv_vars: dict[str, str | None] = {}
         for env_file in env_files:
-            env_path = Path(env_file).expanduser()
-            if env_path.is_file() or env_path.is_fifo():
+            env_path = _resolve_config_file(env_file, self.env_file_depth, allow_fifo=True)
+            if env_path is not None:
                 if debug:
                     logger.debug('Loading env file: %s', env_path.resolve())
                 dotenv_vars.update(self._read_env_file(env_path))
             elif debug:
-                logger.debug('Env file not found, skipping: %s', env_path.resolve())
+                logger.debug('Env file not found, skipping: %s', Path(env_file).expanduser().resolve())
 
         return dotenv_vars
 
@@ -182,7 +181,8 @@ class DotEnvSettingsSource(EnvSettingsSource):
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
-            f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r})'
+            f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r}, '
+            f'env_file_depth={self.env_file_depth!r})'
         )
 
 

--- a/pydantic_settings/sources/providers/dotenv.py
+++ b/pydantic_settings/sources/providers/dotenv.py
@@ -34,7 +34,6 @@ class DotEnvSettingsSource(EnvSettingsSource):
         settings_cls: type[BaseSettings],
         env_file: DotenvType | None = ENV_FILE_SENTINEL,
         env_file_encoding: str | None = None,
-        env_file_depth: int | None = None,
         dotenv_filtering: DotenvFiltering | None = None,
         case_sensitive: bool | None = None,
         env_prefix: str | None = None,
@@ -44,6 +43,7 @@ class DotEnvSettingsSource(EnvSettingsSource):
         env_ignore_empty: bool | None = None,
         env_parse_none_str: str | None = None,
         env_parse_enums: bool | None = None,
+        env_file_depth: int | None = None,
         _init_state: InitState | None = None,
     ) -> None:
         self.env_file = env_file if env_file != ENV_FILE_SENTINEL else settings_cls.model_config.get('env_file')
@@ -181,8 +181,8 @@ class DotEnvSettingsSource(EnvSettingsSource):
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(env_file={self.env_file!r}, env_file_encoding={self.env_file_encoding!r}, '
-            f'env_nested_delimiter={self.env_nested_delimiter!r}, env_prefix_len={self.env_prefix_len!r}, '
-            f'env_file_depth={self.env_file_depth!r})'
+            f'env_file_depth={self.env_file_depth!r}, env_nested_delimiter={self.env_nested_delimiter!r}, '
+            f'env_prefix_len={self.env_prefix_len!r})'
         )
 
 

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -89,6 +89,7 @@ def _resolve_config_file(file: str | os.PathLike[str], depth: int = 0, *, allow_
         return None
 
     for parent in islice(Path.cwd().parents, depth):
+        candidate = parent / file_path
         if candidate.is_file() or (allow_fifo and candidate.is_fifo()):
             return candidate
 

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations as _annotations
 
+import os
 import warnings
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import is_dataclass
 from enum import Enum
+from itertools import islice
+from pathlib import Path
 from typing import Any, TypedDict, TypeVar, cast, get_args, get_origin
 
 from pydantic import BaseModel, Json, RootModel, Secret
@@ -72,6 +75,25 @@ def parse_env_vars(
         for k, v in env_vars.items()
         if not (ignore_empty and v == '')
     }
+
+
+def _resolve_config_file(file: str | os.PathLike[str], depth: int = 0, *, allow_fifo: bool = False) -> Path | None:
+    """Resolve a config file path, optionally searching parent directories of the cwd."""
+
+    file_path = Path(file).expanduser()
+
+    if file_path.is_file() or (allow_fifo and file_path.is_fifo()):
+        return file_path
+
+    if depth <= 0 or file_path.is_absolute():
+        return None
+
+    for parent in islice(Path.cwd().resolve().parents, depth):
+        candidate = parent / file_path
+        if candidate.is_file() or (allow_fifo and candidate.is_fifo()):
+            return candidate
+
+    return None
 
 
 def _substitute_typevars(tp: Any, param_map: dict[Any, Any]) -> Any:
@@ -367,6 +389,7 @@ __all__ = [
     '_is_function',
     '_literal_has_numeric_enum',
     '_parse_env_none_str',
+    '_resolve_config_file',
     '_resolve_type_alias',
     '_strip_annotated',
     '_union_has_strict_types',

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -88,8 +88,7 @@ def _resolve_config_file(file: str | os.PathLike[str], depth: int = 0, *, allow_
     if depth <= 0 or file_path.is_absolute():
         return None
 
-    for parent in islice(Path.cwd().resolve().parents, depth):
-        candidate = parent / file_path
+    for parent in islice(Path.cwd().parents, depth):
         if candidate.is_file() or (allow_fifo and candidate.is_fifo()):
             return candidate
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1702,6 +1702,85 @@ def test_multiple_env_file(tmp_path):
     assert s.port == 8000
 
 
+def test_env_file_depth_not_searched_by_default(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text('a="test"')
+    sub = cd_tmp_path / 'sub'
+    sub.mkdir()
+    os.chdir(sub)
+
+    class Settings(BaseSettings):
+        a: str
+
+        model_config = SettingsConfigDict(env_file='.env')
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'missing'
+
+
+def test_env_file_depth_finds_parent(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text('a="test"')
+    sub = cd_tmp_path / 'x' / 'y'
+    sub.mkdir(parents=True)
+    os.chdir(sub)
+
+    class Settings(BaseSettings):
+        a: str
+
+        model_config = SettingsConfigDict(env_file='.env', env_file_depth=2)
+
+    assert Settings().a == 'test'
+
+
+def test_env_file_depth_from_init_kwarg(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text('a="test"')
+    sub = cd_tmp_path / 'sub'
+    sub.mkdir()
+    os.chdir(sub)
+
+    class Settings(BaseSettings):
+        a: str
+
+        model_config = SettingsConfigDict(env_file='.env')
+
+    assert Settings(_env_file_depth=1).a == 'test'
+
+
+def test_env_file_depth_init_kwarg_overrides_config(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text('a="test"')
+    sub = cd_tmp_path / 'sub'
+    sub.mkdir()
+    os.chdir(sub)
+
+    class Settings(BaseSettings):
+        a: str = 'default'
+
+        model_config = SettingsConfigDict(env_file='.env', env_file_depth=2)
+
+    assert Settings().a == 'test'
+    assert Settings(_env_file_depth=0).a == 'default'
+
+
+def test_multiple_env_file_depth(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text(test_default_env_file)
+    sub = cd_tmp_path / 'sub'
+    sub.mkdir()
+    (sub / '.env.prod').write_text(test_prod_env_file)
+    os.chdir(sub)
+
+    class Settings(BaseSettings):
+        debug_mode: bool
+        host: str
+        port: int
+
+        model_config = SettingsConfigDict(env_file=['.env', '.env.prod'], env_file_depth=1)
+
+    s = Settings()
+    assert s.debug_mode is False
+    assert s.host == 'https://example.com/services'
+    assert s.port == 8000
+
+
 def test_model_env_file_override_model_config(tmp_path):
     base_env = tmp_path / '.env'
     base_env.write_text(test_default_env_file)
@@ -1757,6 +1836,42 @@ def test_read_dotenv_vars(tmp_path):
         'host': 'https://example.com/services',
         'Port': '8000',
     }
+
+
+def test_read_dotenv_vars_cwd_only_by_default(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text(test_default_env_file)
+    sub = cd_tmp_path / 'sub'
+    sub.mkdir()
+    os.chdir(sub)
+
+    source = DotEnvSettingsSource(BaseSettings(), env_file='.env', env_file_encoding='utf8')
+    assert source._read_env_files() == {}
+
+
+def test_read_dotenv_vars_with_depth(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text('a=1')
+    sub = cd_tmp_path / 'a' / 'b'
+    sub.mkdir(parents=True)
+    os.chdir(sub)
+
+    source = DotEnvSettingsSource(BaseSettings(), env_file='.env', env_file_depth=2)
+    assert source._read_env_files() == {'a': '1'}
+
+    source = DotEnvSettingsSource(BaseSettings(), env_file='.env', env_file_depth=1)
+    assert source._read_env_files() == {}
+
+    source = DotEnvSettingsSource(BaseSettings(), env_file='.env')
+    assert source._read_env_files() == {}
+
+
+def test_read_dotenv_vars_absolute_path_with_depth(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text('a=1')
+    sub = cd_tmp_path / 'sub'
+    sub.mkdir()
+    os.chdir(sub)
+
+    source = DotEnvSettingsSource(BaseSettings(), env_file=sub / '.env', env_file_depth=5)
+    assert source._read_env_files() == {}
 
 
 @pytest.mark.skipif(not hasattr(os, 'mkfifo'), reason='requires os.mkfifo (Unix)')
@@ -2282,7 +2397,7 @@ def test_builtins_settings_source_repr():
         == "EnvSettingsSource(env_nested_delimiter='__', env_prefix_len=0)"
     )
     assert repr(DotEnvSettingsSource(BaseSettings, env_file='.env', env_file_encoding='utf-8')) == (
-        "DotEnvSettingsSource(env_file='.env', env_file_encoding='utf-8', env_nested_delimiter=None, env_prefix_len=0)"
+        "DotEnvSettingsSource(env_file='.env', env_file_encoding='utf-8', env_nested_delimiter=None, env_prefix_len=0, env_file_depth=0)"
     )
     assert (
         repr(SecretsSettingsSource(BaseSettings, secrets_dir='/secrets'))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1781,6 +1781,61 @@ def test_multiple_env_file_depth(cd_tmp_path):
     assert s.port == 8000
 
 
+def test_env_file_depth_nearest_wins(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text('a="top"')
+    mid = cd_tmp_path / 'mid'
+    mid.mkdir()
+    (mid / '.env').write_text('a="mid"')
+    sub = mid / 'sub'
+    sub.mkdir()
+    os.chdir(sub)
+
+    class Settings(BaseSettings):
+        a: str
+
+        model_config = SettingsConfigDict(env_file='.env', env_file_depth=2)
+
+    assert Settings().a == 'mid'
+
+
+def test_env_file_depth_nested_relative_path(cd_tmp_path):
+    (cd_tmp_path / 'cfg').mkdir()
+    (cd_tmp_path / 'cfg' / '.env').write_text('a="nested"')
+    sub = cd_tmp_path / 'sub'
+    sub.mkdir()
+    os.chdir(sub)
+
+    class Settings(BaseSettings):
+        a: str
+
+        model_config = SettingsConfigDict(env_file='cfg/.env', env_file_depth=1)
+
+    assert Settings().a == 'nested'
+
+
+def test_env_file_depth_negative(cd_tmp_path):
+    (cd_tmp_path / '.env').write_text('a="test"')
+    sub = cd_tmp_path / 'sub'
+    sub.mkdir()
+    os.chdir(sub)
+
+    class Settings(BaseSettings):
+        a: str = 'default'
+
+        model_config = SettingsConfigDict(env_file='.env', env_file_depth=-1)
+
+    assert Settings().a == 'default'
+
+
+def test_dotenv_source_positional_args_order(cd_tmp_path):
+    """`env_file_depth` must not shift the position of pre-existing positional parameters."""
+    (cd_tmp_path / '.env').write_text('a=1')
+
+    source = DotEnvSettingsSource(BaseSettings(), '.env', 'utf-8', 'only_existing')
+    assert source.dotenv_filtering == 'only_existing'
+    assert source.env_file_depth == 0
+
+
 def test_model_env_file_override_model_config(tmp_path):
     base_env = tmp_path / '.env'
     base_env.write_text(test_default_env_file)
@@ -2397,7 +2452,7 @@ def test_builtins_settings_source_repr():
         == "EnvSettingsSource(env_nested_delimiter='__', env_prefix_len=0)"
     )
     assert repr(DotEnvSettingsSource(BaseSettings, env_file='.env', env_file_encoding='utf-8')) == (
-        "DotEnvSettingsSource(env_file='.env', env_file_encoding='utf-8', env_nested_delimiter=None, env_prefix_len=0, env_file_depth=0)"
+        "DotEnvSettingsSource(env_file='.env', env_file_encoding='utf-8', env_file_depth=0, env_nested_delimiter=None, env_prefix_len=0)"
     )
     assert (
         repr(SecretsSettingsSource(BaseSettings, secrets_dir='/secrets'))


### PR DESCRIPTION
## Summary

Adds an `env_file_depth` config key that lets `env_file` be found in parent
directories of the current working directory, mirroring the existing
`pyproject_toml_depth` option.

Defaults to `0`, which preserves today's cwd-only behaviour exactly.

## Motivation

A relative `env_file` resolves against the cwd, so a project with `.env` at its
root silently falls back to defaults when a script is run from a subdirectory —
a common layout in monorepos and multi-package projects. This has come up before
(pydantic/pydantic#4058), where it was closed by documenting the behaviour rather
than making it configurable. `pyproject_toml_depth` was added afterwards and
solves the same problem for `pyproject.toml`, so this brings `.env` in line with it.

I hit this in my own project and have been working around it with a manual
upward search; making it a config key seemed better than everyone reimplementing it.

## Implementation

- `sources/utils.py`: new `_resolve_config_file(file, depth, *, allow_fifo)` helper.
  Checks the path as given, then up to `depth` parent directories of the cwd.
- `sources/providers/dotenv.py`: `_read_env_files` resolves through the helper.
- `main.py`: `env_file_depth` config key and `_env_file_depth` init argument.

Only relative paths are searched — an absolute path (or one from `~`) is either
present or missing, so walking up from it is meaningless.

## Tests

Parent lookup, depth boundary, absolute paths, init-kwarg override, and multiple
env files at different levels. 