### PR TITLE
Add an AWS Systems Manager Parameter Store settings source

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2536,6 +2536,63 @@ class AWSSecretsManagerSettings(BaseSettings):
         )
 ```
 
+## AWS Systems Manager Parameter Store
+
+You may set the following parameters:
+
+- `ssm_path`: The path hierarchy the parameters live under, for example `/prod/my-app`. Defaults to `/`.
+
+All parameters below `ssm_path` are read recursively with the [`get_parameters_by_path`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm/client/get_parameters_by_path.html)
+API (with `WithDecryption=True`, so `SecureString` parameters are decrypted). The `ssm_path` prefix is stripped from
+each parameter name, and the remaining path is used as the field name.
+
+Because Parameter Store already uses a `/`-delimited hierarchy, nested models are supported with the `/` separator.
+For example, a parameter named `/prod/my-app/sub/a` populates the `a` field of the `sub` model. You must have the same
+naming convention in the field name as in the parameter name, or use an alias.
+
+```py
+import os
+
+from pydantic import BaseModel
+
+from pydantic_settings import (
+    AWSSystemsManagerSettingsSource,
+    BaseSettings,
+    PydanticBaseSettingsSource,
+)
+
+
+class SubModel(BaseModel):
+    a: str
+
+
+class AWSSystemsManagerSettings(BaseSettings):
+    foo: str
+    bar: int
+    sub: SubModel
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        aws_systems_manager_settings = AWSSystemsManagerSettingsSource(
+            settings_cls,
+            os.environ['AWS_SSM_PATH'],
+        )
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            file_secret_settings,
+            aws_systems_manager_settings,
+        )
+```
+
 ## Azure Key Vault
 
 You must set two parameters:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2540,7 +2540,7 @@ class AWSSecretsManagerSettings(BaseSettings):
 
 You may set the following parameters:
 
-- `ssm_path`: The path hierarchy the parameters live under, for example `/prod/my-app`. Defaults to `/`.
+- `ssm_path`: The path hierarchy the parameters live under, for example `/prod/my-app`. Must start with `/`, and defaults to `/`.
 
 All parameters below `ssm_path` are read recursively with the [`get_parameters_by_path`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm/client/get_parameters_by_path.html)
 API (with `WithDecryption=True`, so `SecureString` parameters are decrypted). The `ssm_path` prefix is stripped from

--- a/pydantic_settings/__init__.py
+++ b/pydantic_settings/__init__.py
@@ -3,6 +3,7 @@ from .main import BaseSettings, CliApp, SettingsConfigDict
 from .sources import (
     CLI_SUPPRESS,
     AWSSecretsManagerSettingsSource,
+    AWSSystemsManagerSettingsSource,
     AzureKeyVaultSettingsSource,
     CliDualFlag,
     CliExplicitFlag,
@@ -34,6 +35,7 @@ from .version import VERSION
 __all__ = (
     'CLI_SUPPRESS',
     'AWSSecretsManagerSettingsSource',
+    'AWSSystemsManagerSettingsSource',
     'AzureKeyVaultSettingsSource',
     'BaseSettings',
     'CliApp',

--- a/pydantic_settings/sources/__init__.py
+++ b/pydantic_settings/sources/__init__.py
@@ -8,7 +8,7 @@ from .base import (
     PydanticBaseSettingsSource,
     get_subcommand,
 )
-from .providers.aws import AWSSecretsManagerSettingsSource
+from .providers.aws import AWSSecretsManagerSettingsSource, AWSSystemsManagerSettingsSource
 from .providers.azure import AzureKeyVaultSettingsSource
 from .providers.cli import (
     CLI_SUPPRESS,
@@ -50,6 +50,7 @@ __all__ = [
     'DEFAULT_PATH',
     'ENV_FILE_SENTINEL',
     'AWSSecretsManagerSettingsSource',
+    'AWSSystemsManagerSettingsSource',
     'AzureKeyVaultSettingsSource',
     'CliDualFlag',
     'CliExplicitFlag',

--- a/pydantic_settings/sources/providers/__init__.py
+++ b/pydantic_settings/sources/providers/__init__.py
@@ -1,6 +1,6 @@
 """Package containing individual source implementations."""
 
-from .aws import AWSSecretsManagerSettingsSource
+from .aws import AWSSecretsManagerSettingsSource, AWSSystemsManagerSettingsSource
 from .azure import AzureKeyVaultSettingsSource
 from .cli import (
     CliDualFlag,
@@ -24,6 +24,7 @@ from .yaml import YamlConfigSettingsSource
 
 __all__ = [
     'AWSSecretsManagerSettingsSource',
+    'AWSSystemsManagerSettingsSource',
     'AzureKeyVaultSettingsSource',
     'CliDualFlag',
     'CliExplicitFlag',

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
+from ...exceptions import SettingsError
 from ..utils import InitState, parse_env_vars
 from .env import EnvSettingsSource
 
@@ -111,6 +112,9 @@ class AWSSystemsManagerSettingsSource(EnvSettingsSource):
         env_parse_enums: bool | None = None,
         _init_state: InitState | None = None,
     ) -> None:
+        if not ssm_path.startswith('/'):
+            raise SettingsError(f'AWS Systems Manager path must start with "/": {ssm_path!r}')
+
         import_aws_systems_manager()
         self._ssm_client = boto3_client('ssm', region_name=region_name, endpoint_url=endpoint_url)  # type: ignore
         self._ssm_path = ssm_path

--- a/pydantic_settings/sources/providers/aws.py
+++ b/pydantic_settings/sources/providers/aws.py
@@ -9,6 +9,7 @@ from .env import EnvSettingsSource
 
 if TYPE_CHECKING:
     from types_boto3_secretsmanager.client import SecretsManagerClient
+    from types_boto3_ssm.client import SSMClient
 
     from pydantic_settings.main import BaseSettings
 
@@ -24,6 +25,17 @@ def import_aws_secrets_manager() -> None:
     except ImportError as e:  # pragma: no cover
         raise ImportError(
             'AWS Secrets Manager dependencies are not installed, run `pip install pydantic-settings[aws-secrets-manager]`'
+        ) from e
+
+
+def import_aws_systems_manager() -> None:
+    global boto3_client
+
+    try:
+        from boto3 import client as boto3_client
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            'AWS Systems Manager dependencies are not installed, run `pip install pydantic-settings[aws-systems-manager]`'
         ) from e
 
 
@@ -82,6 +94,61 @@ class AWSSecretsManagerSettingsSource(EnvSettingsSource):
         )
 
 
+class AWSSystemsManagerSettingsSource(EnvSettingsSource):
+    _ssm_path: str
+    _ssm_client: SSMClient
+
+    def __init__(
+        self,
+        settings_cls: type[BaseSettings],
+        ssm_path: str = '/',
+        region_name: str | None = None,
+        endpoint_url: str | None = None,
+        case_sensitive: bool | None = True,
+        env_prefix: str | None = None,
+        env_nested_delimiter: str | None = '/',
+        env_parse_none_str: str | None = None,
+        env_parse_enums: bool | None = None,
+        _init_state: InitState | None = None,
+    ) -> None:
+        import_aws_systems_manager()
+        self._ssm_client = boto3_client('ssm', region_name=region_name, endpoint_url=endpoint_url)  # type: ignore
+        self._ssm_path = ssm_path
+        super().__init__(
+            settings_cls,
+            case_sensitive=case_sensitive,
+            env_prefix=env_prefix,
+            env_nested_delimiter=env_nested_delimiter,
+            env_ignore_empty=False,
+            env_parse_none_str=env_parse_none_str,
+            env_parse_enums=env_parse_enums,
+            _init_state=_init_state,
+        )
+
+    def _load_env_vars(self) -> Mapping[str, str | None]:
+        prefix = self._ssm_path.rstrip('/') + '/'
+
+        paginator = self._ssm_client.get_paginator('get_parameters_by_path')
+        page_iterator = paginator.paginate(Path=self._ssm_path, Recursive=True, WithDecryption=True)
+
+        parameters: dict[str, str | None] = {}
+        for page in page_iterator:
+            for parameter in page['Parameters']:
+                key = parameter['Name'].removeprefix(prefix)
+                parameters[key] = parameter.get('Value')
+
+        return parse_env_vars(
+            parameters,
+            self.case_sensitive,
+            self.env_ignore_empty,
+            self.env_parse_none_str,
+        )
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(ssm_path={self._ssm_path!r}, env_nested_delimiter={self.env_nested_delimiter!r})'
+
+
 __all__ = [
     'AWSSecretsManagerSettingsSource',
+    'AWSSystemsManagerSettingsSource',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ yaml = ["pyyaml>=6.0.1"]
 toml = ["tomli>=2.0.1"]
 azure-key-vault = ["azure-keyvault-secrets>=4.8.0", "azure-identity>=1.16.0"]
 aws-secrets-manager = ["boto3>=1.35.0"]
+aws-systems-manager = ["boto3>=1.35.0"]
 gcp-secret-manager = [
     "google-cloud-secret-manager>=2.23.1",
 ]
@@ -70,7 +71,7 @@ linting = [
     "pyyaml",
     "ruff",
     "types-pyyaml",
-    "types-boto3[secretsmanager]",
+    "types-boto3[secretsmanager,ssm]",
 ]
 testing = [
     "coverage[toml]",
@@ -78,7 +79,7 @@ testing = [
     "pytest-examples",
     "pytest-mock",
     "pytest-pretty",
-    "moto[secretsmanager]",
+    "moto[secretsmanager,ssm]",
     "diff-cover>=9.2.0",
     "chardet<6",
 ]

--- a/tests/test_source_aws_systems_manager.py
+++ b/tests/test_source_aws_systems_manager.py
@@ -7,10 +7,8 @@ import os
 import pytest
 
 try:
-    import yaml
     from moto import mock_aws
 except ImportError:
-    yaml = None
     mock_aws = None
 
 from pydantic import BaseModel, Field
@@ -19,6 +17,7 @@ from pydantic_settings import (
     AWSSystemsManagerSettingsSource,
     BaseSettings,
     PydanticBaseSettingsSource,
+    SettingsError,
 )
 from pydantic_settings.sources.providers.aws import import_aws_systems_manager
 
@@ -32,10 +31,8 @@ except ImportError:
     aws_systems_manager = False
 
 
-MODULE = 'pydantic_settings.sources'
-
-if not yaml:
-    pytest.skip('PyYAML is not installed', allow_module_level=True)
+if not mock_aws:
+    pytest.skip('moto is not installed', allow_module_level=True)
 
 
 @pytest.mark.skipif(not aws_systems_manager, reason='pydantic-settings[aws-systems-manager] is not installed')
@@ -161,3 +158,54 @@ class TestAWSSystemsManagerSettingsSource:
         settings = obj()
 
         assert settings['foo'] == 'bar'
+
+    @mock_aws
+    def test_trailing_slash_is_normalized(self) -> None:
+        """``ssm_path`` with and without a trailing slash behave the same."""
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            foo: str
+
+        client = boto3.client('ssm')
+        client.put_parameter(Name='/test-path/foo', Value='bar', Type='String')
+
+        assert AWSSystemsManagerSettingsSource(AWSSystemsManagerSettings, '/test-path')() == {'foo': 'bar'}
+        assert AWSSystemsManagerSettingsSource(AWSSystemsManagerSettings, '/test-path/')() == {'foo': 'bar'}
+
+    @mock_aws
+    def test_sibling_path_prefix_is_not_matched(self) -> None:
+        """A path sharing a textual prefix with ``ssm_path`` is not picked up."""
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            foo: str
+
+        client = boto3.client('ssm')
+        client.put_parameter(Name='/app/foo', Value='included', Type='String')
+        client.put_parameter(Name='/app-other/bar', Value='excluded', Type='String')
+
+        assert AWSSystemsManagerSettingsSource(AWSSystemsManagerSettings, '/app')() == {'foo': 'included'}
+
+    @mock_aws
+    def test_pagination(self) -> None:
+        """All parameters are read, beyond a single ``get_parameters_by_path`` page."""
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            """AWSSystemsManager settings."""
+
+        client = boto3.client('ssm')
+        for index in range(25):
+            client.put_parameter(Name=f'/test-path/key{index:02d}', Value=str(index), Type='String')
+
+        obj = AWSSystemsManagerSettingsSource(AWSSystemsManagerSettings, '/test-path')
+
+        assert obj._load_env_vars() == {f'key{index:02d}': str(index) for index in range(25)}
+
+    @pytest.mark.parametrize('ssm_path', ['', 'test-path'])
+    def test_path_must_start_with_slash(self, ssm_path: str) -> None:
+        """An ``ssm_path`` without a leading slash is rejected up front."""
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            """AWSSystemsManager settings."""
+
+        with pytest.raises(SettingsError, match='must start with "/"'):
+            AWSSystemsManagerSettingsSource(AWSSystemsManagerSettings, ssm_path)

--- a/tests/test_source_aws_systems_manager.py
+++ b/tests/test_source_aws_systems_manager.py
@@ -1,0 +1,163 @@
+"""
+Test pydantic_settings.AWSSystemsManagerSettingsSource.
+"""
+
+import os
+
+import pytest
+
+try:
+    import yaml
+    from moto import mock_aws
+except ImportError:
+    yaml = None
+    mock_aws = None
+
+from pydantic import BaseModel, Field
+
+from pydantic_settings import (
+    AWSSystemsManagerSettingsSource,
+    BaseSettings,
+    PydanticBaseSettingsSource,
+)
+from pydantic_settings.sources.providers.aws import import_aws_systems_manager
+
+try:
+    aws_systems_manager = True
+    import_aws_systems_manager()
+    import boto3
+
+    os.environ['AWS_DEFAULT_REGION'] = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')
+except ImportError:
+    aws_systems_manager = False
+
+
+MODULE = 'pydantic_settings.sources'
+
+if not yaml:
+    pytest.skip('PyYAML is not installed', allow_module_level=True)
+
+
+@pytest.mark.skipif(not aws_systems_manager, reason='pydantic-settings[aws-systems-manager] is not installed')
+class TestAWSSystemsManagerSettingsSource:
+    """Test AWSSystemsManagerSettingsSource."""
+
+    @mock_aws
+    def test_repr(self) -> None:
+        source = AWSSystemsManagerSettingsSource(BaseSettings, '/test-path')
+        assert repr(source) == "AWSSystemsManagerSettingsSource(ssm_path='/test-path', env_nested_delimiter='/')"
+
+    @mock_aws
+    def test___init__(self) -> None:
+        """Test __init__."""
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            """AWSSystemsManager settings."""
+
+        AWSSystemsManagerSettingsSource(AWSSystemsManagerSettings, '/test-path')
+
+    @mock_aws
+    def test___call__(self) -> None:
+        """Test __call__."""
+
+        class SqlServer(BaseModel):
+            password: str = Field(..., alias='Password')
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            """AWSSystemsManager settings."""
+
+            sql_server_user: str = Field(..., alias='SqlServerUser')
+            sql_server: SqlServer = Field(..., alias='SqlServer')
+
+        client = boto3.client('ssm')
+        client.put_parameter(Name='/test-path/SqlServerUser', Value='test-user', Type='String')
+        client.put_parameter(Name='/test-path/SqlServer/Password', Value='test-password', Type='SecureString')
+
+        obj = AWSSystemsManagerSettingsSource(AWSSystemsManagerSettings, '/test-path')
+
+        settings = obj()
+
+        assert settings['SqlServerUser'] == 'test-user'
+        assert settings['SqlServer']['Password'] == 'test-password'
+
+    @mock_aws
+    def test_systems_manager_case_insensitive(self) -> None:
+        """Test systems manager getitem case insensitive."""
+
+        class SqlServer(BaseModel):
+            password: str = Field(..., alias='Password')
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            """AWSSystemsManager settings."""
+
+            sql_server_user: str
+            sql_server: SqlServer
+
+            @classmethod
+            def settings_customise_sources(
+                cls,
+                settings_cls: type[BaseSettings],
+                init_settings: PydanticBaseSettingsSource,
+                env_settings: PydanticBaseSettingsSource,
+                dotenv_settings: PydanticBaseSettingsSource,
+                file_secret_settings: PydanticBaseSettingsSource,
+            ) -> tuple[PydanticBaseSettingsSource, ...]:
+                return (AWSSystemsManagerSettingsSource(settings_cls, '/test-path', case_sensitive=False),)
+
+        client = boto3.client('ssm')
+        client.put_parameter(Name='/test-path/SQL_SERVER_USER', Value='test-user', Type='String')
+        client.put_parameter(Name='/test-path/SQL_SERVER/PASSWORD', Value='test-password', Type='SecureString')
+
+        settings = AWSSystemsManagerSettings()  # type: ignore
+
+        assert settings.sql_server_user == 'test-user'
+        assert settings.sql_server.password == 'test-password'
+
+    @mock_aws
+    def test_aws_systems_manager_settings_source(self) -> None:
+        """Test AWSSystemsManagerSettingsSource."""
+
+        class SqlServer(BaseModel):
+            password: str = Field(..., alias='Password')
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            """AWSSystemsManager settings."""
+
+            sql_server_user: str = Field(..., alias='SqlServerUser')
+            sql_server: SqlServer = Field(..., alias='SqlServer')
+
+            @classmethod
+            def settings_customise_sources(
+                cls,
+                settings_cls: type[BaseSettings],
+                init_settings: PydanticBaseSettingsSource,
+                env_settings: PydanticBaseSettingsSource,
+                dotenv_settings: PydanticBaseSettingsSource,
+                file_secret_settings: PydanticBaseSettingsSource,
+            ) -> tuple[PydanticBaseSettingsSource, ...]:
+                return (AWSSystemsManagerSettingsSource(settings_cls, '/test-path'),)
+
+        client = boto3.client('ssm')
+        client.put_parameter(Name='/test-path/SqlServerUser', Value='test-user', Type='String')
+        client.put_parameter(Name='/test-path/SqlServer/Password', Value='test-password', Type='SecureString')
+
+        settings = AWSSystemsManagerSettings()  # type: ignore
+
+        assert settings.sql_server_user == 'test-user'
+        assert settings.sql_server.password == 'test-password'
+
+    @mock_aws
+    def test_root_path(self) -> None:
+        """Parameters are read relative to a root ``ssm_path``."""
+
+        class AWSSystemsManagerSettings(BaseSettings):
+            foo: str = Field(..., alias='foo')
+
+        client = boto3.client('ssm')
+        client.put_parameter(Name='/foo', Value='bar', Type='String')
+
+        obj = AWSSystemsManagerSettingsSource(AWSSystemsManagerSettings, '/')
+
+        settings = obj()
+
+        assert settings['foo'] == 'bar'

--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1057,6 +1057,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/c7/4b0bc06f0811caa67f7e8c3ca2e637bd8cb4317c2f8839b7d643d7ace68c/moto-5.1.21-py3-none-any.whl", hash = "sha256:311a30095b08b39dd2707f161f1440d361684fe0090b9fd0751dfd1c9b022445", size = 6514163, upload-time = "2026-02-08T21:52:36.91Z" },
 ]
 
+[package.optional-dependencies]
+ssm = [
+    { name = "pyyaml" },
+]
+
 [[package]]
 name = "msal"
 version = "1.35.1"
@@ -1414,6 +1419,9 @@ dependencies = [
 aws-secrets-manager = [
     { name = "boto3" },
 ]
+aws-systems-manager = [
+    { name = "boto3" },
+]
 azure-key-vault = [
     { name = "azure-identity" },
     { name = "azure-keyvault-secrets" },
@@ -1435,14 +1443,14 @@ linting = [
     { name = "pre-commit" },
     { name = "pyyaml" },
     { name = "ruff" },
-    { name = "types-boto3", extra = ["secretsmanager"] },
+    { name = "types-boto3", extra = ["secretsmanager", "ssm"] },
     { name = "types-pyyaml" },
 ]
 testing = [
     { name = "chardet" },
     { name = "coverage", extra = ["toml"] },
     { name = "diff-cover" },
-    { name = "moto" },
+    { name = "moto", extra = ["ssm"] },
     { name = "pytest" },
     { name = "pytest-examples" },
     { name = "pytest-mock" },
@@ -1454,6 +1462,7 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'azure-key-vault'", specifier = ">=1.16.0" },
     { name = "azure-keyvault-secrets", marker = "extra == 'azure-key-vault'", specifier = ">=4.8.0" },
     { name = "boto3", marker = "extra == 'aws-secrets-manager'", specifier = ">=1.35.0" },
+    { name = "boto3", marker = "extra == 'aws-systems-manager'", specifier = ">=1.35.0" },
     { name = "google-cloud-secret-manager", marker = "extra == 'gcp-secret-manager'", specifier = ">=2.23.1" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "python-dotenv", specifier = ">=0.21.0" },
@@ -1461,7 +1470,7 @@ requires-dist = [
     { name = "tomli", marker = "extra == 'toml'", specifier = ">=2.0.1" },
     { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
-provides-extras = ["aws-secrets-manager", "azure-key-vault", "gcp-secret-manager", "toml", "yaml"]
+provides-extras = ["aws-secrets-manager", "aws-systems-manager", "azure-key-vault", "gcp-secret-manager", "toml", "yaml"]
 
 [package.metadata.requires-dev]
 linting = [
@@ -1470,14 +1479,14 @@ linting = [
     { name = "pre-commit" },
     { name = "pyyaml" },
     { name = "ruff" },
-    { name = "types-boto3", extras = ["secretsmanager"] },
+    { name = "types-boto3", extras = ["secretsmanager", "ssm"] },
     { name = "types-pyyaml" },
 ]
 testing = [
     { name = "chardet", specifier = "<6" },
     { name = "coverage", extras = ["toml"] },
     { name = "diff-cover", specifier = ">=9.2.0" },
-    { name = "moto", extras = ["secretsmanager"] },
+    { name = "moto", extras = ["secretsmanager", "ssm"] },
     { name = "pytest" },
     { name = "pytest-examples" },
     { name = "pytest-mock" },
@@ -1882,6 +1891,9 @@ wheels = [
 secretsmanager = [
     { name = "types-boto3-secretsmanager" },
 ]
+ssm = [
+    { name = "types-boto3-ssm" },
+]
 
 [[package]]
 name = "types-boto3-secretsmanager"
@@ -1893,6 +1905,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/06/2b13da1dea04e74ff941150d2fc5fa59a9a180f8e580425d21157895ed32/types_boto3_secretsmanager-1.42.8.tar.gz", hash = "sha256:9134df496a352acff861c3d046ae83740881d7aead1bc656d1ca32abcb921ae3", size = 19889, upload-time = "2025-12-11T22:12:47.67Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/63/15a5649fbf769e92d0a55c1091696d50ebb922ba77735c263c27267011df/types_boto3_secretsmanager-1.42.8-py3-none-any.whl", hash = "sha256:af75257c3c26da97a8ee470bb1a2e199a25bf70859740cdcdfb74f53853f24da", size = 27194, upload-time = "2025-12-11T22:12:39.498Z" },
+]
+
+[[package]]
+name = "types-boto3-ssm"
+version = "1.42.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/82/beff9a0368158ebd53a5c89e870f487f5a46eaff9c29332796d630a67303/types_boto3_ssm-1.42.54.tar.gz", hash = "sha256:317257f38db758df1541f0c36aefa27bcd0fb744c0b0d4b57be73061d519cf8e", size = 94228, upload-time = "2026-02-20T20:49:45.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1e/768cbf3e3a6bfa0b8dca15f48c60d9d22bf4c15093f25c973cea750d9afe/types_boto3_ssm-1.42.54-py3-none-any.whl", hash = "sha256:4dfceadad2a982727660b4c3a30693847df123d6caf69967ab905165d3c7c472", size = 95912, upload-time = "2026-02-20T20:49:43.079Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds an `AWSSystemsManagerSettingsSource` so settings can be loaded from AWS Systems Manager Parameter Store, which #399 tracks and that @hramezani invited a fresh PR for once the earlier attempt was abandoned.

The source reads every parameter under a given `ssm_path` recursively via `get_parameters_by_path` (with `WithDecryption=True`), strips the path prefix, and uses `/` as the nested delimiter so Parameter Store's native hierarchy maps straight onto nested models. It mirrors the existing `AWSSecretsManagerSettingsSource` in the same module and reuses `EnvSettingsSource` for parsing, so the behaviour (case sensitivity, aliases, nesting) is consistent with the other cloud sources. `boto3` stays optional behind a new `aws-systems-manager` extra.

I added tests with `moto` covering nesting, case-insensitive lookups, the full `settings_customise_sources` flow and a root path, plus a docs section next to the AWS Secrets Manager one. `make lint`, `make mypy` and the test suite pass locally.

Closes #399.