### PR TITLE
Add cached settings instances

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3574,10 +3574,12 @@ clearing: `settings_clear_cache()` only removes the entry for the exact class it
 through a base class, clear each subclass you have cached as well, otherwise those subclasses keep serving their
 existing instances.
 
-The cache is local to each process. The cached object is shared and remains mutable unless the settings model is
-configured as frozen. A cached instance keeps its own class alive for the lifetime of the process, which is what makes
-it a singleton. If you build settings classes dynamically and need them collected, call `settings_clear_cache()` when
-you are done with one, and its cache entry is dropped.
+The cache is local to each process. The cached object is shared, so any change to it is seen by every caller.
+Configuring the model as frozen only prevents assigning to its attributes; it does not freeze the values themselves, so
+a mutable field such as a list or dict can still be updated in place and that change is shared process-wide. A cached
+instance keeps its own class alive for the lifetime of the process, which is what makes it a singleton. If you build
+settings classes dynamically and need them collected, call `settings_clear_cache()` when you are done with one, and its
+cache entry is dropped.
 
 Since `settings_cached` and `settings_clear_cache` are added to `protected_namespaces`, defining a field whose name
 starts with either of those raises a `UserWarning`. If you already have such a field, rename it or override

--- a/docs/index.md
+++ b/docs/index.md
@@ -3569,8 +3569,19 @@ Settings.settings_clear_cache()
 Calling the settings class directly continues to create a fresh instance. Calling `settings_clear_cache()` removes the
 cached instance for that class, so that the next `settings_cached()` call loads the settings sources again.
 
+Each class is cached under its own key, so a subclass never shares an instance with its parent. This also applies when
+clearing: `settings_clear_cache()` only removes the entry for the exact class it is called on. If you reload settings
+through a base class, clear each subclass you have cached as well, otherwise those subclasses keep serving their
+existing instances.
+
 The cache is local to each process. The cached object is shared and remains mutable unless the settings model is
-configured as frozen.
+configured as frozen. A cached instance keeps its own class alive for the lifetime of the process, which is what makes
+it a singleton. If you build settings classes dynamically and need them collected, call `settings_clear_cache()` when
+you are done with one, and its cache entry is dropped.
+
+Since `settings_cached` and `settings_clear_cache` are added to `protected_namespaces`, defining a field whose name
+starts with either of those raises a `UserWarning`. If you already have such a field, rename it or override
+`protected_namespaces` in your model config.
 
 
 ## Async environments

