### PR TITLE
Enable ruff's flake8-return (RET) rules

### DIFF
--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -529,10 +529,9 @@ class BaseSettings(BaseModel):
             cls._settings_restore_init_kwarg_names(cls, init_kwargs, state, init_state)
 
             return state
-        else:
-            # no one should mean to do this, but I think returning an empty dict is marginally preferable
-            # to an informative error and much better than a confusing error
-            return {}
+        # no one should mean to do this, but I think returning an empty dict is marginally preferable
+        # to an informative error and much better than a confusing error
+        return {}
 
     @classmethod
     def _settings_log_debug(cls, states: dict[str, dict[str, Any]]) -> None:
@@ -875,8 +874,7 @@ class CliApp:
             if err.__context__ is None and err.__cause__ is None and cli_settings_source._format_help is not None:
                 error_message = f'{err}\n{cli_settings_source._format_help(parser)}'
                 raise type(err)(error_message) from None
-            else:
-                raise err
+            raise err
 
         subcommand_cls = cast(type[BaseModel], type(subcommand))
         subcommand_arg = cli_settings_source._parser_map[subcommand_dest][subcommand_cls]

--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -518,8 +518,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
             if not annotation or not hasattr(annotation, 'model_fields'):
                 values[name] = value
                 continue
-            else:
-                model_fields: dict[str, FieldInfo] = annotation.model_fields
+            model_fields: dict[str, FieldInfo] = annotation.model_fields
 
             # Find field in sub model by looking in fields case insensitively
             field_key: str | None = None

--- a/pydantic_settings/sources/providers/azure.py
+++ b/pydantic_settings/sources/providers/azure.py
@@ -147,8 +147,7 @@ class AzureKeyVaultSettingsSource(EnvSettingsSource):
 
     def _extract_field_info(self, field: FieldInfo, field_name: str) -> list[tuple[str, str, bool]]:
         if self._snake_case_conversion:
-            field_info = [(x[0], x[1], x[2]) for x in super()._extract_field_info(field, field_name)]
-            return field_info
+            return [(x[0], x[1], x[2]) for x in super()._extract_field_info(field, field_name)]
 
         if self._dash_to_underscore:
             return [(x[0], x[1].replace('_', '-'), x[2]) for x in super()._extract_field_info(field, field_name)]

--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -245,7 +245,7 @@ class _CliArg(BaseModel):
                 raise SettingsError(
                     f'CliSubCommand is not outermost annotation for {self.model.__name__}.{self.field_name}'
                 )
-            elif _annotation_contains_types(type_, (_CliPositionalArg,), is_include_origin=False):
+            if _annotation_contains_types(type_, (_CliPositionalArg,), is_include_origin=False):
                 raise SettingsError(
                     f'CliPositionalArg is not outermost annotation for {self.model.__name__}.{self.field_name}'
                 )
@@ -546,16 +546,15 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
     ) -> dict[str, Any] | CliSettingsSource[T]:
         if args is not None and parsed_args is not None:
             raise SettingsError('`args` and `parsed_args` are mutually exclusive')
-        elif args is not None:
+        if args is not None:
             if args is False:
                 return self._load_env_vars(parsed_args={})
             if args is True:
                 args = sys.argv[1:]
             return self._load_env_vars(parsed_args=self._parse_args(self.root_parser, args))
-        elif parsed_args is not None:
+        if parsed_args is not None:
             return self._load_env_vars(parsed_args=copy.copy(parsed_args))
-        else:
-            return super().__call__()
+        return super().__call__()
 
     @overload
     def _load_env_vars(self) -> Mapping[str, str | None]: ...
@@ -765,13 +764,12 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
 
             if merge_type is str:
                 return merged_list[0]
-            elif merge_type is list:
+            if merge_type is list:
                 return self._merged_list_to_str(merged_list, field_name)
-            else:
-                merged_dict: dict[str, str] = {}
-                for item in merged_list:
-                    merged_dict.update(json.loads(item))
-                return json.dumps(merged_dict)
+            merged_dict: dict[str, str] = {}
+            for item in merged_list:
+                merged_dict.update(json.loads(item))
+            return json.dumps(merged_dict)
         except Exception as e:
             raise SettingsError(f'Parsing error encountered for {field_name}: {e}') from e
 
@@ -853,16 +851,15 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             if _CliSubCommand in field_info.metadata:
                 if not field_info.is_required():
                     raise SettingsError(f'subcommand argument {model.__name__}.{field_name} has a default value')
