### PR TITLE
fix: use self.cli_prefix instead of cli_prefix in CliSettingsSource constructor

### DIFF
--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -423,8 +423,12 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         )
         self._cli_flag_prefix = self.cli_flag_prefix_char * 2
         if self.cli_prefix:
-            if cli_prefix.startswith('.') or cli_prefix.endswith('.') or not cli_prefix.replace('.', '').isidentifier():  # type: ignore
-                raise SettingsError(f'CLI settings source prefix is invalid: {cli_prefix}')
+            if (
+                self.cli_prefix.startswith('.')
+                or self.cli_prefix.endswith('.')
+                or not self.cli_prefix.replace('.', '').isidentifier()
+            ):
+                raise SettingsError(f'CLI settings source prefix is invalid: {self.cli_prefix}')
             self.cli_prefix += '.'
         self.cli_implicit_flags = (
             cli_implicit_flags

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -2530,6 +2530,24 @@ def test_cli_flag_prefix_char():
     assert cfg.model_dump() == {'my_var': 'hello'}
 
 
+def test_cli_prefix_from_model_config():
+    class Cfg(BaseSettings, cli_prefix='cfg'):
+        my_var: str
+
+    cfg = CliApp.run(Cfg, cli_args=['--cfg.my_var=hello'])
+    assert cfg.model_dump() == {'my_var': 'hello'}
+
+    assert '--cfg.my_var' in CliApp.format_help(Cfg)
+
+    for invalid_prefix in ('.cfg', 'cfg.', '123'):
+
+        class InvalidCfg(BaseSettings, cli_prefix=invalid_prefix):
+            my_var: str = ''
+
+        with pytest.raises(SettingsError, match=f'CLI settings source prefix is invalid: {re.escape(invalid_prefix)}'):
+            CliSettingsSource(InvalidCfg)
+
+
 @pytest.mark.parametrize('parser_type', [pytest.Parser, argparse.ArgumentParser, CliDummyParser])
 @pytest.mark.parametrize('prefix', ['', 'cfg'])
 def test_cli_user_settings_source(parser_type, prefix):


### PR DESCRIPTION
Currently, the `CliSettingsSource` constructor uses the variable `cli_prefix` in its constructor (line 426) where it might be None, instead of using `this.cli_prefix`.

This causes an error with the following code:

```python
class SomethingSettings(BaseSettings):
    url: str

    model_config = SettingsConfigDict(cli_parse_args=True, cli_prefix="some_prefix")

print(CliApp.format_help(SomethingSettings))
```