### PR TITLE
docs: improve ENV_FILE_SENTINEL comment phrasing in sources/types.py

### DIFF
--- a/pydantic_settings/sources/types.py
+++ b/pydantic_settings/sources/types.py
@@ -44,8 +44,8 @@ ConfigFileSourceType = Path | str | Traversable | Sequence[Path | str | Traversa
 DotenvFiltering = Literal['match_prefix', 'only_existing']
 DEFAULT_PATH: PathType = Path('')
 
-# This is used as default value for `_env_file` in the `BaseSettings` class and
-# `env_file` in `DotEnvSettingsSource` so the default can be distinguished from `None`.
+# This is used as the default value for `_env_file` in the `BaseSettings` class and
+# `env_file` in `DotEnvSettingsSource` so that the default can be distinguished from `None`.
 # See the docstring of `BaseSettings` for more details.
 ENV_FILE_SENTINEL: DotenvType = Path('')
 


### PR DESCRIPTION
### Summary
- Improve grammatical phrasing in `ENV_FILE_SENTINEL` comment within `pydantic_settings/sources/types.py`.