-                else:
-                    alias_names, *_ = _get_alias_names(field_name, field_info)
-                    if len(alias_names) > 1:
-                        raise SettingsError(f'subcommand argument {model.__name__}.{field_name} has multiple aliases')
-                    field_types = [type_ for type_ in get_args(field_info.annotation) if type_ is not type(None)]
-                    for field_type in field_types:
-                        if not (is_model_class(field_type) or is_pydantic_dataclass(field_type)):
-                            raise SettingsError(
-                                f'subcommand argument {model.__name__}.{field_name} has type not derived from BaseModel'
-                            )
+                alias_names, *_ = _get_alias_names(field_name, field_info)
+                if len(alias_names) > 1:
+                    raise SettingsError(f'subcommand argument {model.__name__}.{field_name} has multiple aliases')
+                field_types = [type_ for type_ in get_args(field_info.annotation) if type_ is not type(None)]
+                for field_type in field_types:
+                    if not (is_model_class(field_type) or is_pydantic_dataclass(field_type)):
+                        raise SettingsError(
+                            f'subcommand argument {model.__name__}.{field_name} has type not derived from BaseModel'
+                        )
                 subcommand_args.append((field_name, field_info))
             elif _CliPositionalArg in field_info.metadata:
                 alias_names, *_ = _get_alias_names(field_name, field_info)
@@ -883,7 +880,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             if len(positional_variadic_arg) > 1:
                 field_names = ', '.join([name for name, info in positional_variadic_arg])
                 raise SettingsError(f'{model.__name__} has multiple variadic positional arguments: {field_names}')
