### PR TITLE
docs: add nested model alias example for env_prefix_target

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -317,6 +317,53 @@ print(TargetVarSettings().model_dump())
 
 1. `env_prefix` will be ignored and the value will be read from `FooAlias` environment variable.
 
+The same applies to an alias on a nested model field:
+
+```py
+import os
+
+from pydantic import BaseModel, Field
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SubModel(BaseModel):
+    var1: str | None = None
+
+
+class NestedSettings(BaseSettings):
+    # default
+    model_config = SettingsConfigDict(env_prefix='APP_', env_nested_delimiter='_')
+    submodel: SubModel | None = Field(alias='SUB', default=None)
+
+
+os.environ['APP_SUB_VAR1'] = 'ignored'  # (1)!
+print(NestedSettings().model_dump())
+#> {'submodel': None}
+del os.environ['APP_SUB_VAR1']
+
+os.environ['SUB_VAR1'] = 'unprefixed alias value'
+print(NestedSettings().model_dump())
+#> {'submodel': {'var1': 'unprefixed alias value'}}
+del os.environ['SUB_VAR1']
+
+
+class NestedTargetAllSettings(NestedSettings):
+    model_config = SettingsConfigDict(
+        env_prefix='APP_',
+        env_nested_delimiter='_',
+        env_prefix_target='all',
+    )
+
+
+os.environ['APP_SUB_VAR1'] = 'prefixed alias value'
+print(NestedTargetAllSettings().model_dump())
+#> {'submodel': {'var1': 'prefixed alias value'}}
+del os.environ['APP_SUB_VAR1']
+```
+
+1. `env_prefix` will be ignored and the alias is looked up under `SUB_VAR1`, not `APP_SUB_VAR1`.
+
 ### Case-sensitivity
 
 By default, environment variable names are case-insensitive.

--- a/docs/index.md
+++ b/docs/index.md
@@ -339,7 +339,7 @@ class NestedSettings(BaseSettings):
 
 os.environ['APP_SUB_VAR1'] = 'ignored'  # (1)!
 print(NestedSettings().model_dump())
-#> {'submodel': None}
+#> {'submodel': {'var1': None}}
 del os.environ['APP_SUB_VAR1']
 
 os.environ['SUB_VAR1'] = 'unprefixed alias value'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1123,6 +1123,33 @@ def test_validation_alias_with_env_prefix_and_env_prefix_target(env, env_prefix_
     assert Settings().foobar == 'bar'
 
 
+@pytest.mark.parametrize('env_prefix_target', ['variable', 'alias', 'all'])
+def test_validation_alias_with_env_prefix_and_env_prefix_target_nested(env, env_prefix_target):
+    class SubModel(BaseModel):
+        var1: str | None = None
+
+    class Settings(BaseSettings):
+        submodel: SubModel | None = Field(alias='SUB', default=None)
+
+        model_config = SettingsConfigDict(
+            env_prefix='APP_', env_nested_delimiter='_', env_prefix_target=env_prefix_target
+        )
+
+    unprefixed_alias_matches = env_prefix_target == 'variable'
+
+    env.set('SUB_VAR1', 'unprefixed-value')
+    if unprefixed_alias_matches:
+        assert Settings().submodel == SubModel(var1='unprefixed-value')
+    else:
+        assert Settings().submodel is None
+
+    env.set('APP_SUB_VAR1', 'prefixed-value')
+    if unprefixed_alias_matches:
+        assert Settings().submodel == SubModel(var1='unprefixed-value')
+    else:
+        assert Settings().submodel == SubModel(var1='prefixed-value')
+
+
 def test_case_sensitive(monkeypatch):
     class Settings(BaseSettings):
         foo: str


### PR DESCRIPTION
Follow-up to the note in #934: `env_prefix` plus a string alias on a nested model looks broken at first glance (`APP_SUB_VAR1` with `env_prefix='APP_'` and `alias='SUB'` gives `submodel=None`), but this is the documented `env_prefix_target='variable'` default: the alias matches unprefixed (`SUB_VAR1`), and `env_prefix_target='all'` or `'alias'` is what makes the prefixed spelling match.

The `env_prefix_target` docs show only a scalar example, and no test covers the nested case. This adds a nested worked example beside the existing one and a test parametrized over `'variable'`, `'alias'` and `'all'`.

## Testing

- `pytest tests/test_settings.py`: 247 passed, 7 skipped (the new test runs 3 cases).
- Full suite on Windows: 580 passed, 70 skipped, 6 failed; all six are pre-existing symlink-privilege failures in `test_source_nested_secrets.py`, identical on clean `main` (1ef0864).
- `ruff check` and `ruff format --check`: clean.
- The docs-example harness skips on Windows, so I checked the new snippet against pytest-examples' black and ruff configs locally and verified its printed output against a live run.

Drafted with AI assistance; I ran the new test and the test_settings.py suite on Windows with Python 3.13.13 and checked the example's output lines myself.
