### PR TITLE
Fix nested secrets precedence for case-insensitive names

### DIFF
--- a/pydantic_settings/sources/providers/nested_secrets.py
+++ b/pydantic_settings/sources/providers/nested_secrets.py
@@ -1,7 +1,6 @@
 import os
 import warnings
 from collections.abc import Iterator
-from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
@@ -120,19 +119,17 @@ class NestedSecretsSettingsSource(EnvSettingsSource):
         self.env_parse_none_str = None  # update manually because of None
 
         # update parent members
-        if not len(self.secrets_paths):
-            self.env_vars = {}
-        else:
-            secrets = reduce(
-                lambda d1, d2: dict((*d1.items(), *d2.items())),
-                (self.load_secrets(p) for p in self.secrets_paths),
+        secrets: dict[str, str | None] = {}
+        for path in self.secrets_paths:
+            secrets.update(
+                parse_env_vars(
+                    self.load_secrets(path),
+                    self.case_sensitive,
+                    self.env_ignore_empty,
+                    self.env_parse_none_str,
+                )
             )
-            self.env_vars = parse_env_vars(
-                secrets,
-                self.case_sensitive,
-                self.env_ignore_empty,
-                self.env_parse_none_str,
-            )
+        self.env_vars = secrets
 
     def validate_secrets_path(self, path: Path) -> None:
         if not path.exists():

--- a/tests/test_source_nested_secrets.py
+++ b/tests/test_source_nested_secrets.py
@@ -1,3 +1,4 @@
+import os
 from enum import Enum
 from os import sep
 from pathlib import Path
@@ -46,7 +47,10 @@ class SampleEnum(str, Enum):
 
 
 @pytest.mark.parametrize('case_sensitive, expected', [(False, 'third'), (True, 'second')])
-def test_directory_precedence_with_different_filename_cases(tmp_path, case_sensitive, expected):
+def test_directory_precedence_with_different_filename_cases(tmp_path, monkeypatch, case_sensitive, expected):
+    # Like the case-sensitive environment tests, use a plain mapping so the
+    # inherited Windows environment fallback does not override this control.
+    monkeypatch.setattr(os, 'environ', {})
     directories = [tmp_path / str(i) for i in range(3)]
     for directory, filename, value in zip(
         directories, ['TOKEN', 'token', 'TOKEN'], ['first', 'second', 'third'], strict=True
@@ -64,8 +68,7 @@ def test_directory_precedence_with_different_filename_cases(tmp_path, case_sensi
         ):
             return (NestedSecretsSettingsSource(file_secret_settings),)
 
-    source = NestedSecretsSettingsSource(SecretsSettingsSource(Settings))
-    assert Settings().token == expected, (source.case_sensitive, source.env_vars)
+    assert Settings().token == expected
 
 
 def test_repr(tmp_path):

--- a/tests/test_source_nested_secrets.py
+++ b/tests/test_source_nested_secrets.py
@@ -45,6 +45,28 @@ class SampleEnum(str, Enum):
     TEST = 'test'
 
 
+@pytest.mark.parametrize('case_sensitive, expected', [(False, 'third'), (True, 'second')])
+def test_directory_precedence_with_different_filename_cases(tmp_path, case_sensitive, expected):
+    directories = [tmp_path / str(i) for i in range(3)]
+    for directory, filename, value in zip(
+        directories, ['TOKEN', 'token', 'TOKEN'], ['first', 'second', 'third'], strict=True
+    ):
+        directory.mkdir()
+        (directory / filename).write_text(value)
+
+    class Settings(BaseSettings):
+        token: str
+        model_config = SettingsConfigDict(secrets_dir=directories, secrets_case_sensitive=case_sensitive)
+
+        @classmethod
+        def settings_customise_sources(
+            cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings
+        ):
+            return (NestedSecretsSettingsSource(file_secret_settings),)
+
+    assert Settings().token == expected
+
+
 def test_repr(tmp_path):
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(

--- a/tests/test_source_nested_secrets.py
+++ b/tests/test_source_nested_secrets.py
@@ -64,7 +64,8 @@ def test_directory_precedence_with_different_filename_cases(tmp_path, case_sensi
         ):
             return (NestedSecretsSettingsSource(file_secret_settings),)
 
-    assert Settings().token == expected
+    source = NestedSecretsSettingsSource(SecretsSettingsSource(Settings))
+    assert Settings().token == expected, (source.case_sensitive, source.env_vars)
 
 
 def test_repr(tmp_path):


### PR DESCRIPTION
Fixes #960.

Normalize each secrets directory's filenames before combining its values with earlier directories. Merging raw names first can violate last-directory-wins precedence: directories containing `TOKEN=first`, `token=second`, and `TOKEN=third` currently yield `second` when matching is case-insensitive. Updating the original `TOKEN` key does not move its insertion position, so the older lowercase spelling wins during the final normalization.

Add a public Settings regression for that ordering and a case-sensitive control. As in the existing case-sensitive environment tests, the fixture uses a plain environment mapping so Windows environment normalization does not override the requested control setting. The former fails before the change; both pass afterward. Empty directory lists and all other source tests continue to pass.

Validation: `make` passed Ruff checks and formatting, mypy for all 22 source files, and the full test suite (750 passed, 5 skipped), then generated the coverage report. Python 3.13.9, Pydantic 2.13.4. Only synthetic temporary files were used; no real secret directories or cloud services were accessed.

Prepared with OpenAI Codex assistance; the failure and verification were executed locally. The initial Windows CI failure exposed the inherited environment fallback in the test fixture; the fixture now isolates that behavior while leaving the production change focused on directory merging.
