### PR TITLE
fix: warn when a field is declared with the v1 env kwarg

### DIFF
--- a/pydantic_settings/__init__.py
+++ b/pydantic_settings/__init__.py
@@ -1,4 +1,4 @@
-from .exceptions import IncompleteFieldDefinitionWarning, SettingsError
+from .exceptions import IgnoredEnvKwargWarning, IncompleteFieldDefinitionWarning, SettingsError
 from .main import BaseSettings, CliApp, SettingsConfigDict
 from .sources import (
     CLI_SUPPRESS,
@@ -53,6 +53,7 @@ __all__ = (
     'EnvSettingsSource',
     'ForceDecode',
     'GoogleSecretManagerSettingsSource',
+    'IgnoredEnvKwargWarning',
     'IncompleteFieldDefinitionWarning',
     'InitSettingsSource',
     'JsonConfigSettingsSource',

--- a/pydantic_settings/exceptions.py
+++ b/pydantic_settings/exceptions.py
@@ -8,3 +8,12 @@ class IncompleteFieldDefinitionWarning(UserWarning):
     A field definition is incomplete when its annotation contains unresolved forward references,
     in which case settings sources may fail to correctly resolve its value.
     """
+
+
+class IgnoredEnvKwargWarning(UserWarning):
+    """Warning emitted when a field is declared with the pydantic v1 `env` keyword argument.
+
+    `Field(env='VAR')` was the pydantic v1 spelling for binding a field to an environment
+    variable. In pydantic v2 the keyword is stored in `json_schema_extra` and settings sources
+    ignore it, so the field is not bound to `VAR`. Use `validation_alias` instead.
+    """

--- a/pydantic_settings/main.py
+++ b/pydantic_settings/main.py
@@ -42,7 +42,7 @@ from .sources import (
     YamlConfigSettingsSource,
     get_subcommand,
 )
-from .sources.utils import InitState, _get_alias_names, _warn_if_field_info_incomplete
+from .sources.utils import InitState, _get_alias_names, _warn_if_field_info_unsupported
 from .utils import _settings_debug_enabled, logger
 
 T = TypeVar('T')
@@ -612,7 +612,7 @@ class BaseSettings(BaseModel):
             state_kwarg_names = set(state.keys())
             init_kwarg_names = set(init_kwargs.keys())
             for field_name, field_info in settings_cls.model_fields.items():
-                _warn_if_field_info_incomplete(field_info, field_name, init_state)
+                _warn_if_field_info_unsupported(field_info, field_name, init_state)
                 alias_names, *_ = _get_alias_names(field_name, field_info)
                 matchable_names = set(alias_names)
                 include_name = settings_cls.model_config.get(

--- a/pydantic_settings/sources/base.py
+++ b/pydantic_settings/sources/base.py
@@ -37,7 +37,7 @@ from .utils import (
     _resolve_type_alias,
     _strip_annotated,
     _union_is_complex,
-    _warn_if_field_info_incomplete,
+    _warn_if_field_info_unsupported,
 )
 
 if TYPE_CHECKING:
@@ -284,7 +284,7 @@ class DefaultSettingsSource(PydanticBaseSettingsSource):
         )
         if self.nested_model_default_partial_update:
             for field_name, field_info in settings_cls.model_fields.items():
-                _warn_if_field_info_incomplete(field_info, field_name, self._init_state)
+                _warn_if_field_info_unsupported(field_info, field_name, self._init_state)
                 if _has_discriminator(field_info):
                     continue
                 alias_names, *_ = _get_alias_names(field_name, field_info)
@@ -337,7 +337,7 @@ class InitSettingsSource(PydanticBaseSettingsSource):
         for key in init_kwargs:
             normalized_provided.setdefault(normalize(key), []).append(key)
         for field_name, field_info in settings_cls.model_fields.items():
-            _warn_if_field_info_incomplete(field_info, field_name, self._init_state)
+            _warn_if_field_info_unsupported(field_info, field_name, self._init_state)
             # Canonical (case-preserving) alias names determine the output key, so the value
             # still matches pydantic's validation aliases, which are always case-sensitive.
             canonical_alias_names, *_ = _get_alias_names(field_name, field_info)
@@ -438,7 +438,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         Returns:
             list[tuple[str, str, bool]]: List of tuples, each tuple contains field_key, env_name, and value_is_complex.
         """
-        _warn_if_field_info_incomplete(field, field_name, self._init_state)
+        _warn_if_field_info_unsupported(field, field_name, self._init_state)
         field_info: list[tuple[str, str, bool]] = []
         if isinstance(field.validation_alias, (AliasChoices, AliasPath)):
             v_alias: str | list[str | int] | list[list[str | int]] | None = field.validation_alias.convert_to_aliases()
@@ -523,7 +523,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
             # Find field in sub model by looking in fields case insensitively
             field_key: str | None = None
             for sub_model_field_name, sub_model_field in model_fields.items():
-                _warn_if_field_info_incomplete(sub_model_field, sub_model_field_name, self._init_state)
+                _warn_if_field_info_unsupported(sub_model_field, sub_model_field_name, self._init_state)
                 aliases, _ = _get_alias_names(sub_model_field_name, sub_model_field)
                 _search = (alias for alias in aliases if alias.lower() == name.lower())
                 if field_key := next(_search, None):
@@ -595,7 +595,7 @@ class PydanticBaseEnvSettingsSource(PydanticBaseSettingsSource):
         data: dict[str, Any] = {}
 
         for field_name, field in self.settings_cls.model_fields.items():
-            _warn_if_field_info_incomplete(field, field_name, self._init_state)
+            _warn_if_field_info_unsupported(field, field_name, self._init_state)
             try:
                 field_value, field_key, value_is_complex = self._get_resolved_field_value(field, field_name)
             except Exception as e:

--- a/pydantic_settings/sources/utils.py
+++ b/pydantic_settings/sources/utils.py
@@ -20,7 +20,7 @@ from pydantic.types import Strict
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
-from ..exceptions import IncompleteFieldDefinitionWarning, SettingsError
+from ..exceptions import IgnoredEnvKwargWarning, IncompleteFieldDefinitionWarning, SettingsError
 from ..utils import _lenient_issubclass
 from .types import EnvNoneType
 
@@ -29,30 +29,46 @@ class InitState(TypedDict, total=False):
     """State shared between settings sources during a single settings resolution."""
 
     field_info_ids: set[int]
-    """The `id()`s of the incomplete `FieldInfo` instances that were already warned about."""
+    """The `id()`s of the `FieldInfo` instances that were already warned about."""
 
 
-def _warn_if_field_info_incomplete(field_info: FieldInfo, field_name: str, init_state: InitState) -> None:
-    """Warn if the field is incomplete, i.e. its annotation contains unresolved forward references.
+def _warn_if_field_info_unsupported(field_info: FieldInfo, field_name: str, init_state: InitState) -> None:
+    """Warn if settings sources cannot resolve the field as it is declared.
 
-    An incomplete `FieldInfo` instance is unsafe to inspect — any of its attributes (annotation,
-    aliases, metadata, default) may rely on the unresolved annotation, so settings sources may
-    silently fail to resolve the field's value. Each instance is only warned about once per
-    `init_state`, so that a field accessed by multiple sources during a single settings
-    resolution doesn't emit duplicate warnings.
+    Two declarations are reported. An incomplete `FieldInfo` instance is unsafe to inspect —
+    any of its attributes (annotation, aliases, metadata, default) may rely on an unresolved
+    forward reference, so settings sources may silently fail to resolve the field's value. A
+    field declared with the pydantic v1 `env` keyword argument is not bound to that environment
+    variable at all, because pydantic v2 stores unknown `Field` keyword arguments in
+    `json_schema_extra`. Each instance is only warned about once per `init_state`, so that a
+    field accessed by multiple sources during a single settings resolution doesn't emit
+    duplicate warnings.
     """
-    if getattr(field_info, '_complete', True):
+    if not getattr(field_info, '_complete', True):
+        message = (
+            f'Field {field_name!r} has an incomplete definition: its annotation contains an unresolved '
+            'forward reference, so settings sources may fail to correctly resolve its value. '
+            'Call `model_rebuild()` on the model where the field is defined, once all the referenced '
+            'types are defined.'
+        )
+        category: type[UserWarning] = IncompleteFieldDefinitionWarning
+    elif isinstance(field_info.json_schema_extra, dict) and 'env' in field_info.json_schema_extra:
+        env = field_info.json_schema_extra['env']
+        message = (
+            f'Field {field_name!r} is declared with `env={env!r}`, the pydantic v1 spelling. It is '
+            'stored in `json_schema_extra` and ignored, so the field is not read from that '
+            f'environment variable. Use `validation_alias={env!r}` instead.'
+        )
+        category = IgnoredEnvKwargWarning
+    else:
         return
     warned_ids = init_state.setdefault('field_info_ids', set())
     if id(field_info) in warned_ids:
         return
     warned_ids.add(id(field_info))
     warnings.warn(  # noqa: B028  (called from many sources at differing depths, so no stacklevel is correct)
-        f'Field {field_name!r} has an incomplete definition: its annotation contains an unresolved '
-        'forward reference, so settings sources may fail to correctly resolve its value. '
-        'Call `model_rebuild()` on the model where the field is defined, once all the referenced '
-        'types are defined.',
-        IncompleteFieldDefinitionWarning,
+        message,
+        category,
     )
 
 
@@ -145,7 +161,7 @@ def _annotation_is_complex(annotation: Any, metadata: list[Any], init_state: Ini
         annotation = cast('type[RootModel[Any]]', annotation)
         root_field = annotation.model_fields['root']
         if init_state is not None:
-            _warn_if_field_info_incomplete(root_field, f'{annotation.__name__}.root', init_state)
+            _warn_if_field_info_unsupported(root_field, f'{annotation.__name__}.root', init_state)
         root_annotation = root_field.annotation
         if root_annotation is not None:  # pragma: no branch
             annotation = root_annotation
@@ -395,6 +411,6 @@ __all__ = [
     '_strip_annotated',
     '_union_has_strict_types',
     '_union_is_complex',
-    '_warn_if_field_info_incomplete',
+    '_warn_if_field_info_unsupported',
     'parse_env_vars',
 ]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -53,6 +53,7 @@ from pydantic_settings import (
     DotEnvSettingsSource,
     EnvSettingsSource,
     ForceDecode,
+    IgnoredEnvKwargWarning,
     IncompleteFieldDefinitionWarning,
     InitSettingsSource,
     JsonConfigSettingsSource,
@@ -4493,6 +4494,33 @@ def test_warn_on_incomplete_field_info_standalone_source():
     incomplete_warnings = [str(w.message) for w in caught if w.category is IncompleteFieldDefinitionWarning]
     assert len(incomplete_warnings) == 1
     assert incomplete_warnings[0].startswith("Field 'service' ")
+
+
+@pytest.mark.filterwarnings('ignore:Using extra keyword arguments on `Field` is deprecated.*')
+def test_warn_on_dropped_v1_env_kwarg(env):
+    """The pydantic v1 `env` keyword argument lands in `json_schema_extra` and is ignored, so the
+    field silently keeps its default. Settings sources emit a single `IgnoredEnvKwargWarning` per
+    field per settings resolution, and leave a correctly declared `validation_alias` alone.
+    """
+
+    class Settings(BaseSettings):
+        legacy: str = Field(default='unset', env='LEGACY_VAR')
+        aliased: str = Field(default='unset', validation_alias='ALIASED_VAR')
+
+    env.set('LEGACY_VAR', 'env-value')
+    env.set('ALIASED_VAR', 'alias-value')
+
+    with pytest.warns(IgnoredEnvKwargWarning) as caught:
+        s = Settings()
+
+    ignored_env_warnings = [str(w.message) for w in caught if w.category is IgnoredEnvKwargWarning]
+    assert len(ignored_env_warnings) == 1
+    assert ignored_env_warnings[0].startswith("Field 'legacy' is declared with `env='LEGACY_VAR'`")
+    assert "Use `validation_alias='LEGACY_VAR'` instead." in ignored_env_warnings[0]
+
+    # `env` is ignored, so the field keeps its default instead of reading `LEGACY_VAR`:
+    assert s.legacy == 'unset'
+    assert s.aliased == 'alias-value'
 
 
 def test_debug_sources_disabled_by_default(env, caplog, monkeypatch):


### PR DESCRIPTION
## Change Summary

`Field(..., env='VAR')` was the pydantic v1 spelling for binding a field to an
environment variable. In v2 `env` is not a known `Field` argument, so pydantic
stores it in `json_schema_extra` and every settings source ignores it. The field
is never read from `VAR`.

Today this fails in two ways, neither of which names the cause:

- A required field raises `Field required [type=missing]` while the variable is
  set, which points the reader at the environment instead of the declaration.
- An optional field keeps its default and nothing fails, so the process runs on
  the wrong value.

Reproduced on `main` (a7134cd) with pydantic 2.13.4:

```python
import os
from pydantic import Field
from pydantic_settings import BaseSettings

os.environ['BACKEND_API_URL'] = 'http://from-env'


class RequiredCase(BaseSettings):
    api_url: str = Field(..., env='BACKEND_API_URL')


class OptionalCase(BaseSettings):
    api_url: str = Field(default='default-sentinel', env='BACKEND_API_URL')


try:
    RequiredCase()
except Exception as e:
    print(e)
print('resolved:', OptionalCase().api_url)
```

```
1 validation error for RequiredCase
api_url
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/missing
resolved: default-sentinel
```

The only signal is pydantic's own `PydanticDeprecatedSince20`: "Using extra
keyword arguments on `Field` is deprecated ... (Extra keys: 'env')". It names the
key but not the consequence, and it says nothing about the environment binding
being dropped. This has come up before: #171 was reported with exactly this
symptom and answered by hand with "use `alias`", with no code change. #193 asks
for the v1 behaviour back, which this PR does not do.

This PR reports the dropped binding where the sources already report field
declarations they cannot honour. `_warn_if_field_info_incomplete` (added in #901)
runs on every field of every source and deduplicates through a shared
per-resolution `InitState` set, so the new check goes there and the helper is
renamed to `_warn_if_field_info_unsupported`.

After the change, both cases warn once per field per resolution:

```
IgnoredEnvKwargWarning: Field 'api_url' is declared with `env='BACKEND_API_URL'`,
the pydantic v1 spelling. It is stored in `json_schema_extra` and ignored, so the
field is not read from that environment variable. Use
`validation_alias='BACKEND_API_URL'` instead.
```

Warning rather than error follows the precedent in
`pydantic_settings/exceptions.py`: `IncompleteFieldDefinitionWarning` is a
`UserWarning` for a declaration the sources cannot resolve, and resolution
continues. `env` in `json_schema_extra` can also be a deliberate schema key, so
raising would break working code.

Reviving v1 `env=` support is not proposed. The behaviour stays the same, it
stops being silent.

## Related issues/PRs

- #171: same symptom, closed with a manual answer and no code change.
- #193: feature request to restore v1 per-field env names. Out of scope here.
- #901: added `IncompleteFieldDefinitionWarning` and the per-field warning hook
  this PR extends.