-            elif subcommand_args:
+            if subcommand_args:
                 field_names = ', '.join([name for name, info in positional_variadic_arg + subcommand_args])
                 raise SettingsError(
                     f'{model.__name__} has variadic positional arguments and subcommand arguments: {field_names}'
@@ -922,7 +919,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
 
             return parse_args_insensitive_method
 
-        elif parser_method is None:
+        if parser_method is None:
 
             def none_parser_method(*args: Any, **kwargs: Any) -> Any:
                 raise SettingsError(
@@ -931,8 +928,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
 
             return none_parser_method
 
-        else:
-            return parser_method
+        return parser_method
 
     def _connect_group_method(self, add_argument_group_method: Callable[..., Any] | None) -> Callable[..., Any]:
         add_argument_group = self._connect_parser_method(add_argument_group_method, 'add_argument_group_method')
@@ -941,16 +937,15 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             if not kwargs.pop('_is_cli_mutually_exclusive_group'):
                 kwargs.pop('required')
                 return add_argument_group(parser, **kwargs)
-            else:
-                main_group_kwargs = {arg: kwargs.pop(arg) for arg in ['title', 'description'] if arg in kwargs}
-                main_group_kwargs['title'] += ' (mutually exclusive)'
-                group = add_argument_group(parser, **main_group_kwargs)
-                if not hasattr(group, 'add_mutually_exclusive_group'):
-                    raise SettingsError(
-                        'cannot connect CLI settings source root parser: '
-                        'group object is missing add_mutually_exclusive_group but is needed for connecting'
-                    )
-                return group.add_mutually_exclusive_group(**kwargs)
+            main_group_kwargs = {arg: kwargs.pop(arg) for arg in ['title', 'description'] if arg in kwargs}
+            main_group_kwargs['title'] += ' (mutually exclusive)'
+            group = add_argument_group(parser, **main_group_kwargs)
+            if not hasattr(group, 'add_mutually_exclusive_group'):
+                raise SettingsError(
+                    'cannot connect CLI settings source root parser: '
+                    'group object is missing add_mutually_exclusive_group but is needed for connecting'
+                )
+            return group.add_mutually_exclusive_group(**kwargs)
 
         return add_group_method
 
@@ -1416,8 +1411,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
     def _get_modified_args(self, obj: Any) -> tuple[str, ...]:
         if not self.cli_hide_none_type:
             return get_args(obj)
-        else:
-            return tuple([type_ for type_ in get_args(obj) if type_ is not type(None)])
+        return tuple([type_ for type_ in get_args(obj) if type_ is not type(None)])
 
     def _metavar_format_choices(self, args: list[str], obj_qualname: str | None = None) -> str:
         if 'JSON' in args:
@@ -1425,8 +1419,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         metavar = ','.join(args)
         if obj_qualname:
             return f'{obj_qualname}[{metavar}]'
-        else:
-            return metavar if len(args) == 1 else f'{{{metavar}}}'
+        return metavar if len(args) == 1 else f'{{{metavar}}}'
 
     def _metavar_format_recurse(self, obj: Any) -> str:
         """Pretty metavar representation of a type. Adapts logic from `pydantic._repr.display_as_type`."""
@@ -1434,11 +1427,11 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         if _is_function(obj):
             # If function is locally defined use __name__ instead of __qualname__
             return obj.__name__ if '<locals>' in obj.__qualname__ else obj.__qualname__
-        elif obj is ...:
+        if obj is ...:
             return '...'
-        elif isinstance(obj, Representation):
+        if isinstance(obj, Representation):
             return repr(obj)
-        elif isinstance(obj, typing.ForwardRef) or typing_objects.is_typealiastype(obj):
+        if isinstance(obj, typing.ForwardRef) or typing_objects.is_typealiastype(obj):
             return str(obj)
 
         if not isinstance(obj, (_typing_base, _WithArgsTypes, type)):
@@ -1447,29 +1440,28 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
         origin = get_origin(obj)
         if is_union_origin(origin):
             return self._metavar_format_choices(list(map(self._metavar_format_recurse, self._get_modified_args(obj))))
-        elif typing_objects.is_literal(origin):
+        if typing_objects.is_literal(origin):
             return self._metavar_format_choices(list(map(str, self._get_modified_args(obj))))
-        elif _lenient_issubclass(obj, Enum):
+        if _lenient_issubclass(obj, Enum):
             return self._metavar_format_choices(
                 [_CliArg.get_kebab_case(name, self.cli_kebab_case == 'all') for name in obj.__members__]
             )
-        elif isinstance(obj, _WithArgsTypes):
+        if isinstance(obj, _WithArgsTypes):
             return self._metavar_format_choices(
                 list(map(self._metavar_format_recurse, self._get_modified_args(obj))),
                 obj_qualname=obj.__qualname__ if hasattr(obj, '__qualname__') else str(obj),
             )
-        elif obj is type(None):
+        if obj is type(None):
             return self.cli_parse_none_str
-        elif is_model_class(obj) or is_pydantic_dataclass(obj):
+        if is_model_class(obj) or is_pydantic_dataclass(obj):
             return (
                 self._metavar_format_recurse(_get_model_fields(obj)['root'].annotation)
                 if getattr(obj, '__pydantic_root_model__', False)
                 else 'JSON'
             )
-        elif isinstance(obj, type):
+        if isinstance(obj, type):
             return obj.__qualname__
-        else:
-            return repr(obj).replace('typing.', '').replace('typing_extensions.', '')
+        return repr(obj).replace('typing.', '').replace('typing_extensions.', '')
 
     def _metavar_format(self, obj: Any) -> str:
         return self._metavar_format_recurse(obj).replace(', ', ',')

--- a/pydantic_settings/sources/providers/env.py
+++ b/pydantic_settings/sources/providers/env.py
@@ -141,7 +141,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         if is_complex or value_is_complex:
             if isinstance(value, EnvNoneType):
                 return value
-            elif value is None:
+            if value is None:
                 # field is complex but no value found so far, try explode_env_vars
                 env_val_built = self.explode_env_vars(field_name, field, self.env_vars)
                 if env_val_built:
@@ -156,11 +156,13 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
 
                 if isinstance(value, dict):
                     return deep_update(value, self.explode_env_vars(field_name, field, self.env_vars))
-                else:
-                    return value
+                return value
         elif value is not None:
             # simplest case, field is not complex, we only need to add the value if it was found
             return self._coerce_env_val_strict(field, value)
+
+        # No value resolved for this field; `None` tells the caller to skip it.
+        return None
 
     def _matches_alias_path_head(self, field: FieldInfo | Any | None, key: str) -> bool:
         """
@@ -253,7 +255,7 @@ class EnvSettingsSource(PydanticBaseEnvSettingsSource):
         if _lenient_issubclass(get_origin(annotation), dict):
             # get value type if it's a dict
             return get_args(annotation)[-1]
-        elif is_model_class(annotation) or is_pydantic_dataclass(annotation):  # type: ignore[arg-type]
+        if is_model_class(annotation) or is_pydantic_dataclass(annotation):  # type: ignore[arg-type]
             fields = _get_model_fields(annotation)
             # `case_sensitive is None` is here to be compatible with the old behavior.
             # Has to be removed in V3.

--- a/pydantic_settings/sources/providers/nested_secrets.py
+++ b/pydantic_settings/sources/providers/nested_secrets.py
@@ -93,8 +93,7 @@ class NestedSecretsSettingsSource(EnvSettingsSource):
         if self.secrets_nested_subdir:
             if secrets_nested_delimiter or conf.get('secrets_nested_delimiter'):
                 raise SettingsError('Options secrets_nested_delimiter and secrets_nested_subdir are mutually exclusive')
-            else:
-                self.secrets_nested_delimiter = os.sep
+            self.secrets_nested_delimiter = os.sep
 
         # ensure valid secrets_path
         if self.secrets_dir is None:

--- a/pydantic_settings/sources/providers/secrets.py
+++ b/pydantic_settings/sources/providers/secrets.py
@@ -135,11 +135,10 @@ class SecretsSettingsSource(PydanticBaseEnvSettingsSource):
                     # locale encoding, so a UTF-8 secret is corrupted on a non-UTF-8
                     # Windows code page (silently, when every byte happens to map).
                     return path.read_text(encoding='utf-8').strip(), field_key, value_is_complex
-                else:
-                    warnings.warn(
-                        f'attempted to load secret file "{path}" but found a {path_type_label(path)} instead.',
-                        stacklevel=4,
-                    )
+                warnings.warn(
+                    f'attempted to load secret file "{path}" but found a {path_type_label(path)} instead.',
+                    stacklevel=4,
+                )
 
         return None, field_key, value_is_complex
 

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -268,8 +268,7 @@ def _annotation_contains_types(
 def _strip_annotated(annotation: Any) -> Any:
     if typing_objects.is_annotated(get_origin(annotation)):
         return annotation.__origin__
-    else:
-        return annotation
+    return annotation
 
 
 def _annotation_enum_val_to_name(annotation: type[Any] | None, value: Any) -> str | None:
@@ -342,7 +341,7 @@ def _get_alias_names(
         for alias in (field_info.alias, field_info.validation_alias):
             if alias is None:
                 continue
-            elif isinstance(alias, str):
+            if isinstance(alias, str):
                 alias_names.append(alias)
                 is_alias_path_only = False
             elif isinstance(alias, AliasChoices):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ extend-select = [
     'Q', 'RUF100', 'C90', 'UP', 'I', 'B', 'RUF036',
     # Rule sets the codebase already satisfies; selected to keep it that way.
     'C4', 'PIE', 'PERF', 'ISC', 'ICN', 'LOG', 'G', 'INT', 'DTZ', 'YTT', 'ASYNC', 'FLY',
-    'FURB110', 'PTH201', 'RSE102', 'RUF043',
+    'FURB110', 'PTH201', 'RSE102', 'RUF043', 'RET',
 ]
 ignore = [
     # Selecting `B` also matches the `BLE` prefix. Defensive/fallback code in the

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -20,6 +20,8 @@ def skip_docs_tests():
     if platform.python_implementation() != 'CPython':
         return 'not cpython'
 
+    return None
+
 
 class GroupModuleGlobals:
     def __init__(self) -> None:
@@ -29,6 +31,8 @@ class GroupModuleGlobals:
     def get(self, name: str | None):
         if name is not None and name == self.name:
             return self.module_dict
+
+        return None
 
     def set(self, name: str | None, module_dict: dict[str, str]):
         self.name = name

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2681,10 +2681,9 @@ def test_discriminated_union_with_callable_discriminator(env):
 
         if v0 == 'a':
             return 'a'
-        elif v0 == 'b':
+        if v0 == 'b':
             return 'b'
-        else:
-            return None
+        return None
 
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(env_nested_delimiter='__')


### PR DESCRIPTION
## Summary

Follow-up to #950, which left `RET` as the remaining candidate from the rule survey.

Selects `RET` and fixes the 39 violations it reports (the earlier survey counted 26 — fixing one nesting level exposes more).

| Rule | Count | What it is |
|---|---|---|
| `RET505`/`RET506`/`RET507` | 35 | `else` after a `return`/`raise`/`continue` — dropping it flattens a level of nesting |
| `RET503` | 3 | implicit `return None` made explicit |
| `RET504` | 1 | temp variable assigned immediately before its `return` |

35 were autofixed. Four needed a judgement call:

- **`azure.py`** — dropped a temp var that was assigned and immediately returned.
- **`env.py`** — `prepare_field_value` has real paths that fall off the end (complex field, `value is None`, `explode_env_vars` empty). The implicit `None` there *means* "no value resolved", so it's now an explicit `return None` with a comment saying so.
- **`test_docs.py`** (×2) — `skip_docs_tests` returns a reason-or-nothing and `GroupModuleGlobals.get` returns dict-or-nothing; both use implicit `None` as a sentinel, now explicit.

## The one transform worth reviewing closely

In `_sort_arg_fields` (`cli.py`) a block dedents out of an `else`, which is the shape where this rule family *could* change reachability. It's equivalent here:

```python
if _CliSubCommand in field_info.metadata:
    if not field_info.is_required():
        raise SettingsError(...)      # <- guarantees the rest is else-only
    alias_names, *_ = _get_alias_names(...)
    ...
    subcommand_args.append(...)        # <- was already outside the else
```

The preceding `raise` means the dedented code is reachable only when the `else` would have run, and the trailing `append` was already outside the `else` before this change.

## Verification

- `make lint` — clean
- `make mypy` — clean
- Full suite — 723 passed, 5 skipped
- `tests/test_docs.py` — 76 passed

That last one is the check that mattered: `pytest-examples` lints the `docs/index.md` snippets against this same ruff config, which is what ruled out `T201` and `ERA001` in #950. `RET` is clear there.

Note: the `cli.py:137` mypy failure mentioned in #950 as pre-existing is now gone — it was resolved upstream, not by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaHmJQbb3GND3DAHX5zuRt