### PR TITLE
Fix CliVariadicArg empty-value handling for named options

### DIFF
--- a/pydantic_settings/sources/providers/cli.py
+++ b/pydantic_settings/sources/providers/cli.py
@@ -645,7 +645,10 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
 
                 cli_arg = self._parser_map.get(field_name, {}).get(None)
                 if cli_arg and cli_arg.is_no_decode:
-                    parsed_args[field_name] = ','.join(val)
+                    # `nargs='*'` accepts the option with no values. Joining to '' would make the arg
+                    # indistinguishable from unset (and dropped entirely under env_ignore_empty), so keep
+                    # the empty list intact. A NoDecode value is never JSON decoded, so '[]' is not usable.
+                    parsed_args[field_name] = ','.join(val) if val else val
                     continue
 
                 parsed_args[field_name] = self._merge_parsed_list(val, field_name)
@@ -1209,7 +1212,9 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
             )
         if is_append_action:
             if _CliVariadicArg in field_info.metadata:
-                kwargs['nargs'] = '*'
+                # A required variadic option must consume at least one value, otherwise a bare flag would
+                # satisfy argparse and silently resolve to an empty list.
+                kwargs['nargs'] = '+' if kwargs.get('required') else '*'
             else:
                 kwargs['action'] = 'append'
             if _annotation_contains_types(field_info.annotation, (dict, Mapping), is_strip_annotated=True):

--- a/tests/test_source_cli.py
+++ b/tests/test_source_cli.py
@@ -1928,6 +1928,30 @@ def test_cli_variadic_named_arg_no_values():
     assert CliApp.run(Settings, cli_args=['--options']).model_dump() == {'param': [], 'options': {}}
 
 
+def test_cli_variadic_named_arg_required_no_values():
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(cli_parse_args=True, cli_enforce_required=True)
+        param: CliVariadicArg[list[str]]
+
+    with pytest.raises(SettingsError, match='error parsing CLI: argument --param: expected at least one argument'):
+        CliApp.run(Settings, cli_args=['--param'], cli_exit_on_error=False)
+    assert CliApp.run(Settings, cli_args=['--param', 'a', 'b']).model_dump() == {'param': ['a', 'b']}
+
+
+def test_cli_variadic_named_arg_no_decode_no_values(env):
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(cli_parse_args=True, env_ignore_empty=True)
+        param: Annotated[CliVariadicArg[list[str]], NoDecode] = Field(default_factory=list)
+
+    # A valueless variadic must resolve to an empty list, not '', otherwise the arg looks unset and a
+    # lower priority source would win over the explicitly provided CLI flag.
+    assert CliApp.run(Settings, cli_args=['--param']).model_dump() == {'param': []}
+
+    # The explicit CLI flag must still win over an environment variable.
+    env.set('PARAM', 'x')
+    assert CliApp.run(Settings, cli_args=['--param']).model_dump() == {'param': []}
+
+
 def test_cli_variadic_named_with_positional():
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(cli_parse_args=True)


### PR DESCRIPTION
Follow-up to #949, which added `CliVariadicArg`. Two bugs in the named-option path, both found by review and each covered by a regression test that fails without the fix.

### 1. Required named variadic accepted zero values

`_convert_append_action` hardcoded `nargs='*'` for every named `CliVariadicArg`, ignoring whether the field was required. The positional path already derives this correctly.

With `cli_enforce_required=True` and `param: CliVariadicArg[list[str]]`, a bare `--param` satisfied argparse's `required=True` and validated to `{'param': []}` — a required field silently becoming empty. `nargs` is now derived as `'+' if required else '*'`, mirroring `_convert_positional_arg`.

Keyed off `kwargs['required']` rather than `field_info.is_required()` directly, since `nargs='+'` is a CLI-level constraint and should only bind when actually enforced at the CLI — using the field's own required-ness would newly break `--param` with no values under `cli_enforce_required=False`.

### 2. Empty-list fix missed the `NoDecode` path

The `if not merged_list: return '[]'` guard from 9553d8e lives in `_merged_list_to_str`, but `_resolve_parsed_args` short-circuits `NoDecode` fields earlier via `','.join(val)`, which yields `''` and never reaches the guard. With `Annotated[CliVariadicArg[list[str]], NoDecode]`:

- `--param` alone raised `ValidationError: Input should be a valid list [input_value='']` — the exact bug 9553d8e set out to fix.
- Worse, `CliSettingsSource` builds its own env vars through `parse_env_vars(..., env_ignore_empty, ...)`, so under `env_ignore_empty=True` the `''` was stripped, the CLI arg vanished, and a **lower-priority environment variable won over the explicit CLI flag** — inverting documented source precedence.

Fixed by keeping the empty list intact rather than joining to `''`. Emitting `'[]'` here would be wrong: a `NoDecode` value is never JSON-decoded, so it would land as the literal 2-character string `"[]"`. An actual empty list passes through correctly — `CliUnknownArgs` (itself `NoDecode` + list) already relies on exactly this and survives `env_ignore_empty=True`.

### Verification

Full suite: 744 passed, 5 skipped. `ruff check` and `ruff format --check` clean. Both new tests confirmed failing against the unfixed source.

One adjacent failure I hit while testing — a `NoDecode` `list[str]` not splitting `'a,b'` — reproduces identically on unfixed `main`. That is pydantic's `NoDecode` semantics and is untouched here; it is also why the second test asserts precedence via the CLI flag winning rather than an env-var fallback value, which would need a custom validator to split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr9GucgZhTT8qSDQhyH4Pq