--- a/docs/index.md
+++ b/docs/index.md
@@ -3527,6 +3527,52 @@ print(mutable_settings.foo)
 ```
 
 
+## Caching settings
+
+Constructing a settings model reads and validates its configured settings sources each time. This can be costly when
+sources read from disk, such as dotenv, secrets, JSON, TOML, or YAML files, or retrieve secrets from cloud secret
+managers and parameter stores. Use `settings_cached()` when an application needs one default settings instance per
+settings class and process:
+
+```py
+import os
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    foo: str = 'foo'
+
+
+settings = Settings.settings_cached()
+
+print(settings.foo)
+#> foo
+
+os.environ['foo'] = 'bar'
+print(Settings.settings_cached().foo)
+#> foo
+
+print(Settings().foo)
+#> bar
+
+Settings.settings_clear_cache()
+reloaded_settings = Settings.settings_cached()
+
+print(reloaded_settings.foo)
+#> bar
+
+os.environ.pop('foo')
+Settings.settings_clear_cache()
+```
+
+Calling the settings class directly continues to create a fresh instance. Calling `settings_clear_cache()` removes the
+cached instance for that class, so that the next `settings_cached()` call loads the settings sources again.
+
+The cache is local to each process. The cached object is shared and remains mutable unless the settings model is
+configured as frozen.
+
+
 ## Async environments
 
 Settings are loaded synchronously. When you use sources that read from disk, such as dotenv, secrets, JSON, TOML, or

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -285,23 +285,25 @@ class BaseSettings(BaseModel):
         The instance is constructed on first use and reused afterwards. Subclasses are cached
         separately, so caching a class does not affect its parents or children.
         """
-        settings = _settings_cache.get(cls)
-        if settings is not None:
-            return cast(Self, settings)
-
         with _settings_cache_guard:
+            settings = _settings_cache.get(cls)
+            if settings is not None:
+                return cast(Self, settings)
             lock = _settings_cache_locks.get(cls)
             if lock is None:
                 lock = _settings_cache_locks.setdefault(cls, threading.Lock())
 
-        # The class is constructed outside of the global guard so that settings sources which
-        # wait on other threads, e.g. cloud secret managers, cannot deadlock the cache, and so
-        # that unrelated settings classes can be loaded concurrently.
+        # The settings are constructed without holding `_settings_cache_guard` so that sources
+        # which wait on other threads, e.g. cloud secret managers, cannot deadlock the cache,
+        # and so that unrelated settings classes can be loaded concurrently. The per-class lock
+        # keeps a class from being built more than once.
         with lock:
-            settings = _settings_cache.get(cls)
+            with _settings_cache_guard:
+                settings = _settings_cache.get(cls)
             if settings is None:
                 settings = cls()
-                _settings_cache[cls] = settings
+                with _settings_cache_guard:
+                    _settings_cache[cls] = settings
             return cast(Self, settings)
 
     @classmethod
@@ -310,8 +312,12 @@ class BaseSettings(BaseModel):
 
         Only the cache entry for this exact class is removed. Subclasses keep their own cached
         instances and must be cleared individually.
+
+        A `settings_cached()` call already in flight may still return the instance it was
+        building, so clearing does not retroactively invalidate references other threads hold.
         """
-        _settings_cache.pop(cls, None)
+        with _settings_cache_guard:
+            _settings_cache.pop(cls, None)
 
     @classmethod
     def settings_customise_sources(

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -10,6 +10,7 @@ from argparse import Namespace
 from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Any, ClassVar, Literal, TextIO, TypeVar, cast
+from weakref import WeakKeyDictionary
 
 from pydantic import ConfigDict
 from pydantic._internal._config import config_keys
@@ -46,8 +47,9 @@ from .utils import _settings_debug_enabled, logger
 
 T = TypeVar('T')
 
-_settings_cache: dict[type[BaseSettings], BaseSettings] = {}
-_settings_cache_lock = threading.RLock()
+_settings_cache: WeakKeyDictionary[type[BaseSettings], BaseSettings] = WeakKeyDictionary()
+_settings_cache_locks: WeakKeyDictionary[type[BaseSettings], threading.Lock] = WeakKeyDictionary()
+_settings_cache_guard = threading.Lock()
 
 
 class SettingsConfigDict(ConfigDict, total=False):
@@ -278,8 +280,24 @@ class BaseSettings(BaseModel):
 
     @classmethod
     def settings_cached(cls) -> Self:
-        """Return the cached default settings instance for this settings class."""
-        with _settings_cache_lock:
+        """Return the cached default settings instance for this settings class.
+
+        The instance is constructed on first use and reused afterwards. Subclasses are cached
+        separately, so caching a class does not affect its parents or children.
+        """
+        settings = _settings_cache.get(cls)
+        if settings is not None:
+            return cast(Self, settings)
+
+        with _settings_cache_guard:
+            lock = _settings_cache_locks.get(cls)
+            if lock is None:
+                lock = _settings_cache_locks.setdefault(cls, threading.Lock())
+
+        # The class is constructed outside of the global guard so that settings sources which
+        # wait on other threads, e.g. cloud secret managers, cannot deadlock the cache, and so
+        # that unrelated settings classes can be loaded concurrently.
+        with lock:
             settings = _settings_cache.get(cls)
             if settings is None:
                 settings = cls()
@@ -288,9 +306,12 @@ class BaseSettings(BaseModel):
 
     @classmethod
     def settings_clear_cache(cls) -> None:
-        """Remove the cached default settings instance for this settings class, if any."""
-        with _settings_cache_lock:
-            _settings_cache.pop(cls, None)
+        """Remove the cached default settings instance for this settings class, if any.
+
+        Only the cache entry for this exact class is removed. Subclasses keep their own cached
+        instances and must be cleared individually.
+        """
+        _settings_cache.pop(cls, None)
 
     @classmethod
     def settings_customise_sources(

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -17,6 +17,7 @@ from pydantic._internal._signature import _field_name_for_signature
 from pydantic._internal._utils import deep_update, is_model_class
 from pydantic.dataclasses import is_pydantic_dataclass
 from pydantic.main import BaseModel
+from typing_extensions import Self
 
 from .exceptions import SettingsError
 from .sources import (
@@ -44,6 +45,9 @@ from .sources.utils import InitState, _get_alias_names, _warn_if_field_info_inco
 from .utils import _settings_debug_enabled, logger
 
 T = TypeVar('T')
+
+_settings_cache: dict[type[BaseSettings], BaseSettings] = {}
+_settings_cache_lock = threading.RLock()
 
 
 class SettingsConfigDict(ConfigDict, total=False):
@@ -271,6 +275,22 @@ class BaseSettings(BaseModel):
         )
 
         super().__init__(**__pydantic_self__.__class__._settings_build_values(sources, init_kwargs))
+
+    @classmethod
+    def settings_cached(cls) -> Self:
+        """Return the cached default settings instance for this settings class."""
+        with _settings_cache_lock:
+            settings = _settings_cache.get(cls)
+            if settings is None:
+                settings = cls()
+                _settings_cache[cls] = settings
+            return cast(Self, settings)
+
+    @classmethod
+    def settings_clear_cache(cls) -> None:
+        """Remove the cached default settings instance for this settings class, if any."""
+        with _settings_cache_lock:
+            _settings_cache.pop(cls, None)
 
     @classmethod
     def settings_customise_sources(
@@ -665,7 +685,13 @@ class BaseSettings(BaseModel):
         yaml_config_section=None,
         toml_file=None,
         secrets_dir=None,
-        protected_namespaces=('model_validate', 'model_dump', 'settings_customise_sources'),
+        protected_namespaces=(
+            'model_validate',
+            'model_dump',
+            'settings_cached',
+            'settings_clear_cache',
+            'settings_customise_sources',
+        ),
         enable_decoding=True,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ requires-python = '>=3.10'
 dependencies = [
     'pydantic>=2.7.0',
     'python-dotenv>=0.21.0',
+    'typing-extensions>=4.0.0',
     'typing-inspection>=0.4.0',
 ]
 dynamic = ['version']

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -194,30 +194,31 @@ def test_settings_cached_does_not_deadlock_on_other_threads(env, clear_settings_
 
 
 def test_settings_cached_loads_unrelated_classes_concurrently(env, clear_settings_cache):
-    """A slow class must not block loading of an unrelated one."""
+    """A class being constructed must not block loading of an unrelated one.
 
-    class Slow(BaseSettings):
+    Both classes wait on the same barrier from inside ``__init__``, so this only completes if
+    they are constructed at the same time. If loading were serialized, the second class would
+    never start and the barrier would time out.
+    """
+    both_constructing = threading.Barrier(2, timeout=10)
+
+    class First(BaseSettings):
         def __init__(self) -> None:
-            time.sleep(0.2)
+            both_constructing.wait()
             super().__init__()
 
-    class AlsoSlow(BaseSettings):
+    class Second(BaseSettings):
         def __init__(self) -> None:
-            time.sleep(0.2)
+            both_constructing.wait()
             super().__init__()
-
-    barrier = threading.Barrier(2)
 
     def load(settings_cls: type[BaseSettings]) -> BaseSettings:
-        barrier.wait()
         return settings_cls.settings_cached()
 
-    start = time.monotonic()
     with ThreadPoolExecutor(max_workers=2) as executor:
-        list(executor.map(load, [Slow, AlsoSlow]))
-    elapsed = time.monotonic() - start
+        loaded = list(executor.map(load, [First, Second]))
 
-    assert elapsed < 0.35, f'unrelated settings classes were serialized ({elapsed:.2f}s)'
+    assert [type(instance) for instance in loaded] == [First, Second]
 
 
 def test_settings_cached_releases_class_after_clearing(env, clear_settings_cache):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,5 @@
 import dataclasses
+import gc
 import json
 import logging
 import os
@@ -8,6 +9,7 @@ import sys
 import threading
 import time
 import uuid
+import weakref
 from collections.abc import Callable, Hashable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timezone
@@ -60,6 +62,7 @@ from pydantic_settings import (
     SettingsConfigDict,
     SettingsError,
 )
+from pydantic_settings.main import _settings_cache
 from pydantic_settings.sources import DefaultSettingsSource, read_env_file
 
 try:
@@ -102,7 +105,15 @@ def test_sub_env(env):
     assert s.apple == 'hello'
 
 
-def test_settings_cached(env):
+@pytest.fixture
+def clear_settings_cache():
+    """Leave the process-wide settings cache empty, even if a test fails part way through."""
+    _settings_cache.clear()
+    yield
+    _settings_cache.clear()
+
+
+def test_settings_cached(env, clear_settings_cache):
     class Settings(BaseSettings):
         apple: str
 
@@ -119,10 +130,8 @@ def test_settings_cached(env):
     assert reloaded is not initial
     assert reloaded.apple == 'granny_smith'
 
-    Settings.settings_clear_cache()
 
-
-def test_settings_cached_per_subclass():
+def test_settings_cached_per_subclass(env, clear_settings_cache):
     class ParentSettings(BaseSettings):
         parent: bool = True
 
@@ -139,11 +148,8 @@ def test_settings_cached_per_subclass():
     assert ParentSettings.settings_cached() is not parent
     assert ChildSettings.settings_cached() is child
 
-    ParentSettings.settings_clear_cache()
-    ChildSettings.settings_clear_cache()
 
-
-def test_settings_cached_is_thread_safe():
+def test_settings_cached_is_thread_safe(env, clear_settings_cache):
     class Settings(BaseSettings):
         constructions: ClassVar[int] = 0
 
@@ -164,7 +170,86 @@ def test_settings_cached_is_thread_safe():
     assert Settings.constructions == 1
     assert all(instance is settings[0] for instance in settings)
 
+
+def test_settings_cached_does_not_deadlock_on_other_threads(env, clear_settings_cache):
+    """Construction must not hold a global lock, or waiting on another thread deadlocks."""
+
+    class Inner(BaseSettings):
+        inner: bool = True
+
+    class Outer(BaseSettings):
+        outer: bool = True
+
+        @model_validator(mode='after')
+        def load_inner(self) -> 'Outer':
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                executor.submit(Inner.settings_cached).result(timeout=10)
+            return self
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        outer = executor.submit(Outer.settings_cached).result(timeout=10)
+
+    assert isinstance(outer, Outer)
+    assert Outer.settings_cached() is outer
+
+
+def test_settings_cached_loads_unrelated_classes_concurrently(env, clear_settings_cache):
+    """A slow class must not block loading of an unrelated one."""
+
+    class Slow(BaseSettings):
+        def __init__(self) -> None:
+            time.sleep(0.2)
+            super().__init__()
+
+    class AlsoSlow(BaseSettings):
+        def __init__(self) -> None:
+            time.sleep(0.2)
+            super().__init__()
+
+    barrier = threading.Barrier(2)
+
+    def load(settings_cls: type[BaseSettings]) -> BaseSettings:
+        barrier.wait()
+        return settings_cls.settings_cached()
+
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(load, [Slow, AlsoSlow]))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.35, f'unrelated settings classes were serialized ({elapsed:.2f}s)'
+
+
+def test_settings_cached_releases_class_after_clearing(env, clear_settings_cache):
+    """A cleared class must be collectable.
+
+    While cached, the instance necessarily references its own class, so the entry is kept
+    alive on purpose: that is what makes it a per-process singleton. Clearing the cache
+    must drop the entry entirely so dynamically built classes can be collected.
+    """
+
+    class Settings(BaseSettings):
+        apple: str = 'honeycrisp'
+
+    Settings.settings_cached()
     Settings.settings_clear_cache()
+    ref = weakref.ref(Settings)
+
+    del Settings
+    gc.collect()
+
+    assert ref() is None, 'cleared settings class was kept alive by the cache'
+
+
+def test_settings_cached_retries_after_failure(env, clear_settings_cache):
+    class Settings(BaseSettings):
+        apple: str
+
+    with pytest.raises(ValidationError):
+        Settings.settings_cached()
+
+    env.set('apple', 'honeycrisp')
+    assert Settings.settings_cached().apple == 'honeycrisp'
 
 
 def test_sub_env_override(env):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,12 +6,14 @@ import pathlib
 import re
 import sys
 import threading
+import time
 import uuid
 from collections.abc import Callable, Hashable
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timezone
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Annotated, Any, Generic, Literal, TypeVar
+from typing import Annotated, Any, ClassVar, Generic, Literal, TypeVar
 from unittest import mock
 
 import pytest
@@ -98,6 +100,71 @@ def test_sub_env(env):
     env.set('apple', 'hello')
     s = SimpleSettings()
     assert s.apple == 'hello'
+
+
+def test_settings_cached(env):
+    class Settings(BaseSettings):
+        apple: str
+
+    env.set('apple', 'honeycrisp')
+    initial = Settings.settings_cached()
+
+    env.set('apple', 'granny_smith')
+    assert Settings.settings_cached() is initial
+    assert Settings.settings_cached().apple == 'honeycrisp'
+    assert Settings().apple == 'granny_smith'
+
+    Settings.settings_clear_cache()
+    reloaded = Settings.settings_cached()
+    assert reloaded is not initial
+    assert reloaded.apple == 'granny_smith'
+
+    Settings.settings_clear_cache()
+
+
+def test_settings_cached_per_subclass():
+    class ParentSettings(BaseSettings):
+        parent: bool = True
+
+    class ChildSettings(ParentSettings):
+        child: bool = True
+
+    parent = ParentSettings.settings_cached()
+    child = ChildSettings.settings_cached()
+
+    assert type(parent) is ParentSettings
+    assert type(child) is ChildSettings
+
+    ParentSettings.settings_clear_cache()
+    assert ParentSettings.settings_cached() is not parent
+    assert ChildSettings.settings_cached() is child
+
+    ParentSettings.settings_clear_cache()
+    ChildSettings.settings_clear_cache()
+
+
+def test_settings_cached_is_thread_safe():
+    class Settings(BaseSettings):
+        constructions: ClassVar[int] = 0
+
+        def __init__(self) -> None:
+            type(self).constructions += 1
+            time.sleep(0.01)
+            super().__init__()
+
+    barrier = threading.Barrier(8)
+
+    def load_settings(_: int) -> Settings:
+        barrier.wait()
+        return Settings.settings_cached()
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        settings = list(executor.map(load_settings, range(8)))
+
+    assert Settings.constructions == 1
+    assert all(instance is settings[0] for instance in settings)
+
+    Settings.settings_clear_cache()
 
 
 def test_sub_env_override(env):

--- a/uv.lock
+++ b/uv.lock
@@ -1419,6 +1419,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
 
@@ -1475,6 +1476,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=0.21.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.1" },
     { name = "tomli", marker = "extra == 'toml'", specifier = ">=2.0.1" },
+    { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
 provides-extras = ["aws-secrets-manager", "aws-systems-manager", "azure-key-vault", "gcp-secret-manager", "toml", "yaml"]


### PR DESCRIPTION
## Summary

Add opt-in caching for default `BaseSettings` instances.

## Human Note

We use a bunch of these patterns internally, but the types and logic seems a bit too complex for me to ask users to implement on their own.

I would prefer to have this as a first-class feature than document replicating that logic in the full-stack-fastapi-template and the FastAPI docs.

I would update both to use this if it was available.

## AI text below

 The text below is written by Codex, but I read it all an is accurate, didn't see anything too spammy to remove, so I'll leave it.

## Summary

- `settings_cached()` returns one process-local cached instance per concrete settings class.
- `settings_clear_cache()` invalidates the cached instance for only that class.
- Calling the settings class directly continues to construct a fresh instance.

## Motivation

Constructing a settings model reads and validates every configured source each time. Applications commonly wrap settings construction in `functools.lru_cache` to avoid repeatedly reading dotenv and other files or retrieving secrets from cloud providers. That requires application-owned cache machinery and can complicate preserving the concrete settings type.

This makes the pattern an opt-in part of `BaseSettings`, with a `Self` return type and no constructor behavior change.

## Implementation

- Cache instances by concrete settings class.
- Synchronize access so concurrent first calls receive the same instance.
- Protect the new public method namespaces from field conflicts.
- Cover caching, fresh construction, per-subclass invalidation, and concurrent access.
- Document the cost model, process-local behavior, mutability, and reload workflow.

## Verification

- Full suite: 727 passed, 5 skipped.
- Ruff and formatting checks pass.
- Mypy passes, including a consumer-style `assert_type` check for the concrete subclass.
- Changed-line coverage: 100%.

## AI Disclaimer

Made with the help of AI, using Codex with `gpt-5.6-sol`, manually reviewed.